### PR TITLE
db-device:add db device

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,4 +3,5 @@
 members = [
     "crates/db-allocator",
     "crates/db-arch",
+    "crates/db-device",
 ]

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This repository contains the following crates:
 | --- | --- | --- |
 | [db-allocator](crates/db-allocator) | allocator for vmm resource | TBD |
 | [db-arch](crates/db-arch) | collections of CPU architecture related modules | TBD |
+| [db-device](crates/db-device) | virtual machine's device model | TBD |
 
 (Dragonball is a virtual machine monitor developed by Alibaba and db is the abbreviation for Dragonball.)
 

--- a/crates/db-device/Cargo.toml
+++ b/crates/db-device/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "db-device"
+version = "0.1.0"
+authors = ["Alibaba Dragonball Team"]
+license = "Apache-2.0"
+edition = "2018"
+homepage = "https://github.com/openanolis/dragonball-sandbox"
+repository = "https://github.com/openanolis/dragonball-sandbox"
+keywords = ["dragonball", "device", "resource"]
+readme = "README.md"

--- a/crates/db-device/README.md
+++ b/crates/db-device/README.md
@@ -1,0 +1,109 @@
+# db-device
+
+The db-device crate mainly contains:
+
+- `DeviceIo` and `DeviceIoMut` trait: defining the read/write operation on specific device
+- `IoManager`: managing all devices of virtual machine, (un)register their io resource callback
+- `IoManagerContext` trait: transaction context for `IoManager` to (un)register devices
+- `ResourceConstraint`, `Resource` and `DeviceResources`: abstractions for requiring and describing resources of a device
+
+## Design
+
+The db-device crate is designed to support the virtual machine's device model.
+
+The core concepts of device model are [Port I/O](https://wiki.osdev.org/I/O_Ports) and [Memory-mapped I/O](https://en.wikipedia.org/wiki/Memory-mapped_I/O), which are two main methods of performing I/O between CPU and devices.
+
+The `DeviceIo` and `DeviceIoMut` trait are used to define the operations of devices in vm when guest OS performing I/O to emulated devices.
+
+In addition, we need to let CPU know the I/O operation would be sent to which device, so the devices also need to declare the resources they used for I/O operation, which are defined in `Resource` enum. It also defines the other resources that the device will use, such as interrupts, KVM slots and MAC addresses. And `DeviceResources` struct gathers a series resources of a device together.
+
+When a device is creating, it may not yet know the specific parameters of the resources it uses, but only the constraint of resources it needs, so `ResourceConstraint` enum is used to describe the resources requirements for each device.
+
+## Usage
+
+First, a vm needs to create an `IoManager` to help it distribute I/O events to devices. And an `IoManager` has two types of bus, pio bus and mmio bus.
+
+Then, when creating a device, it needs to implement the `DeviceIo` or `DeviceIoMut` trait to receive read or write events send by driver in guest OS:
+- `read()` and `write()` methods is used to deal with MMIO events
+- `pio_read()` and `pio_write()` methods is used to deal with PIO events
+- `get_assigned_resources()` method is used to get all resources assigned to the device
+- `get_trapped_io_resources()` method is used to get only MMIO/PIO resources assigned to the device
+
+The difference of `DeviceIo` and `DeviceIoMut` is the reference type of `self` passed to method:
+- `DeviceIo` trait would pass a immutable reference `&self` to method, so the implementation of device would provide interior mutability and thread-safe protection itself
+- `DeviceIoMut` trait would pass a mutable reference `&mut self` to method, and it can give mutability to device which is wrapped by `Mutex` directly to simplify the difficulty of achieving interior mutability. Additionally, the `DeviceIo` trait would auto implement for `Mutex<T: DeviceIoMut>`
+
+Last, the device needs to be added to `IoManager` by using `register_device_io()`, and the function would add device to pio bus or mmio bus by the resources it have. If a device has not only MMIO resource but PIO resource, it would be added to both pio bus and mmio bus. So the device would wrapped by `Arc<T>`.
+
+From now on, the IoManager will be routing I/O requests for the registered address range to the device. The requests are dispatched by the client code, for example when handling VM exits, using IoManager's methods like `pio_read`, `pio_write`, `mmio_read` and `mmio_write`.
+
+## Examples
+
+
+```rust
+use std::sync::Arc;
+
+use db_device::device_manager::IoManager;
+use db_device::resources::{DeviceResources, Resource};
+use db_device::{DeviceIo, IoAddress, PioAddress};
+
+struct DummyDevice {}
+
+impl DeviceIo for DummyDevice {
+    fn read(&self, base: IoAddress, offset: IoAddress, data: &mut [u8]) {
+        println!(
+            "mmio read, base: 0x{:x}, offset: 0x{:x}",
+            base.raw_value(),
+            offset.raw_value()
+        );
+    }
+
+    fn write(&self, base: IoAddress, offset: IoAddress, data: &[u8]) {
+        println!(
+            "mmio write, base: 0x{:x}, offset: 0x{:x}",
+            base.raw_value(),
+            offset.raw_value()
+        );
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    fn pio_read(&self, base: PioAddress, offset: PioAddress, data: &mut [u8]) {
+        println!(
+            "pio read, base: 0x{:x}, offset: 0x{:x}",
+            base.raw_value(),
+            offset.raw_value()
+        );
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    fn pio_write(&self, base: PioAddress, offset: PioAddress, data: &[u8]) {
+        println!(
+            "pio write, base: 0x{:x}, offset: 0x{:x}",
+            base.raw_value(),
+            offset.raw_value()
+        );
+    }
+}
+
+// Allocate resources for device
+let mut resources = DeviceResources::new();
+resources.append(Resource::MmioAddressRange {
+    base: 0,
+    size: 4096,
+});
+#[cfg(target_arch = "x86_64")]
+resources.append(Resource::PioAddressRange { base: 0, size: 32 });
+
+// Register device to `IoManager` with resources
+let device = Arc::new(DummyDevice {});
+let mut manager = IoManager::new();
+manager.register_device_io(device, &resources).unwrap();
+
+// Dispatch I/O event from `IoManager` to device
+manager.mmio_write(0, &vec![0, 1]).unwrap();
+#[cfg(target_arch = "x86_64")]
+{
+    let mut buffer = vec![0; 4];
+    manager.pio_read(0, &mut buffer);
+}
+```

--- a/crates/db-device/src/device_manager.rs
+++ b/crates/db-device/src/device_manager.rs
@@ -1,0 +1,740 @@
+// Copyright 2020 Alibaba Cloud. All Rights Reserved.
+// Copyright © 2019 Intel Corporation. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! System level device management.
+//!
+//! [IoManager](struct.IoManager.html) is respondsible for managing
+//! all devices of virtual machine, registering IO resources callback,
+//! unregistering devices and helping VM IO exit handling.
+//！VMM would be responsible for getting device resource request, ask
+//! vm_allocator to allocate the resources, ask vm_device to register the
+//! devices IO ranges, and finally set resources to virtual device.
+//!
+//! # Examples
+//!
+//! Creating a dummy deivce which implement DeviceIo trait, and register it to
+//! IoManager with mmio/pio resources:
+//!
+//! ```
+//! use std::sync::Arc;
+//!
+//! use db_device::device_manager::IoManager;
+//! use db_device::resources::{DeviceResources, Resource};
+//! use db_device::{DeviceIo, IoAddress, PioAddress};
+//!
+//! struct DummyDevice {}
+//!
+//! impl DeviceIo for DummyDevice {
+//!     fn read(&self, base: IoAddress, offset: IoAddress, data: &mut [u8]) {
+//!         println!(
+//!             "mmio read, base: 0x{:x}, offset: 0x{:x}",
+//!             base.raw_value(),
+//!             offset.raw_value()
+//!         );
+//!     }
+//!
+//!     fn write(&self, base: IoAddress, offset: IoAddress, data: &[u8]) {
+//!         println!(
+//!             "mmio write, base: 0x{:x}, offset: 0x{:x}",
+//!             base.raw_value(),
+//!             offset.raw_value()
+//!         );
+//!     }
+//!
+//!     #[cfg(target_arch = "x86_64")]
+//!     fn pio_read(&self, base: PioAddress, offset: PioAddress, data: &mut [u8]) {
+//!         println!(
+//!             "pio read, base: 0x{:x}, offset: 0x{:x}",
+//!             base.raw_value(),
+//!             offset.raw_value()
+//!         );
+//!     }
+//!
+//!     #[cfg(target_arch = "x86_64")]
+//!     fn pio_write(&self, base: PioAddress, offset: PioAddress, data: &[u8]) {
+//!         println!(
+//!             "pio write, base: 0x{:x}, offset: 0x{:x}",
+//!             base.raw_value(),
+//!             offset.raw_value()
+//!         );
+//!     }
+//! }
+//!
+//! // Allocate resources for device
+//! let mut resources = DeviceResources::new();
+//! resources.append(Resource::MmioAddressRange {
+//!     base: 0,
+//!     size: 4096,
+//! });
+//! #[cfg(target_arch = "x86_64")]
+//! resources.append(Resource::PioAddressRange { base: 0, size: 32 });
+//!
+//! // Register device to `IoManager` with resources
+//! let device = Arc::new(DummyDevice {});
+//! let mut manager = IoManager::new();
+//! manager.register_device_io(device, &resources).unwrap();
+//!
+//! // Dispatch I/O event from `IoManager` to device
+//! manager.mmio_write(0, &vec![0, 1]).unwrap();
+//! #[cfg(target_arch = "x86_64")]
+//! {
+//!     let mut buffer = vec![0; 4];
+//!     manager.pio_read(0, &mut buffer);
+//! }
+//! ```
+
+use std::cmp::{Ord, Ordering, PartialEq, PartialOrd};
+use std::collections::btree_map::BTreeMap;
+use std::fmt::{Display, Formatter};
+use std::ops::Deref;
+use std::result;
+use std::sync::Arc;
+
+use crate::resources::Resource;
+#[cfg(target_arch = "x86_64")]
+use crate::PioAddress;
+use crate::{DeviceIo, IoAddress, IoSize};
+
+/// Error type for `IoManager` usage.
+#[derive(Debug)]
+pub enum Error {
+    /// The inserting device overlaps with a current device.
+    DeviceOverlap,
+    /// The device doesn't exist.
+    NoDevice,
+}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Error::DeviceOverlap => write!(
+                f,
+                "device_manager: device address conflicts with existing devices"
+            ),
+            Error::NoDevice => write!(f, "device_manager: no such device"),
+        }
+    }
+}
+
+impl std::error::Error for Error {}
+
+/// Simplify the `Result` type.
+pub type Result<T> = result::Result<T, Error>;
+
+/// Structure describing an IO range.
+#[derive(Debug, Copy, Clone, Eq)]
+pub struct IoRange {
+    base: IoAddress,
+    size: IoSize,
+}
+
+impl IoRange {
+    #[cfg(target_arch = "x86_64")]
+    fn new_pio_range(base: u16, size: u16) -> Self {
+        IoRange {
+            base: IoAddress(base as u64),
+            size: IoSize(size as u64),
+        }
+    }
+
+    fn new_mmio_range(base: u64, size: u64) -> Self {
+        IoRange {
+            base: IoAddress(base),
+            size: IoSize(size),
+        }
+    }
+}
+
+impl PartialEq for IoRange {
+    fn eq(&self, other: &IoRange) -> bool {
+        self.base == other.base
+    }
+}
+
+impl Ord for IoRange {
+    fn cmp(&self, other: &IoRange) -> Ordering {
+        self.base.cmp(&other.base)
+    }
+}
+
+impl PartialOrd for IoRange {
+    fn partial_cmp(&self, other: &IoRange) -> Option<Ordering> {
+        self.base.partial_cmp(&other.base)
+    }
+}
+
+/// System IO manager serving for all devices management and VM exit handling.
+#[derive(Clone, Default)]
+pub struct IoManager {
+    #[cfg(target_arch = "x86_64")]
+    /// Range mapping for VM exit pio operations.
+    pio_bus: BTreeMap<IoRange, Arc<dyn DeviceIo>>,
+    /// Range mapping for VM exit mmio operations.
+    mmio_bus: BTreeMap<IoRange, Arc<dyn DeviceIo>>,
+}
+
+impl IoManager {
+    /// Create an default IoManager with empty IO member.
+    pub fn new() -> Self {
+        IoManager::default()
+    }
+
+    /// Register a new device IO with its allocated resources.
+    /// VMM is responsible for providing the allocated resources to virtual device.
+    ///
+    /// # Arguments
+    ///
+    /// * `device`: device instance object to be registered
+    /// * `resources`: resources that this device owns, might include
+    ///                port I/O and memory-mapped I/O ranges, irq number, etc.
+    pub fn register_device_io(
+        &mut self,
+        device: Arc<dyn DeviceIo>,
+        resources: &[Resource],
+    ) -> Result<()> {
+        // Register and mark device resources
+        //
+        // The resources addresses being registered are sucessfully allocated
+        // before.
+        for (idx, res) in resources.iter().enumerate() {
+            match *res {
+                #[cfg(target_arch = "x86_64")]
+                Resource::PioAddressRange { base, size } => {
+                    if self
+                        .pio_bus
+                        .insert(IoRange::new_pio_range(base, size), device.clone())
+                        .is_some()
+                    {
+                        // Unregister registered resources.
+                        self.unregister_device_io(&resources[0..idx])
+                            .expect("failed to unregister devices");
+
+                        return Err(Error::DeviceOverlap);
+                    }
+                }
+                Resource::MmioAddressRange { base, size } => {
+                    if self
+                        .mmio_bus
+                        .insert(IoRange::new_mmio_range(base, size), device.clone())
+                        .is_some()
+                    {
+                        // Unregister registered resources.
+                        self.unregister_device_io(&resources[0..idx])
+                            .expect("failed to unregister devices");
+
+                        return Err(Error::DeviceOverlap);
+                    }
+                }
+                _ => continue,
+            }
+        }
+        Ok(())
+    }
+
+    /// Unregister a device from `IoManager`, e.g. users specified removing.
+    ///
+    /// VMM pre-fetches the resources e.g. dev.get_assigned_resources() VMM is
+    /// responsible for freeing the resources.
+    ///
+    /// # Arguments
+    ///
+    /// * `resources`: resources that this device owns, might include port I/O
+    ///                and memory-mapped I/O ranges, irq number, etc.
+    pub fn unregister_device_io(&mut self, resources: &[Resource]) -> Result<()> {
+        for res in resources.iter() {
+            match *res {
+                #[cfg(target_arch = "x86_64")]
+                Resource::PioAddressRange { base, size } => {
+                    self.pio_bus.remove(&IoRange::new_pio_range(base, size));
+                }
+                Resource::MmioAddressRange { base, size } => {
+                    self.mmio_bus.remove(&IoRange::new_mmio_range(base, size));
+                }
+                _ => continue,
+            }
+        }
+        Ok(())
+    }
+
+    /// A helper function handling MMIO read command during VM exit.
+    ///
+    /// The virtual device itself provides mutable ability and thead-safe
+    /// protection.
+    ///
+    /// Return error if failed to get the device.
+    pub fn mmio_read(&self, addr: u64, data: &mut [u8]) -> Result<()> {
+        self.get_device(IoAddress(addr))
+            .map(|(device, base)| device.read(base, IoAddress(addr - base.raw_value()), data))
+            .ok_or(Error::NoDevice)
+    }
+
+    /// A helper function handling MMIO write command during VM exit.
+    ///
+    /// The virtual device itself provides mutable ability and thead-safe
+    /// protection.
+    ///
+    /// Return error if failed to get the device.
+    pub fn mmio_write(&self, addr: u64, data: &[u8]) -> Result<()> {
+        self.get_device(IoAddress(addr))
+            .map(|(device, base)| device.write(base, IoAddress(addr - base.raw_value()), data))
+            .ok_or(Error::NoDevice)
+    }
+
+    // Return the Device mapped `addr` and the base address.
+    fn get_device(&self, addr: IoAddress) -> Option<(&Arc<dyn DeviceIo>, IoAddress)> {
+        let range = IoRange::new_mmio_range(addr.raw_value(), 0);
+        if let Some((range, dev)) = self.mmio_bus.range(..=&range).nth_back(0) {
+            if (addr.raw_value() - range.base.raw_value()) < range.size.raw_value() {
+                return Some((dev, range.base));
+            }
+        }
+        None
+    }
+}
+
+#[cfg(target_arch = "x86_64")]
+impl IoManager {
+    /// A helper function handling PIO read command during VM exit.
+    ///
+    /// The virtual device itself provides mutable ability and thead-safe
+    /// protection.
+    ///
+    /// Return error if failed to get the device.
+    pub fn pio_read(&self, addr: u16, data: &mut [u8]) -> Result<()> {
+        self.get_pio_device(PioAddress(addr))
+            .map(|(device, base)| device.pio_read(base, PioAddress(addr - base.raw_value()), data))
+            .ok_or(Error::NoDevice)
+    }
+
+    /// A helper function handling PIO write command during VM exit.
+    ///
+    /// The virtual device itself provides mutable ability and thead-safe
+    /// protection.
+    ///
+    /// Return error if failed to get the device.
+    pub fn pio_write(&self, addr: u16, data: &[u8]) -> Result<()> {
+        self.get_pio_device(PioAddress(addr))
+            .map(|(device, base)| device.pio_write(base, PioAddress(addr - base.raw_value()), data))
+            .ok_or(Error::NoDevice)
+    }
+
+    // Return the Device mapped `addr` and the base address.
+    fn get_pio_device(&self, addr: PioAddress) -> Option<(&Arc<dyn DeviceIo>, PioAddress)> {
+        let range = IoRange::new_pio_range(addr.raw_value(), 0);
+        if let Some((range, dev)) = self.pio_bus.range(..=&range).nth_back(0) {
+            if (addr.raw_value() as u64 - range.base.raw_value()) < range.size.raw_value() {
+                return Some((dev, PioAddress(range.base.0 as u16)));
+            }
+        }
+        None
+    }
+}
+
+impl PartialEq for IoManager {
+    fn eq(&self, other: &IoManager) -> bool {
+        #[cfg(target_arch = "x86_64")]
+        if self.pio_bus.len() != other.pio_bus.len() {
+            return false;
+        }
+        if self.mmio_bus.len() != other.mmio_bus.len() {
+            return false;
+        }
+
+        #[cfg(target_arch = "x86_64")]
+        for (io_range, device_io) in self.pio_bus.iter() {
+            if !other.pio_bus.contains_key(io_range) {
+                return false;
+            }
+            let other_device_io = &other.pio_bus[io_range];
+            if device_io.get_trapped_io_resources() != other_device_io.get_trapped_io_resources() {
+                return false;
+            }
+        }
+
+        for (io_range, device_io) in self.mmio_bus.iter() {
+            if !other.mmio_bus.contains_key(io_range) {
+                return false;
+            }
+            let other_device_io = &other.mmio_bus[io_range];
+            if device_io.get_trapped_io_resources() != other_device_io.get_trapped_io_resources() {
+                return false;
+            }
+        }
+
+        true
+    }
+}
+
+/// Io manager transaction context to register/unregister devices.
+pub trait IoManagerContext {
+    /// Type of context object.
+    type Context;
+
+    /// Begin a transaction and return a context object.
+    ///
+    /// The returned context object must be passed to commit_tx() or cancel_tx()
+    /// later.
+    fn begin_tx(&self) -> Self::Context;
+
+    /// Commit the transaction.
+    fn commit_tx(&self, ctx: Self::Context);
+
+    /// Cancel the transaction.
+    fn cancel_tx(&self, ctx: Self::Context);
+
+    /// Register a new device IO with its allocated resources.
+    ///
+    /// # Arguments
+    ///
+    /// * `ctx`: context object returned by begin_tx().
+    /// * `device`: device instance object to be registered
+    /// * `resources`: resources that this device owns, might include port I/O
+    ///                and memory-mapped I/O ranges, irq number, etc.
+    fn register_device_io(
+        &self,
+        ctx: &mut Self::Context,
+        device: Arc<dyn DeviceIo>,
+        resources: &[Resource],
+    ) -> Result<()>;
+
+    /// Unregister a device from `IoManager`, e.g. users specified removing.
+    ///
+    /// VMM pre-fetches the resources e.g. dev.get_assigned_resources()
+    ///
+    /// VMM is responsible for freeing the resources.
+    ///
+    /// # Arguments
+    ///
+    /// * `ctx`: context object returned by begin_tx().
+    /// * `resources`: resources that this device owns, might include port I/O
+    ///                and memory-mapped I/O ranges, irq number, etc.
+    fn unregister_device_io(&self, ctx: &mut Self::Context, resources: &[Resource]) -> Result<()>;
+}
+
+impl<T: IoManagerContext> IoManagerContext for Arc<T> {
+    type Context = T::Context;
+
+    fn begin_tx(&self) -> Self::Context {
+        self.deref().begin_tx()
+    }
+
+    fn commit_tx(&self, ctx: Self::Context) {
+        self.deref().commit_tx(ctx)
+    }
+
+    fn cancel_tx(&self, ctx: Self::Context) {
+        self.deref().cancel_tx(ctx)
+    }
+
+    fn register_device_io(
+        &self,
+        ctx: &mut Self::Context,
+        device: Arc<dyn DeviceIo>,
+        resources: &[Resource],
+    ) -> std::result::Result<(), Error> {
+        self.deref().register_device_io(ctx, device, resources)
+    }
+
+    fn unregister_device_io(
+        &self,
+        ctx: &mut Self::Context,
+        resources: &[Resource],
+    ) -> std::result::Result<(), Error> {
+        self.deref().unregister_device_io(ctx, resources)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::error::Error;
+    use std::sync::Mutex;
+
+    use super::*;
+    use crate::resources::DeviceResources;
+
+    #[cfg(target_arch = "x86_64")]
+    const PIO_ADDRESS_SIZE: u16 = 4;
+    #[cfg(target_arch = "x86_64")]
+    const PIO_ADDRESS_BASE: u16 = 0x40;
+    const MMIO_ADDRESS_SIZE: u64 = 0x8765_4321;
+    const MMIO_ADDRESS_BASE: u64 = 0x1234_5678;
+    const LEGACY_IRQ: u32 = 4;
+    const CONFIG_DATA: u32 = 0x1234;
+
+    struct DummyDevice {
+        config: Mutex<u32>,
+    }
+
+    impl DummyDevice {
+        fn new(config: u32) -> Self {
+            DummyDevice {
+                config: Mutex::new(config),
+            }
+        }
+    }
+
+    impl DeviceIo for DummyDevice {
+        fn read(&self, _base: IoAddress, _offset: IoAddress, data: &mut [u8]) {
+            if data.len() > 4 {
+                return;
+            }
+            for (idx, iter) in data.iter_mut().enumerate() {
+                let config = self.config.lock().expect("failed to acquire lock");
+                *iter = (*config >> (idx * 8) & 0xff) as u8;
+            }
+        }
+
+        fn write(&self, _base: IoAddress, _offset: IoAddress, data: &[u8]) {
+            let mut config = self.config.lock().expect("failed to acquire lock");
+            *config = u32::from(data[0]) & 0xff;
+        }
+
+        #[cfg(target_arch = "x86_64")]
+        fn pio_read(&self, _base: PioAddress, _offset: PioAddress, data: &mut [u8]) {
+            if data.len() > 4 {
+                return;
+            }
+            for (idx, iter) in data.iter_mut().enumerate() {
+                let config = self.config.lock().expect("failed to acquire lock");
+                *iter = (*config >> (idx * 8) & 0xff) as u8;
+            }
+        }
+
+        #[cfg(target_arch = "x86_64")]
+        fn pio_write(&self, _base: PioAddress, _offset: PioAddress, data: &[u8]) {
+            let mut config = self.config.lock().expect("failed to acquire lock");
+            *config = u32::from(data[0]) & 0xff;
+        }
+    }
+
+    #[test]
+    fn test_clone_io_manager() {
+        let mut io_mgr = IoManager::new();
+        let dummy = DummyDevice::new(0);
+        let dum = Arc::new(dummy);
+
+        let mut resource: Vec<Resource> = Vec::new();
+        let mmio = Resource::MmioAddressRange {
+            base: MMIO_ADDRESS_BASE,
+            size: MMIO_ADDRESS_SIZE,
+        };
+        let irq = Resource::LegacyIrq(LEGACY_IRQ);
+
+        resource.push(mmio);
+        resource.push(irq);
+
+        #[cfg(target_arch = "x86_64")]
+        {
+            let pio = Resource::PioAddressRange {
+                base: PIO_ADDRESS_BASE,
+                size: PIO_ADDRESS_SIZE,
+            };
+            resource.push(pio);
+        }
+
+        assert!(io_mgr.register_device_io(dum.clone(), &resource).is_ok());
+
+        let io_mgr2 = io_mgr.clone();
+        assert_eq!(io_mgr2.mmio_bus.len(), 1);
+
+        #[cfg(target_arch = "x86_64")]
+        {
+            assert_eq!(io_mgr2.pio_bus.len(), 1);
+
+            let (dev, addr) = io_mgr2
+                .get_device(IoAddress(MMIO_ADDRESS_BASE + 1))
+                .unwrap();
+            assert_eq!(Arc::strong_count(dev), 5);
+
+            assert_eq!(addr, IoAddress(MMIO_ADDRESS_BASE));
+
+            drop(io_mgr);
+            assert_eq!(Arc::strong_count(dev), 3);
+
+            drop(io_mgr2);
+            assert_eq!(Arc::strong_count(&dum), 1);
+        }
+    }
+
+    #[test]
+    fn test_register_unregister_device_io() {
+        let mut io_mgr = IoManager::new();
+        let dummy = DummyDevice::new(0);
+        let dum = Arc::new(dummy);
+
+        let mut resources = DeviceResources::new();
+        let mmio = Resource::MmioAddressRange {
+            base: MMIO_ADDRESS_BASE,
+            size: MMIO_ADDRESS_SIZE,
+        };
+        #[cfg(target_arch = "x86_64")]
+        let pio = Resource::PioAddressRange {
+            base: PIO_ADDRESS_BASE,
+            size: PIO_ADDRESS_SIZE,
+        };
+        let irq = Resource::LegacyIrq(LEGACY_IRQ);
+
+        resources.append(mmio);
+        #[cfg(target_arch = "x86_64")]
+        resources.append(pio);
+        resources.append(irq);
+
+        assert!(io_mgr.register_device_io(dum.clone(), &resources).is_ok());
+        assert!(io_mgr.register_device_io(dum, &resources).is_err());
+        assert!(io_mgr.unregister_device_io(&resources).is_ok())
+    }
+
+    #[test]
+    fn test_mmio_read_write() {
+        let mut io_mgr: IoManager = Default::default();
+        let dum = Arc::new(DummyDevice::new(CONFIG_DATA));
+        let mut resource: Vec<Resource> = Vec::new();
+
+        let mmio = Resource::MmioAddressRange {
+            base: MMIO_ADDRESS_BASE,
+            size: MMIO_ADDRESS_SIZE,
+        };
+        resource.push(mmio);
+        assert!(io_mgr.register_device_io(dum.clone(), &resource).is_ok());
+
+        let mut data = [0; 4];
+        assert!(io_mgr.mmio_read(MMIO_ADDRESS_BASE, &mut data).is_ok());
+        assert_eq!(data, [0x34, 0x12, 0, 0]);
+
+        assert!(io_mgr
+            .mmio_read(MMIO_ADDRESS_BASE + MMIO_ADDRESS_SIZE, &mut data)
+            .is_err());
+
+        data = [0; 4];
+        assert!(io_mgr.mmio_write(MMIO_ADDRESS_BASE, &data).is_ok());
+        assert_eq!(*dum.config.lock().unwrap(), 0);
+
+        assert!(io_mgr
+            .mmio_write(MMIO_ADDRESS_BASE + MMIO_ADDRESS_SIZE, &data)
+            .is_err());
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    #[test]
+    fn test_pio_read_write() {
+        let mut io_mgr: IoManager = Default::default();
+        let dum = Arc::new(DummyDevice::new(CONFIG_DATA));
+        let mut resource: Vec<Resource> = Vec::new();
+
+        let pio = Resource::PioAddressRange {
+            base: PIO_ADDRESS_BASE,
+            size: PIO_ADDRESS_SIZE,
+        };
+        resource.push(pio);
+        assert!(io_mgr.register_device_io(dum.clone(), &resource).is_ok());
+
+        let mut data = [0; 4];
+        assert!(io_mgr.pio_read(PIO_ADDRESS_BASE, &mut data).is_ok());
+        assert_eq!(data, [0x34, 0x12, 0, 0]);
+
+        assert!(io_mgr
+            .pio_read(PIO_ADDRESS_BASE + PIO_ADDRESS_SIZE, &mut data)
+            .is_err());
+
+        data = [0; 4];
+        assert!(io_mgr.pio_write(PIO_ADDRESS_BASE, &data).is_ok());
+        assert_eq!(*dum.config.lock().unwrap(), 0);
+
+        assert!(io_mgr
+            .pio_write(PIO_ADDRESS_BASE + PIO_ADDRESS_SIZE, &data)
+            .is_err());
+    }
+
+    #[test]
+    fn test_device_manager_data_structs() {
+        let range1 = IoRange::new_mmio_range(0x1000, 0x1000);
+        let range2 = IoRange::new_mmio_range(0x1000, 0x2000);
+        let range3 = IoRange::new_mmio_range(0x2000, 0x1000);
+
+        assert_eq!(range1, range1.clone());
+        assert_eq!(range1, range2);
+        assert!(range1 < range3);
+    }
+
+    #[test]
+    fn test_error_code() {
+        let err = super::Error::DeviceOverlap;
+
+        assert!(err.source().is_none());
+        assert_eq!(
+            format!("{}", err),
+            "device_manager: device address conflicts with existing devices"
+        );
+
+        let err = super::Error::NoDevice;
+        assert!(err.source().is_none());
+        assert_eq!(format!("{:#?}", err), "NoDevice");
+    }
+
+    #[test]
+    fn test_io_manager_partial_eq() {
+        let mut io_mgr1 = IoManager::new();
+        let mut io_mgr2 = IoManager::new();
+        let dummy1 = Arc::new(DummyDevice::new(0));
+        let dummy2 = Arc::new(DummyDevice::new(0));
+
+        let mut resources1 = DeviceResources::new();
+        let mut resources2 = DeviceResources::new();
+
+        let mmio = Resource::MmioAddressRange {
+            base: MMIO_ADDRESS_BASE,
+            size: MMIO_ADDRESS_SIZE,
+        };
+        #[cfg(target_arch = "x86_64")]
+        let pio = Resource::PioAddressRange {
+            base: PIO_ADDRESS_BASE,
+            size: PIO_ADDRESS_SIZE,
+        };
+
+        resources1.append(mmio.clone());
+        #[cfg(target_arch = "x86_64")]
+        resources1.append(pio.clone());
+
+        resources2.append(mmio);
+        #[cfg(target_arch = "x86_64")]
+        resources2.append(pio);
+
+        io_mgr1.register_device_io(dummy1, &resources1).unwrap();
+        io_mgr2.register_device_io(dummy2, &resources2).unwrap();
+
+        assert!(io_mgr1 == io_mgr2);
+    }
+
+    #[test]
+    fn test_io_manager_partial_neq() {
+        let mut io_mgr1 = IoManager::new();
+        let mut io_mgr2 = IoManager::new();
+        let dummy1 = Arc::new(DummyDevice::new(0));
+        let dummy2 = Arc::new(DummyDevice::new(0));
+
+        let mut resources1 = DeviceResources::new();
+        let mut resources2 = DeviceResources::new();
+
+        let mmio = Resource::MmioAddressRange {
+            base: MMIO_ADDRESS_BASE,
+            size: MMIO_ADDRESS_SIZE,
+        };
+        #[cfg(target_arch = "x86_64")]
+        let pio = Resource::PioAddressRange {
+            base: PIO_ADDRESS_BASE,
+            size: PIO_ADDRESS_SIZE,
+        };
+
+        resources1.append(mmio.clone());
+        #[cfg(target_arch = "x86_64")]
+        resources1.append(pio);
+
+        resources2.append(mmio);
+
+        io_mgr1.register_device_io(dummy1, &resources1).unwrap();
+        io_mgr2.register_device_io(dummy2, &resources2).unwrap();
+
+        assert!(io_mgr1 != io_mgr2);
+    }
+}

--- a/crates/db-device/src/lib.rs
+++ b/crates/db-device/src/lib.rs
@@ -1,0 +1,436 @@
+// Copyright 2020 Alibaba Cloud. All Rights Reserved.
+// Copyright © 2019 Intel Corporation. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#![deny(missing_docs)]
+
+//! dragonball-vmm device model.
+
+pub mod device_manager;
+pub mod resources;
+
+use std::cmp::{Ord, PartialOrd};
+use std::sync::Mutex;
+
+use self::resources::DeviceResources;
+#[cfg(target_arch = "x86_64")]
+pub use self::x86::{PioAddress, PioSize};
+
+/// IO Size.
+#[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
+pub struct IoSize(pub u64);
+
+impl IoSize {
+    /// Get the raw value as u64 to make operation simple.
+    #[inline]
+    pub fn raw_value(self) -> u64 {
+        self.0
+    }
+}
+
+impl From<u64> for IoSize {
+    #[inline]
+    fn from(size: u64) -> Self {
+        IoSize(size)
+    }
+}
+
+impl From<IoSize> for u64 {
+    #[inline]
+    fn from(size: IoSize) -> Self {
+        size.0
+    }
+}
+
+/// IO Addresses.
+#[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
+pub struct IoAddress(pub u64);
+
+impl IoAddress {
+    /// Get the raw value of IO Address to make operation simple.
+    #[inline]
+    pub fn raw_value(self) -> u64 {
+        self.0
+    }
+}
+
+impl From<u64> for IoAddress {
+    #[inline]
+    fn from(addr: u64) -> Self {
+        IoAddress(addr)
+    }
+}
+
+impl From<IoAddress> for u64 {
+    #[inline]
+    fn from(addr: IoAddress) -> Self {
+        addr.0
+    }
+}
+
+#[cfg(target_arch = "x86_64")]
+mod x86 {
+    use std::convert::TryFrom;
+
+    use super::{IoAddress, IoSize};
+
+    type PioAddressType = u16;
+
+    #[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
+    /// Port I/O size.
+    pub struct PioSize(pub PioAddressType);
+
+    impl PioSize {
+        /// Get the raw value as u64 to make operation simple.
+        #[inline]
+        pub fn raw_value(self) -> PioAddressType {
+            self.0
+        }
+    }
+
+    impl From<PioAddressType> for PioSize {
+        #[inline]
+        fn from(size: PioAddressType) -> Self {
+            PioSize(size)
+        }
+    }
+
+    impl From<PioSize> for PioAddressType {
+        #[inline]
+        fn from(size: PioSize) -> Self {
+            size.0
+        }
+    }
+
+    impl TryFrom<IoSize> for PioSize {
+        type Error = IoSize;
+
+        #[inline]
+        fn try_from(size: IoSize) -> Result<Self, Self::Error> {
+            if size.raw_value() <= std::u16::MAX as u64 {
+                Ok(PioSize(size.raw_value() as PioAddressType))
+            } else {
+                Err(size)
+            }
+        }
+    }
+
+    impl From<PioSize> for IoSize {
+        #[inline]
+        fn from(size: PioSize) -> Self {
+            IoSize(size.raw_value() as u64)
+        }
+    }
+
+    /// Port I/O address.
+    #[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
+    pub struct PioAddress(pub PioAddressType);
+
+    impl PioAddress {
+        /// Get the raw value of IO Address to make operation simple.
+        #[inline]
+        pub fn raw_value(self) -> PioAddressType {
+            self.0
+        }
+    }
+
+    impl From<PioAddressType> for PioAddress {
+        #[inline]
+        fn from(addr: PioAddressType) -> Self {
+            PioAddress(addr)
+        }
+    }
+
+    impl From<PioAddress> for PioAddressType {
+        #[inline]
+        fn from(addr: PioAddress) -> Self {
+            addr.0
+        }
+    }
+
+    impl TryFrom<IoAddress> for PioAddress {
+        type Error = IoAddress;
+
+        #[inline]
+        fn try_from(addr: IoAddress) -> Result<Self, Self::Error> {
+            if addr.0 <= std::u16::MAX as u64 {
+                Ok(PioAddress(addr.raw_value() as PioAddressType))
+            } else {
+                Err(addr)
+            }
+        }
+    }
+
+    impl From<PioAddress> for IoAddress {
+        #[inline]
+        fn from(addr: PioAddress) -> Self {
+            IoAddress(addr.raw_value() as u64)
+        }
+    }
+}
+
+/// IO Addresses.
+///
+/// Device IO trait adopting interior mutability pattern.
+///
+/// A device supporting memory based I/O should implement this trait, then
+/// register itself against the different IO type ranges it handles. The VMM
+/// will then dispatch IO (PIO or MMIO) VM exits by calling into the registered
+/// devices read or write method from this trait.
+///
+/// The DeviceIo trait adopts the interior mutability pattern so we can get a
+/// real concurrent multiple threads handling. For device backend drivers not
+/// focusing on high performance, they may use the Mutex<T: DeviceIoMut> adapter
+/// to simplify implementation.
+#[allow(unused_variables)]
+pub trait DeviceIo: Send + Sync {
+    /// Read from the guest physical address `base`, starting at `offset`.
+    /// Result is placed in `data`.
+    fn read(&self, base: IoAddress, offset: IoAddress, data: &mut [u8]) {}
+
+    /// Write `data` to the guest physical address `base`, starting from
+    /// `offset`.
+    fn write(&self, base: IoAddress, offset: IoAddress, data: &[u8]) {}
+
+    #[cfg(target_arch = "x86_64")]
+    /// Read from the guest physical address `base`, starting at `offset`.
+    /// Result is placed in `data`.
+    fn pio_read(&self, base: PioAddress, offset: PioAddress, data: &mut [u8]) {}
+
+    #[cfg(target_arch = "x86_64")]
+    /// Write `data` to the guest physical address `base`, starting from
+    /// `offset`.
+    fn pio_write(&self, base: PioAddress, offset: PioAddress, data: &[u8]) {}
+
+    /// Get resources assigned to the device.
+    fn get_assigned_resources(&self) -> DeviceResources {
+        DeviceResources::new()
+    }
+
+    /// Get the IO resources which will be trapped by the DeviceManager.
+    ///
+    /// All none Mmio/Pio resources in the returned resource list will be
+    /// ignored.
+    fn get_trapped_io_resources(&self) -> DeviceResources {
+        self.get_assigned_resources()
+    }
+}
+
+/// Device IO trait without interior mutability.
+///
+/// Many device backend drivers will mutate itself when handling IO requests.
+/// The DeviceIo trait assumes interior mutability, but it's a little complex to
+/// support interior mutability. So the Mutex<T: DeviceIoMut> adapter may be
+/// used to ease device backend driver implementations.
+///
+/// The Mutex<T: DeviceIoMut> adapter is an zero overhead abstraction without
+/// performance penalty.
+#[allow(unused_variables)]
+pub trait DeviceIoMut: Send {
+    /// Read from the guest physical address `base`, starting at `offset`.
+    /// Result is placed in `data`.
+    fn read(&mut self, base: IoAddress, offset: IoAddress, data: &mut [u8]) {}
+
+    /// Write `data` to the guest physical address `base`, starting from
+    /// `offset`.
+    fn write(&mut self, base: IoAddress, offset: IoAddress, data: &[u8]) {}
+
+    #[cfg(target_arch = "x86_64")]
+    /// Read from the guest physical address `base`, starting at `offset`.
+    /// Result is placed in `data`.
+    fn pio_read(&mut self, base: PioAddress, offset: PioAddress, data: &mut [u8]) {}
+
+    #[cfg(target_arch = "x86_64")]
+    /// Write `data` to the guest physical address `base`, starting from
+    /// `offset`.
+    fn pio_write(&mut self, base: PioAddress, offset: PioAddress, data: &[u8]) {}
+
+    /// Get resources assigned to the device.
+    fn get_assigned_resources(&self) -> DeviceResources {
+        DeviceResources::new()
+    }
+
+    /// Get the IO resources which will be trapped by the DeviceManager.
+    ///
+    /// All none Mmio/Pio resources in the returned resource list will be
+    /// ignored.
+    fn get_trapped_io_resources(&self) -> DeviceResources {
+        self.get_assigned_resources()
+    }
+}
+
+impl<T: DeviceIoMut> DeviceIo for Mutex<T> {
+    fn read(&self, base: IoAddress, offset: IoAddress, data: &mut [u8]) {
+        // Safe to unwrap() because we don't expect poisoned lock here.
+        self.lock().unwrap().read(base, offset, data)
+    }
+
+    fn write(&self, base: IoAddress, offset: IoAddress, data: &[u8]) {
+        // Safe to unwrap() because we don't expect poisoned lock here.
+        self.lock().unwrap().write(base, offset, data)
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    fn pio_read(&self, base: PioAddress, offset: PioAddress, data: &mut [u8]) {
+        // Safe to unwrap() because we don't expect poisoned lock here.
+        self.lock().unwrap().pio_read(base, offset, data)
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    fn pio_write(&self, base: PioAddress, offset: PioAddress, data: &[u8]) {
+        // Safe to unwrap() because we don't expect poisoned lock here.
+        self.lock().unwrap().pio_write(base, offset, data)
+    }
+
+    fn get_assigned_resources(&self) -> DeviceResources {
+        // Safe to unwrap() because we don't expect poisoned lock here.
+        self.lock().unwrap().get_assigned_resources()
+    }
+
+    fn get_trapped_io_resources(&self) -> DeviceResources {
+        // Safe to unwrap() because we don't expect poisoned lock here.
+        self.lock().unwrap().get_trapped_io_resources()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(target_arch = "x86_64")]
+    use std::convert::TryFrom;
+    use std::sync::Arc;
+
+    use super::*;
+
+    #[derive(Default)]
+    struct MockDevice {
+        data: Mutex<u8>,
+    }
+
+    impl DeviceIo for MockDevice {
+        fn read(&self, _base: IoAddress, _offset: IoAddress, data: &mut [u8]) {
+            data[0] = *self.data.lock().unwrap();
+        }
+
+        fn write(&self, _base: IoAddress, _offset: IoAddress, data: &[u8]) {
+            *self.data.lock().unwrap() = data[0];
+        }
+
+        #[cfg(target_arch = "x86_64")]
+        fn pio_read(&self, _base: PioAddress, _offset: PioAddress, data: &mut [u8]) {
+            data[0] = *self.data.lock().unwrap();
+        }
+
+        #[cfg(target_arch = "x86_64")]
+        fn pio_write(&self, _base: PioAddress, _offset: PioAddress, data: &[u8]) {
+            *self.data.lock().unwrap() = data[0];
+        }
+    }
+
+    #[derive(Default)]
+    struct MockDeviceMut {
+        data: u8,
+    }
+
+    impl DeviceIoMut for MockDeviceMut {
+        fn read(&mut self, _base: IoAddress, _offset: IoAddress, data: &mut [u8]) {
+            data[0] = self.data;
+        }
+
+        fn write(&mut self, _base: IoAddress, _offset: IoAddress, data: &[u8]) {
+            self.data = data[0];
+        }
+
+        #[cfg(target_arch = "x86_64")]
+        fn pio_read(&mut self, _base: PioAddress, _offset: PioAddress, data: &mut [u8]) {
+            data[0] = self.data;
+        }
+
+        #[cfg(target_arch = "x86_64")]
+        fn pio_write(&mut self, _base: PioAddress, _offset: PioAddress, data: &[u8]) {
+            self.data = data[0];
+        }
+    }
+
+    fn register_device(device: Arc<dyn DeviceIo>) {
+        device.write(IoAddress(0), IoAddress(0), &[0x10u8]);
+        let mut buf = [0x0u8];
+        device.read(IoAddress(0), IoAddress(0), &mut buf);
+        assert_eq!(buf[0], 0x10);
+
+        #[cfg(target_arch = "x86_64")]
+        {
+            device.pio_write(PioAddress(0), PioAddress(0), &[0x10u8]);
+            let mut buf = [0x0u8];
+            device.pio_read(PioAddress(0), PioAddress(0), &mut buf);
+            assert_eq!(buf[0], 0x10);
+        }
+
+        // test trait's default implementation
+        let resource = DeviceResources::new();
+        assert_eq!(resource, device.get_assigned_resources());
+        assert_eq!(resource, device.get_trapped_io_resources());
+    }
+
+    #[test]
+    fn test_device_io_adapter() {
+        let device = Arc::new(MockDevice::default());
+
+        register_device(device.clone());
+        assert_eq!(*device.data.lock().unwrap(), 0x010);
+    }
+
+    #[test]
+    fn test_device_io_mut_adapter() {
+        let device_mut = Arc::new(Mutex::new(MockDeviceMut::default()));
+
+        register_device(device_mut.clone());
+        assert_eq!(device_mut.lock().unwrap().data, 0x010);
+    }
+
+    #[test]
+    fn test_io_data_struct() {
+        let io_size = IoSize::from(0x1111u64);
+        assert_eq!(io_size.raw_value(), 0x1111u64);
+        assert_eq!(u64::from(io_size), 0x1111u64);
+        assert_eq!(io_size, io_size.clone());
+        let io_size1 = IoSize::from(0x1112u64);
+        assert!(io_size < io_size1);
+
+        let io_addr = IoAddress::from(0x1234u64);
+        assert_eq!(io_addr.raw_value(), 0x1234u64);
+        assert_eq!(u64::from(io_addr), 0x1234u64);
+        assert_eq!(io_addr, io_addr.clone());
+        let io_addr1 = IoAddress::from(0x1235u64);
+        assert!(io_addr < io_addr1);
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    #[test]
+    fn test_pio_data_struct() {
+        let pio_size = PioSize::from(0x1111u16);
+        assert_eq!(pio_size.raw_value(), 0x1111u16);
+        assert_eq!(u16::from(pio_size), 0x1111u16);
+        assert_eq!(pio_size, pio_size.clone());
+        let pio_size1 = PioSize::from(0x1112u16);
+        assert!(pio_size < pio_size1);
+
+        let pio_size = PioSize::try_from(IoSize(0x1111u64)).unwrap();
+        assert_eq!(pio_size.raw_value(), 0x1111u16);
+
+        assert!(PioSize::try_from(IoSize(std::u16::MAX as u64 + 1)).is_err());
+
+        let io_size = IoSize::from(PioSize::from(0x1111u16));
+        assert_eq!(io_size.raw_value(), 0x1111u64);
+
+        let pio_addr = PioAddress::from(0x1234u16);
+        assert_eq!(pio_addr.raw_value(), 0x1234u16);
+        assert_eq!(u16::from(pio_addr), 0x1234u16);
+        assert_eq!(pio_addr, pio_addr.clone());
+        let pio_addr1 = PioAddress::from(0x1235u16);
+        assert!(pio_addr < pio_addr1);
+
+        assert!(PioAddress::try_from(IoAddress::from(0x12_3456u64)).is_err());
+        assert!(PioAddress::try_from(IoAddress::from(0x1234u64)).is_ok());
+        assert_eq!(IoAddress::from(pio_addr).raw_value(), 0x1234u64);
+    }
+}

--- a/crates/db-device/src/resources.rs
+++ b/crates/db-device/src/resources.rs
@@ -1,0 +1,626 @@
+// Copyright (C) 2019 Alibaba Cloud. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Structs to manage device resources.
+//!
+//! The high level flow of resource management among the VMM, the device
+//! manager, and the device is as below:
+//! 1) the VMM creates a new device object.
+//! 2) the VMM asks the new device object for its resource constraints.
+//! 3) the VMM allocates resources for the device object according to resource
+//!    constraints.
+//! 4) the VMM passes the allocated resources to the device object.
+//! 5) the VMM registers the new device onto corresponding device managers
+//!    according the allocated resources.
+
+use std::ops::Deref;
+
+/// Enumeration describing a device's resource constraints.
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum ResourceConstraint {
+    #[cfg(target_arch = "x86_64")]
+    /// Constraint for an IO Port address range.
+    PioAddress {
+        /// Allocating resource within the range [`min`, `max`] if specified.
+        range: Option<(u16, u16)>,
+        /// Alignment for the allocated address.
+        align: u16,
+        /// Size for the allocated address range.
+        size: u16,
+    },
+    /// Constraint for a Memory Mapped IO address range.
+    MmioAddress {
+        /// Allocating resource within the range [`min`, `max`] if specified.
+        range: Option<(u64, u64)>,
+        /// Alignment for the allocated address.
+        align: u64,
+        /// Size for the allocated address range.
+        size: u64,
+    },
+    /// Constraint for a Guest Mem address range.
+    MemAddress {
+        /// Allocating resource within the range [`min`, `max`] if specified.
+        range: Option<(u64, u64)>,
+        /// Alignment for the allocated address.
+        align: u64,
+        /// Size for the allocated address range.
+        size: u64,
+    },
+    /// Constraint for a legacy IRQ.
+    LegacyIrq {
+        /// Reserving the pre-allocated IRQ if it's specified.
+        irq: Option<u32>,
+    },
+    /// Constraint for PCI MSI IRQs.
+    PciMsiIrq {
+        /// Number of Irqs to allocate.
+        size: u32,
+    },
+    /// Constraint for PCI MSIx IRQs.
+    PciMsixIrq {
+        /// Number of Irqs to allocate.
+        size: u32,
+    },
+    /// Constraint for generic IRQs.
+    GenericIrq {
+        /// Number of Irqs to allocate.
+        size: u32,
+    },
+    /// Constraint for KVM mem_slot indexes to map memory into the guest.
+    KvmMemSlot {
+        /// Allocating kvm memory slots starting from the index `slot` if
+        /// specified.
+        slot: Option<u32>,
+        /// Number of slots to allocate.
+        size: u32,
+    },
+}
+
+impl ResourceConstraint {
+    #[cfg(target_arch = "x86_64")]
+    /// Create a new PIO address constraint object with default configuration.
+    pub fn new_pio(size: u16) -> Self {
+        ResourceConstraint::PioAddress {
+            range: None,
+            align: 0x1,
+            size,
+        }
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    /// Create a new PIO address constraint object.
+    pub fn pio_with_constraints(size: u16, range: Option<(u16, u16)>, align: u16) -> Self {
+        ResourceConstraint::PioAddress { range, align, size }
+    }
+
+    /// Create a new MMIO address constraint object with default configuration.
+    pub fn new_mmio(size: u64) -> Self {
+        ResourceConstraint::MmioAddress {
+            range: None,
+            align: 0x1000,
+            size,
+        }
+    }
+
+    /// Create a new MMIO address constraint object.
+    pub fn mmio_with_constraints(size: u64, range: Option<(u64, u64)>, align: u64) -> Self {
+        ResourceConstraint::MmioAddress { range, align, size }
+    }
+
+    /// Create a new Mem address constraint object with default configuration.
+    pub fn new_mem(size: u64) -> Self {
+        ResourceConstraint::MemAddress {
+            range: None,
+            align: 0x1000,
+            size,
+        }
+    }
+
+    /// Create a new Mem address constraint object.
+    pub fn mem_with_constraints(size: u64, range: Option<(u64, u64)>, align: u64) -> Self {
+        ResourceConstraint::MemAddress { range, align, size }
+    }
+
+    /// Create a new legacy IRQ constraint object.
+    ///
+    /// Allocating the pre-allocated legacy Irq `irq` if specified.
+    pub fn new_legacy_irq(irq: Option<u32>) -> Self {
+        ResourceConstraint::LegacyIrq { irq }
+    }
+
+    /// Create a new PCI MSI IRQ constraint object.
+    pub fn new_pci_msi_irq(size: u32) -> Self {
+        ResourceConstraint::PciMsiIrq { size }
+    }
+
+    /// Create a new PCI MSIX IRQ constraint object.
+    pub fn new_pci_msix_irq(size: u32) -> Self {
+        ResourceConstraint::PciMsixIrq { size }
+    }
+
+    /// Create a new Generic IRQ constraint object.
+    pub fn new_generic_irq(size: u32) -> Self {
+        ResourceConstraint::GenericIrq { size }
+    }
+
+    /// Create a new KVM memory slot constraint object.
+    ///
+    /// Allocating kvm memory slots starting from the index `slot` if specified.
+    pub fn new_kvm_mem_slot(size: u32, slot: Option<u32>) -> Self {
+        ResourceConstraint::KvmMemSlot { slot, size }
+    }
+}
+
+/// Type of Message Singaled Interrupt
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum MsiIrqType {
+    /// PCI MSI IRQ numbers.
+    PciMsi,
+    /// PCI MSIx IRQ numbers.
+    PciMsix,
+    /// Generic MSI IRQ numbers.
+    GenericMsi,
+}
+
+/// Enumeration for device resources.
+#[derive(Clone, Debug, PartialEq)]
+pub enum Resource {
+    #[cfg(target_arch = "x86_64")]
+    /// IO Port resource range.
+    PioAddressRange {
+        /// Pio resource base
+        base: u16,
+        /// Pio resource size
+        size: u16,
+    },
+    /// Memory Mapped IO resource range.
+    MmioAddressRange {
+        /// Mmio resource base
+        base: u64,
+        /// Mmio resource size
+        size: u64,
+    },
+    /// Guest Mem resource range.
+    MemAddressRange {
+        /// Mem resource base
+        base: u64,
+        /// Mem resource size
+        size: u64,
+    },
+    /// Legacy IRQ number.
+    LegacyIrq(u32),
+    /// Message Signaled Interrupt
+    MsiIrq {
+        /// Msi irq type
+        ty: MsiIrqType,
+        /// Msi irq base
+        base: u32,
+        /// Msi irq size
+        size: u32,
+    },
+    /// Network Interface Card MAC address.
+    MacAddresss(String),
+    /// KVM memslot index.
+    KvmMemSlot(u32),
+}
+
+/// Newtype to store a set of device resources.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct DeviceResources(Vec<Resource>);
+
+impl DeviceResources {
+    /// Create a container object to store device resources.
+    pub fn new() -> Self {
+        DeviceResources(Vec::new())
+    }
+
+    /// Append a device resource to the container object.
+    pub fn append(&mut self, entry: Resource) {
+        self.0.push(entry);
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    /// Get the IO port address resources.
+    pub fn get_pio_address_ranges(&self) -> Vec<(u16, u16)> {
+        let mut vec = Vec::new();
+        for entry in self.0.iter().as_ref() {
+            if let Resource::PioAddressRange { base, size } = entry {
+                vec.push((*base, *size));
+            }
+        }
+        vec
+    }
+
+    /// Get the Memory Mapped IO address resources.
+    pub fn get_mmio_address_ranges(&self) -> Vec<(u64, u64)> {
+        let mut vec = Vec::new();
+        for entry in self.0.iter().as_ref() {
+            if let Resource::MmioAddressRange { base, size } = entry {
+                vec.push((*base, *size));
+            }
+        }
+        vec
+    }
+
+    /// Get the Guest Memory address resources.
+    pub fn get_mem_address_ranges(&self) -> Vec<(u64, u64)> {
+        let mut vec = Vec::new();
+        for entry in self.0.iter().as_ref() {
+            if let Resource::MemAddressRange { base, size } = entry {
+                vec.push((*base, *size));
+            }
+        }
+        vec
+    }
+
+    /// Get the first legacy interrupt number(IRQ).
+    pub fn get_legacy_irq(&self) -> Option<u32> {
+        for entry in self.0.iter().as_ref() {
+            if let Resource::LegacyIrq(base) = entry {
+                return Some(*base);
+            }
+        }
+        None
+    }
+
+    /// Get information about the first PCI MSI interrupt resource.
+    pub fn get_pci_msi_irqs(&self) -> Option<(u32, u32)> {
+        self.get_msi_irqs(MsiIrqType::PciMsi)
+    }
+
+    /// Get information about the first PCI MSIx interrupt resource.
+    pub fn get_pci_msix_irqs(&self) -> Option<(u32, u32)> {
+        self.get_msi_irqs(MsiIrqType::PciMsix)
+    }
+
+    /// Get information about the first Generic MSI interrupt resource.
+    pub fn get_generic_msi_irqs(&self) -> Option<(u32, u32)> {
+        self.get_msi_irqs(MsiIrqType::GenericMsi)
+    }
+
+    fn get_msi_irqs(&self, ty: MsiIrqType) -> Option<(u32, u32)> {
+        for entry in self.0.iter().as_ref() {
+            if let Resource::MsiIrq {
+                ty: msi_type,
+                base,
+                size,
+            } = entry
+            {
+                if ty == *msi_type {
+                    return Some((*base, *size));
+                }
+            }
+        }
+        None
+    }
+
+    /// Get the KVM memory slots to map memory into the guest.
+    pub fn get_kvm_mem_slots(&self) -> Vec<u32> {
+        let mut vec = Vec::new();
+        for entry in self.0.iter().as_ref() {
+            if let Resource::KvmMemSlot(index) = entry {
+                vec.push(*index);
+            }
+        }
+        vec
+    }
+
+    /// Get the first resource information for NIC MAC address.
+    pub fn get_mac_address(&self) -> Option<String> {
+        for entry in self.0.iter().as_ref() {
+            if let Resource::MacAddresss(addr) = entry {
+                return Some(addr.clone());
+            }
+        }
+        None
+    }
+
+    /// Get immutable reference to all the resources.
+    pub fn get_all_resources(&self) -> &[Resource] {
+        &self.0
+    }
+}
+
+impl Deref for DeviceResources {
+    type Target = [Resource];
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use super::*;
+
+    #[cfg(target_arch = "x86_64")]
+    const PIO_ADDRESS_SIZE: u16 = 5;
+    #[cfg(target_arch = "x86_64")]
+    const PIO_ADDRESS_BASE: u16 = 0;
+    const MMIO_ADDRESS_SIZE: u64 = 0x8765_4321;
+    const MMIO_ADDRESS_BASE: u64 = 0x1234_5678;
+    const MEM_ADDRESS_SIZE: u64 = 0x8765_4321;
+    const MEM_ADDRESS_BASE: u64 = 0x1234_5678;
+    const LEGACY_IRQ: u32 = 0x168;
+    const PCI_MSI_IRQ_SIZE: u32 = 0x8888;
+    const PCI_MSI_IRQ_BASE: u32 = 0x6666;
+    const PCI_MSIX_IRQ_SIZE: u32 = 0x16666;
+    const PCI_MSIX_IRQ_BASE: u32 = 0x8888;
+    const GENERIC_MSI_IRQS_SIZE: u32 = 0x16888;
+    const GENERIC_MSI_IRQS_BASE: u32 = 0x16688;
+    const MAC_ADDRESS: &str = "00:08:63:66:86:88";
+    const KVM_SLOT_ID: u32 = 0x0100;
+
+    pub fn get_device_resource() -> DeviceResources {
+        let mut resource = DeviceResources::new();
+
+        #[cfg(target_arch = "x86_64")]
+        {
+            let entry = Resource::PioAddressRange {
+                base: PIO_ADDRESS_BASE,
+                size: PIO_ADDRESS_SIZE,
+            };
+            resource.append(entry.clone());
+            assert_eq!(entry, resource[0]);
+        }
+
+        let entry = Resource::MmioAddressRange {
+            base: MMIO_ADDRESS_BASE,
+            size: MMIO_ADDRESS_SIZE,
+        };
+        resource.append(entry.clone());
+        assert_eq!(entry, resource[1]);
+
+        let entry = Resource::MemAddressRange {
+            base: MEM_ADDRESS_BASE,
+            size: MEM_ADDRESS_SIZE,
+        };
+        resource.append(entry.clone());
+        assert_eq!(entry, resource[2]);
+
+        let entry = Resource::LegacyIrq(LEGACY_IRQ);
+        resource.append(entry.clone());
+        assert_eq!(entry, resource[3]);
+
+        let entry = Resource::MsiIrq {
+            ty: MsiIrqType::PciMsi,
+            base: PCI_MSI_IRQ_BASE,
+            size: PCI_MSI_IRQ_SIZE,
+        };
+        resource.append(entry.clone());
+        assert_eq!(entry, resource[4]);
+
+        let entry = Resource::MsiIrq {
+            ty: MsiIrqType::PciMsix,
+            base: PCI_MSIX_IRQ_BASE,
+            size: PCI_MSIX_IRQ_SIZE,
+        };
+        resource.append(entry.clone());
+        assert_eq!(entry, resource[5]);
+
+        let entry = Resource::MsiIrq {
+            ty: MsiIrqType::GenericMsi,
+            base: GENERIC_MSI_IRQS_BASE,
+            size: GENERIC_MSI_IRQS_SIZE,
+        };
+        resource.append(entry.clone());
+        assert_eq!(entry, resource[6]);
+
+        let entry = Resource::MacAddresss(MAC_ADDRESS.to_string());
+        resource.append(entry.clone());
+        assert_eq!(entry, resource[7]);
+
+        let entry = Resource::KvmMemSlot(KVM_SLOT_ID);
+        resource.append(entry.clone());
+        assert_eq!(entry, resource[8]);
+
+        resource
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    #[test]
+    fn get_pio_address_ranges() {
+        let resources = get_device_resource();
+        assert!(
+            resources.get_pio_address_ranges()[0].0 == PIO_ADDRESS_BASE
+                && resources.get_pio_address_ranges()[0].1 == PIO_ADDRESS_SIZE
+        );
+        assert_eq!(
+            resources[0],
+            Resource::PioAddressRange {
+                base: PIO_ADDRESS_BASE,
+                size: PIO_ADDRESS_SIZE,
+            }
+        );
+        assert_ne!(resources[0], resources[1]);
+
+        let resources2 = resources.clone();
+        assert_eq!(resources.len(), resources2.len());
+        drop(resources);
+        assert_eq!(
+            resources2[0],
+            Resource::PioAddressRange {
+                base: PIO_ADDRESS_BASE,
+                size: PIO_ADDRESS_SIZE,
+            }
+        );
+    }
+
+    #[test]
+    fn test_get_mmio_address_ranges() {
+        let resources = get_device_resource();
+        assert!(
+            resources.get_mmio_address_ranges()[0].0 == MMIO_ADDRESS_BASE
+                && resources.get_mmio_address_ranges()[0].1 == MMIO_ADDRESS_SIZE
+        );
+    }
+
+    #[test]
+    fn test_get_mem_address_ranges() {
+        let resources = get_device_resource();
+        assert!(
+            resources.get_mem_address_ranges()[0].0 == MEM_ADDRESS_BASE
+                && resources.get_mem_address_ranges()[0].1 == MEM_ADDRESS_SIZE
+        );
+    }
+
+    #[test]
+    fn test_get_legacy_irq() {
+        let resources = get_device_resource();
+        assert!(resources.get_legacy_irq().unwrap() == LEGACY_IRQ);
+    }
+
+    #[test]
+    fn test_get_pci_msi_irqs() {
+        let resources = get_device_resource();
+        assert!(
+            resources.get_pci_msi_irqs().unwrap().0 == PCI_MSI_IRQ_BASE
+                && resources.get_pci_msi_irqs().unwrap().1 == PCI_MSI_IRQ_SIZE
+        );
+    }
+
+    #[test]
+    fn test_pci_msix_irqs() {
+        let resources = get_device_resource();
+        assert!(
+            resources.get_pci_msix_irqs().unwrap().0 == PCI_MSIX_IRQ_BASE
+                && resources.get_pci_msix_irqs().unwrap().1 == PCI_MSIX_IRQ_SIZE
+        );
+    }
+
+    #[test]
+    fn test_get_generic_msi_irqs() {
+        let resources = get_device_resource();
+        assert!(
+            resources.get_generic_msi_irqs().unwrap().0 == GENERIC_MSI_IRQS_BASE
+                && resources.get_generic_msi_irqs().unwrap().1 == GENERIC_MSI_IRQS_SIZE
+        );
+    }
+
+    #[test]
+    fn test_get_mac_address() {
+        let resources = get_device_resource();
+        assert_eq!(resources.get_mac_address().unwrap(), MAC_ADDRESS);
+    }
+
+    #[test]
+    fn test_get_kvm_slot() {
+        let resources = get_device_resource();
+        assert_eq!(resources.get_kvm_mem_slots(), vec![KVM_SLOT_ID]);
+    }
+
+    #[test]
+    fn test_get_all_resources() {
+        let resources = get_device_resource();
+        assert_eq!(resources.get_all_resources().len(), 9);
+    }
+
+    #[test]
+    fn test_resource_constraint() {
+        #[cfg(target_arch = "x86_64")]
+        {
+            let pio = ResourceConstraint::new_pio(2);
+            let pio2 = pio;
+            let mmio = ResourceConstraint::new_mmio(0x1000);
+            assert_eq!(pio, pio2);
+            assert_ne!(pio, mmio);
+
+            if let ResourceConstraint::PioAddress { range, align, size } =
+                ResourceConstraint::new_pio(2)
+            {
+                assert_eq!(range, None);
+                assert_eq!(align, 1);
+                assert_eq!(size, 2);
+            } else {
+                panic!("Pio resource constraint is invalid.");
+            }
+
+            if let ResourceConstraint::PioAddress { range, align, size } =
+                ResourceConstraint::pio_with_constraints(2, Some((15, 16)), 2)
+            {
+                assert_eq!(range, Some((15, 16)));
+                assert_eq!(align, 2);
+                assert_eq!(size, 2);
+            } else {
+                panic!("Pio resource constraint is invalid.");
+            }
+        }
+
+        if let ResourceConstraint::MmioAddress { range, align, size } =
+            ResourceConstraint::new_mmio(0x2000)
+        {
+            assert_eq!(range, None);
+            assert_eq!(align, 0x1000);
+            assert_eq!(size, 0x2000);
+        } else {
+            panic!("Mmio resource constraint is invalid.");
+        }
+
+        if let ResourceConstraint::MmioAddress { range, align, size } =
+            ResourceConstraint::mmio_with_constraints(0x2000, Some((0x0, 0x2000)), 0x2000)
+        {
+            assert_eq!(range, Some((0x0, 0x2000)));
+            assert_eq!(align, 0x2000);
+            assert_eq!(size, 0x2000);
+        } else {
+            panic!("Mmio resource constraint is invalid.");
+        }
+
+        if let ResourceConstraint::MemAddress { range, align, size } =
+            ResourceConstraint::mem_with_constraints(0x2000, Some((0x0, 0x2000)), 0x2000)
+        {
+            assert_eq!(range, Some((0x0, 0x2000)));
+            assert_eq!(align, 0x2000);
+            assert_eq!(size, 0x2000);
+        } else {
+            panic!("Mmio resource constraint is invalid.");
+        }
+
+        if let ResourceConstraint::LegacyIrq { irq } =
+            ResourceConstraint::new_legacy_irq(Some(0x123))
+        {
+            assert_eq!(irq, Some(0x123));
+        } else {
+            panic!("IRQ resource constraint is invalid.");
+        }
+
+        if let ResourceConstraint::PciMsiIrq { size } = ResourceConstraint::new_pci_msi_irq(0x123) {
+            assert_eq!(size, 0x123);
+        } else {
+            panic!("Pci MSI irq resource constraint is invalid.");
+        }
+
+        if let ResourceConstraint::PciMsixIrq { size } = ResourceConstraint::new_pci_msix_irq(0x123)
+        {
+            assert_eq!(size, 0x123);
+        } else {
+            panic!("Pci MSIx irq resource constraint is invalid.");
+        }
+
+        if let ResourceConstraint::GenericIrq { size } = ResourceConstraint::new_generic_irq(0x123)
+        {
+            assert_eq!(size, 0x123);
+        } else {
+            panic!("generic irq resource constraint is invalid.");
+        }
+
+        if let ResourceConstraint::KvmMemSlot { slot, size } =
+            ResourceConstraint::new_kvm_mem_slot(0x1000, Some(0x2000))
+        {
+            assert_eq!(slot, Some(0x2000));
+            assert_eq!(size, 0x1000);
+        } else {
+            panic!("KVM slot resource constraint is invalid.");
+        }
+    }
+
+    #[test]
+    fn test_resources_deref() {
+        let resources = get_device_resource();
+        let mut count = 0;
+        for _res in resources.iter() {
+            count += 1;
+        }
+        assert_eq!(count, resources.0.len());
+    }
+}


### PR DESCRIPTION
Introduce db-device crate to dragonball-sandbox, which is designed to support the virtual machine's device model.