### PR TITLE
db-arch: refine CPUID transformer

### DIFF
--- a/crates/db-arch/src/x86_64/cpuid/mod.rs
+++ b/crates/db-arch/src/x86_64/cpuid/mod.rs
@@ -8,16 +8,17 @@
 
 //! Utilities for configuring the CPUID (CPU identification) for the guest microVM.
 
-use kvm_bindings::CpuId;
-
 pub mod bit_helper;
 pub mod cpu_leaf;
-
-pub use transformer::{CpuidTransformer, Error, VmSpec, VpmuFeatureLevel};
 
 mod brand_string;
 mod common;
 mod transformer;
+
+pub use transformer::{Error, VmSpec, VpmuFeatureLevel};
+
+type CpuId = kvm_bindings::CpuId;
+type CpuIdEntry = kvm_bindings::kvm_cpuid_entry2;
 
 /// Setup CPUID entries for the given vCPU.
 ///
@@ -43,14 +44,14 @@ mod transformer;
 /// let entries = kvm_cpuid.as_mut_slice();
 /// ```
 pub fn process_cpuid(kvm_cpuid: &mut CpuId, vm_spec: &VmSpec) -> Result<(), Error> {
+    use transformer::CpuidTransformer;
+
     match vm_spec.cpu_vendor_id() {
         self::common::VENDOR_ID_INTEL => {
-            let transformer = self::transformer::intel::IntelCpuidTransformer {};
-            transformer.process_cpuid(kvm_cpuid, vm_spec)
+            self::transformer::intel::IntelCpuidTransformer::new().process_cpuid(kvm_cpuid, vm_spec)
         }
         self::common::VENDOR_ID_AMD => {
-            let transformer = self::transformer::amd::AmdCpuidTransformer {};
-            transformer.process_cpuid(kvm_cpuid, vm_spec)
+            self::transformer::amd::AmdCpuidTransformer::new().process_cpuid(kvm_cpuid, vm_spec)
         }
         _ => Err(Error::CpuNotSupported),
     }

--- a/crates/db-arch/src/x86_64/cpuid/transformer/mod.rs
+++ b/crates/db-arch/src/x86_64/cpuid/transformer/mod.rs
@@ -2,17 +2,15 @@
 // Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use super::brand_string::{BrandString, Reg as BsReg};
+use super::common::get_vendor_id;
+use super::{CpuId, CpuIdEntry};
+
 pub mod amd;
 pub mod common;
 pub mod intel;
 
-pub use kvm_bindings::{kvm_cpuid_entry2, CpuId};
-
-use crate::cpuid::brand_string::BrandString;
-use crate::cpuid::brand_string::Reg as BsReg;
-use crate::cpuid::common::get_vendor_id;
-
-/// enum indicating vpmu feature level
+/// Enum indicating vpmu feature level
 #[derive(Debug, PartialEq, Copy, Clone)]
 pub enum VpmuFeatureLevel {
     /// Disabled means vpmu feature is off (by default)
@@ -93,18 +91,16 @@ pub enum Error {
     VcpuCountOverflow,
 }
 
-pub type EntryTransformerFn =
-    fn(entry: &mut kvm_cpuid_entry2, vm_spec: &VmSpec) -> Result<(), Error>;
+pub type EntryTransformerFn = fn(entry: &mut CpuIdEntry, vm_spec: &VmSpec) -> Result<(), Error>;
 
 /// Generic trait that provides methods for transforming the cpuid
 pub trait CpuidTransformer {
-    /// Trait main function. It processes the cpuid and makes the desired transformations.
-    /// The default logic can be overwritten if needed. For example see `AmdCpuidTransformer`.
+    /// Process the cpuid array and make the desired transformations.
     fn process_cpuid(&self, cpuid: &mut CpuId, vm_spec: &VmSpec) -> Result<(), Error> {
         self.process_entries(cpuid, vm_spec)
     }
 
-    /// Iterates through all the cpuid entries and calls the associated transformer for each one.
+    /// Iterate through all the cpuid entries and calls the associated transformer for each one.
     fn process_entries(&self, cpuid: &mut CpuId, vm_spec: &VmSpec) -> Result<(), Error> {
         for entry in cpuid.as_mut_slice().iter_mut() {
             let maybe_transformer_fn = self.entry_transformer_fn(entry);
@@ -117,8 +113,8 @@ pub trait CpuidTransformer {
         Ok(())
     }
 
-    /// Gets the associated transformer for a cpuid entry
-    fn entry_transformer_fn(&self, _entry: &mut kvm_cpuid_entry2) -> Option<EntryTransformerFn> {
+    /// Get the associated transformer for a cpuid entry
+    fn entry_transformer_fn(&self, _entry: &mut CpuIdEntry) -> Option<EntryTransformerFn> {
         None
     }
 }


### PR DESCRIPTION
Refine CPUID transformer by:
1) add better doc
2) refine code structure
3) add wrapper type "CpuIdEntry" for future extensions.

Signed-off-by: Liu Jiang <gerry@linux.alibaba.com>