### PR TITLE
error: use this_error to optimize error display

### DIFF
--- a/crates/db-allocator/Cargo.toml
+++ b/crates/db-allocator/Cargo.toml
@@ -8,3 +8,6 @@ homepage = "https://github.com/openanolis/dragonball-sandbox"
 repository = "https://github.com/openanolis/dragonball-sandbox"
 keywords = ["dragonball"]
 readme = "README.md"
+
+[dependencies]
+thiserror = "1.0"

--- a/crates/db-allocator/src/lib.rs
+++ b/crates/db-allocator/src/lib.rs
@@ -7,24 +7,15 @@
 
 mod interval_tree;
 pub use interval_tree::{IntervalTree, NodeState, Range};
-use std::fmt::{Display, Formatter};
 use std::result;
+use thiserror::Error;
 
 /// Error conditions that may appear during `Allocator` related operations.
-#[derive(Debug, PartialEq)]
+#[derive(Error, Debug, PartialEq)]
 pub enum Error {
     /// Invalid Constraint Max and Min
+    #[error("invalid constraint max ({0}) and min ({1})")]
     InvalidBoundary(u64, u64),
-}
-
-impl Display for Error {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Error::InvalidBoundary(max, min) => {
-                write!(f, "invalid constraint max ({}) and min ({})", max, min)
-            }
-        }
-    }
 }
 
 /// Policy for resource allocation.


### PR DESCRIPTION
this error crate could help implement display trait for error with clear
derive macro

Signed-off-by: Chao Wu <chaowu@linux.alibaba.com>