### PR TITLE
ci: remove upload result for unit test.

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -35,16 +35,10 @@ jobs:
           key: ${{ runner.os }}-build-${{ env.cache-name }}
       - name: Generate test result and coverage report
         run: |
-          cargo install cargo2junit grcov;
-          cargo test $CARGO_OPTIONS -- -Z unstable-options --format json | cargo2junit > results.xml;
+          cargo install grcov;
+          cargo test $CARGO_OPTIONS -- -Z unstable-options;
           zip -0 ccov.zip `find ./target \( -name "*.gc*" \) -print`;
           grcov ccov.zip -s . -t lcov --llvm --ignore-not-existing --ignore "/*" --ignore "tests/*" -o lcov.info;
-      - name: Upload test results
-        uses: EnricoMi/publish-unit-test-result-action@v1
-        with:
-          check_name: Test Results
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          files: results.xml
       - name: Upload to CodeCov
         uses: codecov/codecov-action@v2
         with:


### PR DESCRIPTION
This function does not work for fork repositories.

Signed-off-by: wllenyj <wllenyj@linux.alibaba.com>