### PR TITLE
db-boot: init db-boot and boot layout constants

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,5 +3,6 @@
 members = [
     "crates/db-allocator",
     "crates/db-arch",
+    "crates/db-boot",
     "crates/db-device",
 ]

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This repository contains the following crates:
 | --- | --- | --- |
 | [db-allocator](crates/db-allocator) | allocator for vmm resource | TBD |
 | [db-arch](crates/db-arch) | collections of CPU architecture related modules | TBD |
+| [db-boot](crates/db-boot) | collections of constants, structs and utilities used during VM boot stage | TBD |
 | [db-device](crates/db-device) | virtual machine's device model | TBD |
 
 (Dragonball is a virtual machine monitor developed by Alibaba and db is the abbreviation for Dragonball.)

--- a/crates/db-boot/Cargo.toml
+++ b/crates/db-boot/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "db-boot"
+version = "0.1.0"
+authors = ["Alibaba Dragonball Team"]
+license = "Apache-2.0"
+edition = "2018"
+homepage = "https://github.com/openanolis/dragonball-sandbox"
+repository = "https://github.com/openanolis/dragonball-sandbox"
+keywords = ["dragonball", "boot", "VMM"]
+readme = "README.md"
+
+[dependencies]

--- a/crates/db-boot/README.md
+++ b/crates/db-boot/README.md
@@ -1,0 +1,21 @@
+# db-boot
+
+## Design
+
+The `db-boot` crate is a collection of constants, structs and utilities used to boot virtual machines.
+
+## Submodule List
+
+This repository contains the following submodules:
+| Name | Arch| Description |
+| --- | --- | --- |
+| [layout](src/x86_64/layout.rs) | x86_64 | x86_64 layout constants |
+| [layout](src/aarch64/layout.rs/) | aarch64 | aarch64 layout constants |
+
+## Acknowledgement
+
+Part of the code is derived from the [Firecracker](https://github.com/firecracker-microvm/firecracker) project.
+
+## License
+
+This project is licensed under [Apache License](http://www.apache.org/licenses/LICENSE-2.0), Version 2.0.

--- a/crates/db-boot/src/aarch64/layout.rs
+++ b/crates/db-boot/src/aarch64/layout.rs
@@ -1,0 +1,81 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//      ==== Address map in use in ARM development systems today ====
+//
+//              - 32-bit -              - 36-bit -          - 40-bit -
+//1024GB    +                   +                      +-------------------+     <- 40-bit
+//          |                                           | DRAM              |
+//          ~                   ~                       ~                   ~
+//          |                                           |                   |
+//          |                                           |                   |
+//          |                                           |                   |
+//          |                                           |                   |
+//544GB     +                   +                       +-------------------+
+//          |                                           | Hole or DRAM      |
+//          |                                           |                   |
+//512GB     +                   +                       +-------------------+
+//          |                                           |       Mapped      |
+//          |                                           |       I/O         |
+//          ~                   ~                       ~                   ~
+//          |                                           |                   |
+//256GB     +                   +                       +-------------------+
+//          |                                           |       Reserved    |
+//          ~                   ~                       ~                   ~
+//          |                                           |                   |
+//64GB      +                   +-----------------------+-------------------+   <- 36-bit
+//          |                   |                   DRAM                    |
+//          ~                   ~                   ~                       ~
+//          |                   |                                           |
+//          |                   |                                           |
+//34GB      +                   +-----------------------+-------------------+
+//          |                   |                  Hole or DRAM             |
+//32GB      +                   +-----------------------+-------------------+
+//          |                   |                   Mapped I/O              |
+//          ~                   ~                       ~                   ~
+//          |                   |                                           |
+//16GB      +                   +-----------------------+-------------------+
+//          |                   |                   Reserved                |
+//          ~                   ~                       ~                   ~
+//4GB       +-------------------+-----------------------+-------------------+   <- 32-bit
+//          |           2GB of DRAM                                         |
+//          |                                                               |
+//2GB       +-------------------+-----------------------+-------------------+
+//          |                           Mapped I/O                          |
+//1GB       +-------------------+-----------------------+-------------------+
+//          |                          ROM & RAM & I/O                      |
+//0GB       +-------------------+-----------------------+-------------------+   0
+//              - 32-bit -              - 36-bit -              - 40-bit -
+//
+// Taken from (http://infocenter.arm.com/help/topic/com.arm.doc.den0001c/DEN0001C_principles_of_arm_memory_maps.pdf).
+
+/// Start of RAM on 64 bit ARM.
+pub const DRAM_MEM_START: u64 = 0x8000_0000; // 2 GB.
+/// The maximum addressable RAM address.
+pub const DRAM_MEM_END: u64 = 0x00F8_0000_0000; // 1024 - 32 = 992 GB.
+/// The maximum RAM size.
+pub const DRAM_MEM_MAX_SIZE: u64 = DRAM_MEM_END - DRAM_MEM_START;
+
+/// Kernel command line maximum size.
+/// As per `arch/arm64/include/uapi/asm/setup.h`.
+pub const CMDLINE_MAX_SIZE: usize = 2048;
+
+/// Maximum size of the device tree blob as specified in https://www.kernel.org/doc/Documentation/arm64/booting.txt.
+pub const FDT_MAX_SIZE: usize = 0x20_0000;
+
+// As per virt/kvm/arm/vgic/vgic-kvm-device.c we need
+// the number of interrupts our GIC will support to be:
+// * bigger than 32
+// * less than 1023 and
+// * a multiple of 32.
+// We are setting up our interrupt controller to support a maximum of 128 interrupts.
+/// First usable interrupt on aarch64.
+pub const IRQ_BASE: u32 = 32;
+
+/// Last usable interrupt on aarch64.
+pub const IRQ_MAX: u32 = 159;
+
+/// Below this address will reside the GIC, above this address will reside the MMIO devices.
+pub const MAPPED_IO_START: u64 = 1 << 30; // 1 GB
+/// End address (inclusive) of the MMIO window.
+pub const MAPPED_IO_END: u64 = (2 << 30) - 1; // 1 GB

--- a/crates/db-boot/src/aarch64/mod.rs
+++ b/crates/db-boot/src/aarch64/mod.rs
@@ -1,0 +1,7 @@
+// Copyright 2021 Alibaba Cloud. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! VM boot related constants and utilities for `aarch64` architecture.
+
+/// Magic addresses externally used to lay out aarch64 VMs.
+pub mod layout;

--- a/crates/db-boot/src/lib.rs
+++ b/crates/db-boot/src/lib.rs
@@ -1,0 +1,19 @@
+// Copyright 2021-2022 Alibaba Cloud. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#![deny(missing_docs)]
+
+//! CPU architecture specific constants and utilities.
+//!
+//! This crate provides CPU architecture specific constants and utilities to abstract away CPU
+//! architecture specific details from the Dragonball Sandbox or other VMMs.
+
+#[cfg(target_arch = "x86_64")]
+mod x86_64;
+#[cfg(target_arch = "x86_64")]
+pub use x86_64::*;
+
+#[cfg(target_arch = "aarch64")]
+mod aarch64;
+#[cfg(target_arch = "aarch64")]
+pub use aarch64::*;

--- a/crates/db-boot/src/x86_64/layout.rs
+++ b/crates/db-boot/src/x86_64/layout.rs
@@ -1,0 +1,38 @@
+// Copyright 2021-2022 Alibaba Cloud. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Portions Copyright 2017 The Chromium OS Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the THIRD-PARTY file.
+
+/// Magic addresses externally used to lay out x86_64 VMs.
+
+/// Initial stack for the boot CPU.
+pub const BOOT_STACK_POINTER: u64 = 0x8ff0;
+
+/// Kernel command line start address.
+pub const CMDLINE_START: u64 = 0x20000;
+/// Kernel command line start address maximum size.
+pub const CMDLINE_MAX_SIZE: usize = 0x10000;
+
+/// Kernel dragonball boot parameters start address.
+pub const DB_BOOT_PARAM_START: u64 = 0x30000;
+/// Kernel dragonball boot parameters length maximum size.
+pub const DB_BOOT_PARAM_MAX_SIZE: u32 = 0x10000;
+
+/// Start of the high memory.
+pub const HIMEM_START: u64 = 0x0010_0000; //1 MB.
+
+// Typically, on x86 systems 16 IRQs are used (0-15).
+/// First usable IRQ ID for virtio device interrupts on x86_64.
+pub const IRQ_BASE: u32 = 5;
+/// Last usable IRQ ID for virtio device interrupts on x86_64.
+pub const IRQ_MAX: u32 = 15;
+
+/// Address for the TSS setup.
+pub const KVM_TSS_ADDRESS: u64 = 0xfffb_d000;
+
+/// The 'zero page', a.k.a linux kernel bootparams.
+pub const ZERO_PAGE_START: u64 = 0x7000;

--- a/crates/db-boot/src/x86_64/mod.rs
+++ b/crates/db-boot/src/x86_64/mod.rs
@@ -1,0 +1,7 @@
+// Copyright 2021 Alibaba Cloud. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! VM boot related constants and utilities for `x86_64` architecture.
+
+/// Magic addresses externally used to lay out x86_64 VMs.
+pub mod layout;


### PR DESCRIPTION
This patch inits db-boot crate and introduce cpu architecture specific
layout constants

Signed-off-by: Chao Wu <chaowu@linux.alibaba.com>