### PR TITLE
db-micro-http: introduce db-micro-http

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,4 +6,5 @@ members = [
     "crates/db-arch",
     "crates/db-boot",
     "crates/db-device",
+    "crates/db-micro-http",
 ]

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This repository contains the following crates:
 | [db-arch](crates/db-arch) | collections of CPU architecture related modules | TBD |
 | [db-boot](crates/db-boot) | collections of constants, structs and utilities used during VM boot stage | TBD |
 | [db-device](crates/db-device) | virtual machine's device model | TBD |
+| [db-micro-http](crates/db-micro-http) | implementation of the HTTP/1.0 and HTTP/1.1 protocols | TBD |
 
 (Dragonball is a virtual machine monitor developed by Alibaba and db is the abbreviation for Dragonball.)
 

--- a/crates/db-micro-http/Cargo.toml
+++ b/crates/db-micro-http/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "micro_http"
+version = "0.1.0"
+license = "Apache-2.0"
+authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
+edition = "2018"
+
+[dependencies]
+libc = "0.2.39"
+vmm-sys-util = "0.9.0"

--- a/crates/db-micro-http/README.md
+++ b/crates/db-micro-http/README.md
@@ -1,0 +1,67 @@
+# db-micro-http
+
+## Design
+
+db-micro-http is a minimal implementations of HTTP 1.0 and HTTP 1.1 protocols. 
+
+## Acknowledgement
+
+This crate is forked from the [Firecracker](https://github.com/firecracker-microvm/firecracker) project with modification to support more usage cases.
+
+## Example
+
+Example for parsing an HTTP Request from a slice:
+
+```rust
+use micro_http::{Request, Version};
+let request_bytes = b"GET http://localhost/home HTTP/1.0\r\n\r\n";
+let http_request = Request::try_from(request_bytes, None).unwrap();
+assert_eq!(http_request.http_version(), Version::Http10);
+assert_eq!(http_request.uri().get_abs_path(), "/home");
+```
+
+Example for creating an HTTP Response:
+
+```rust
+use micro_http::{Body, MediaType, Response, StatusCode, Version};
+let mut response = Response::new(Version::Http10, StatusCode::OK);
+let body = String::from("This is a test");
+response.set_body(Body::new(body.clone()));
+response.set_content_type(MediaType::PlainText);
+
+assert!(response.status() == StatusCode::OK);
+assert_eq!(response.body().unwrap(), Body::new(body));
+assert_eq!(response.http_version(), Version::Http10);
+
+let mut response_buf: [u8; 126] = [0; 126];
+assert!(response.write_all(&mut response_buf.as_mut()).is_ok());
+```
+
+Example for using the server:
+
+```rust
+use micro_http::{HttpServer, Response, StatusCode};
+
+let path_to_socket = "/tmp/example.sock";
+std::fs::remove_file(path_to_socket).unwrap_or_default();
+// Start the server.
+let mut server = HttpServer::new(path_to_socket).unwrap();
+server.start_server().unwrap();
+
+// Connect a client to the server so it doesn't block in our example.
+let mut socket = std::os::unix::net::UnixStream::connect(path_to_socket).unwrap();
+
+// Server loop processing requests.
+loop {
+    for request in server.requests().unwrap() {
+        let response = request.process(|request| {
+            // Your code here.
+            Response::new(request.http_version(), StatusCode::NoContent)
+        });
+        server.respond(response);
+    }
+    // Break this example loop.
+    break;
+}
+```
+

--- a/crates/db-micro-http/src/common/headers.rs
+++ b/crates/db-micro-http/src/common/headers.rs
@@ -1,0 +1,787 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::HashMap;
+use std::result::Result;
+
+use crate::HttpHeaderError;
+use crate::RequestError;
+
+/// Wrapper over an HTTP Header type.
+#[derive(Debug, Eq, Hash, PartialEq)]
+pub enum Header {
+    /// Header `Content-Length`.
+    ContentLength,
+    /// Header `Content-Type`.
+    ContentType,
+    /// Header `Expect`.
+    Expect,
+    /// Header `Transfer-Encoding`.
+    TransferEncoding,
+    /// Header `Server`.
+    Server,
+    /// Header `Accept`
+    Accept,
+    /// Header `Accept-Encoding`
+    AcceptEncoding,
+}
+
+impl Header {
+    /// Returns a byte slice representation of the object.
+    pub fn raw(&self) -> &'static [u8] {
+        match self {
+            Self::ContentLength => b"Content-Length",
+            Self::ContentType => b"Content-Type",
+            Self::Expect => b"Expect",
+            Self::TransferEncoding => b"Transfer-Encoding",
+            Self::Server => b"Server",
+            Self::Accept => b"Accept",
+            Self::AcceptEncoding => b"Accept-Encoding",
+        }
+    }
+
+    /// Parses a byte slice into a Header structure. Header must be ASCII, so also
+    /// UTF-8 valid.
+    ///
+    /// # Errors
+    /// `InvalidRequest` is returned if slice contains invalid utf8 characters.
+    /// `InvalidHeader` is returned if unsupported header found.
+    fn try_from(string: &[u8]) -> Result<Self, RequestError> {
+        if let Ok(mut utf8_string) = String::from_utf8(string.to_vec()) {
+            utf8_string.make_ascii_lowercase();
+            match utf8_string.trim() {
+                "content-length" => Ok(Self::ContentLength),
+                "content-type" => Ok(Self::ContentType),
+                "expect" => Ok(Self::Expect),
+                "transfer-encoding" => Ok(Self::TransferEncoding),
+                "server" => Ok(Self::Server),
+                "accept" => Ok(Self::Accept),
+                "accept-encoding" => Ok(Self::AcceptEncoding),
+                invalid_key => Err(RequestError::HeaderError(HttpHeaderError::UnsupportedName(
+                    invalid_key.to_string(),
+                ))),
+            }
+        } else {
+            Err(RequestError::InvalidRequest)
+        }
+    }
+}
+
+/// Wrapper over the list of headers associated with a Request that we need
+/// in order to parse the request correctly and be able to respond to it.
+///
+/// The only `Content-Type`s supported are `text/plain` and `application/json`, which are both
+/// in plain text actually and don't influence our parsing process.
+///
+/// All the other possible header fields are not necessary in order to serve this connection
+/// and, thus, are not of interest to us. However, we still look for header fields that might
+/// invalidate our request as we don't support the full set of HTTP/1.1 specification.
+/// Such header entries are "Transfer-Encoding: identity; q=0", which means a compression
+/// algorithm is applied to the body of the request, or "Expect: 103-checkpoint".
+#[derive(Debug, PartialEq)]
+pub struct Headers {
+    /// The `Content-Length` header field tells us how many bytes we need to receive
+    /// from the source after the headers.
+    content_length: u32,
+    /// The `Expect` header field is set when the headers contain the entry "Expect: 100-continue".
+    /// This means that, per HTTP/1.1 specifications, we must send a response with the status code
+    /// 100 after we have received the headers in order to receive the body of the request. This
+    /// field should be known immediately after parsing the headers.
+    expect: bool,
+    /// `Chunked` is a possible value of the `Transfer-Encoding` header field and every HTTP/1.1
+    /// server must support it. It is useful only when receiving the body of the request and should
+    /// be known immediately after parsing the headers.
+    chunked: bool,
+    /// `Accept` header might be used by HTTP clients to enforce server responses with content
+    /// formatted in a specific way.
+    accept: MediaType,
+    /// Hashmap reserved for storing custom headers.
+    custom_entries: HashMap<String, String>,
+}
+
+impl Default for Headers {
+    /// By default Requests are created with no headers.
+    fn default() -> Self {
+        Self {
+            content_length: Default::default(),
+            expect: Default::default(),
+            chunked: Default::default(),
+            // The default `Accept` media type is plain text. This is inclusive enough
+            // for structured and unstructured text.
+            accept: MediaType::PlainText,
+            custom_entries: HashMap::default(),
+        }
+    }
+}
+
+impl Headers {
+    /// Expects one header line and parses it, updating the header structure or returning an
+    /// error if the header is invalid.
+    ///
+    /// # Errors
+    /// `UnsupportedHeader` is returned when the parsed header line is not of interest
+    /// to us or when it is unrecognizable.
+    /// `InvalidHeader` is returned when the parsed header is formatted incorrectly or suggests
+    /// that the client is using HTTP features that we do not support in this implementation,
+    /// which invalidates the request.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use micro_http::Headers;
+    ///
+    /// let mut request_header = Headers::default();
+    /// assert!(request_header.parse_header_line(b"Content-Length: 24").is_ok());
+    /// assert!(request_header.parse_header_line(b"Content-Length: 24: 2").is_err());
+    /// ```
+    pub fn parse_header_line(&mut self, header_line: &[u8]) -> Result<(), RequestError> {
+        // Headers must be ASCII, so also UTF-8 valid.
+        match std::str::from_utf8(header_line) {
+            Ok(headers_str) => {
+                let entry = headers_str.splitn(2, ':').collect::<Vec<&str>>();
+                if entry.len() != 2 {
+                    return Err(RequestError::HeaderError(HttpHeaderError::InvalidFormat(
+                        entry[0].to_string(),
+                    )));
+                }
+                if let Ok(head) = Header::try_from(entry[0].as_bytes()) {
+                    match head {
+                        Header::ContentLength => match entry[1].trim().parse::<u32>() {
+                            Ok(content_length) => {
+                                self.content_length = content_length;
+                                Ok(())
+                            }
+                            Err(_) => {
+                                Err(RequestError::HeaderError(HttpHeaderError::InvalidValue(
+                                    entry[0].to_string(),
+                                    entry[1].to_string(),
+                                )))
+                            }
+                        },
+                        Header::ContentType => {
+                            match MediaType::try_from(entry[1].trim().as_bytes()) {
+                                Ok(_) => Ok(()),
+                                Err(_) => Err(RequestError::HeaderError(
+                                    HttpHeaderError::UnsupportedValue(
+                                        entry[0].to_string(),
+                                        entry[1].to_string(),
+                                    ),
+                                )),
+                            }
+                        }
+                        Header::Accept => match MediaType::try_from(entry[1].trim().as_bytes()) {
+                            Ok(accept_type) => {
+                                self.accept = accept_type;
+                                Ok(())
+                            }
+                            Err(_) => Err(RequestError::HeaderError(
+                                HttpHeaderError::UnsupportedValue(
+                                    entry[0].to_string(),
+                                    entry[1].to_string(),
+                                ),
+                            )),
+                        },
+                        Header::TransferEncoding => match entry[1].trim() {
+                            "chunked" => {
+                                self.chunked = true;
+                                Ok(())
+                            }
+                            "identity" => Ok(()),
+                            _ => Err(RequestError::HeaderError(
+                                HttpHeaderError::UnsupportedValue(
+                                    entry[0].to_string(),
+                                    entry[1].to_string(),
+                                ),
+                            )),
+                        },
+                        Header::Expect => match entry[1].trim() {
+                            "100-continue" => {
+                                self.expect = true;
+                                Ok(())
+                            }
+                            _ => Err(RequestError::HeaderError(
+                                HttpHeaderError::UnsupportedValue(
+                                    entry[0].to_string(),
+                                    entry[1].to_string(),
+                                ),
+                            )),
+                        },
+                        Header::Server => Ok(()),
+                        Header::AcceptEncoding => Encoding::try_from(entry[1].trim().as_bytes()),
+                    }
+                } else {
+                    self.insert_custom_header(
+                        entry[0].trim().to_string(),
+                        entry[1].trim().to_string(),
+                    )?;
+                    Ok(())
+                }
+            }
+            Err(utf8_err) => Err(RequestError::HeaderError(
+                HttpHeaderError::InvalidUtf8String(utf8_err),
+            )),
+        }
+    }
+
+    /// Returns the content length of the body.
+    pub fn content_length(&self) -> u32 {
+        self.content_length
+    }
+
+    /// Returns `true` if the transfer encoding is chunked.
+    #[allow(unused)]
+    pub fn chunked(&self) -> bool {
+        self.chunked
+    }
+
+    /// Returns `true` if the client is expecting the code 100.
+    #[allow(unused)]
+    pub fn expect(&self) -> bool {
+        self.expect
+    }
+
+    /// Returns the `Accept` header `MediaType`.
+    pub fn accept(&self) -> MediaType {
+        self.accept
+    }
+
+    /// Parses a byte slice into a Headers structure for a HTTP request.
+    ///
+    /// The byte slice is expected to have the following format: </br>
+    ///     * Request Header Lines "<header_line> CRLF"- Optional </br>
+    /// There can be any number of request headers, including none, followed by
+    /// an extra sequence of Carriage Return and Line Feed.
+    /// All header fields are parsed. However, only the ones present in the
+    /// [`Headers`](struct.Headers.html) struct are relevant to us and stored
+    /// for future use.
+    ///
+    /// # Errors
+    /// The function returns `InvalidHeader` when parsing the byte stream fails.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use micro_http::Headers;
+    ///
+    /// let request_headers = Headers::try_from(b"Content-Length: 55\r\n\r\n");
+    /// ```
+    pub fn try_from(bytes: &[u8]) -> Result<Headers, RequestError> {
+        // Headers must be ASCII, so also UTF-8 valid.
+        if let Ok(text) = std::str::from_utf8(bytes) {
+            let mut headers = Self::default();
+
+            let header_lines = text.split("\r\n");
+            for header_line in header_lines {
+                if header_line.is_empty() {
+                    break;
+                }
+                match headers.parse_header_line(header_line.as_bytes()) {
+                    Ok(_)
+                    | Err(RequestError::HeaderError(HttpHeaderError::UnsupportedValue(_, _))) => {
+                        continue
+                    }
+                    Err(e) => return Err(e),
+                };
+            }
+            return Ok(headers);
+        }
+        Err(RequestError::InvalidRequest)
+    }
+
+    /// Accept header setter.
+    pub fn set_accept(&mut self, media_type: MediaType) {
+        self.accept = media_type;
+    }
+
+    /// Insert a new custom header and value pair into the `HashMap`.
+    pub fn insert_custom_header(&mut self, key: String, value: String) -> Result<(), RequestError> {
+        self.custom_entries.insert(key, value);
+        Ok(())
+    }
+
+    /// Returns the custom header `HashMap`.
+    pub fn custom_entries(&self) -> &HashMap<String, String> {
+        &self.custom_entries
+    }
+}
+
+/// Wrapper over supported AcceptEncoding.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct Encoding {}
+
+impl Encoding {
+    /// Parses a byte slice and checks if identity encoding is invalidated. Encoding
+    /// must be ASCII, so also UTF-8 valid.
+    ///
+    /// # Errors
+    /// `InvalidRequest` is returned when the byte stream is empty.
+    ///
+    /// `InvalidValue` is returned when the identity encoding is invalidated.
+    ///
+    /// `InvalidUtf8String` is returned when the byte stream contains invalid characters.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use micro_http::Encoding;
+    ///
+    /// assert!(Encoding::try_from(b"deflate").is_ok());
+    /// assert!(Encoding::try_from(b"identity;q=0").is_err());
+    /// ```
+    pub fn try_from(bytes: &[u8]) -> Result<(), RequestError> {
+        if bytes.is_empty() {
+            return Err(RequestError::InvalidRequest);
+        }
+        match std::str::from_utf8(bytes) {
+            Ok(headers_str) => {
+                let entry = headers_str.split(',').collect::<Vec<&str>>();
+
+                for encoding in entry {
+                    match encoding.trim() {
+                        "identity;q=0" => {
+                            Err(RequestError::HeaderError(HttpHeaderError::InvalidValue(
+                                "Accept-Encoding".to_string(),
+                                encoding.to_string(),
+                            )))
+                        }
+                        "*;q=0" if !headers_str.contains("identity") => {
+                            Err(RequestError::HeaderError(HttpHeaderError::InvalidValue(
+                                "Accept-Encoding".to_string(),
+                                encoding.to_string(),
+                            )))
+                        }
+                        _ => Ok(()),
+                    }?;
+                }
+                Ok(())
+            }
+            Err(utf8_err) => Err(RequestError::HeaderError(
+                HttpHeaderError::InvalidUtf8String(utf8_err),
+            )),
+        }
+    }
+}
+
+/// Wrapper over supported Media Types.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum MediaType {
+    /// Media Type: "text/plain".
+    PlainText,
+    /// Media Type: "application/json".
+    ApplicationJson,
+}
+
+impl Default for MediaType {
+    /// Default value for MediaType is application/json
+    fn default() -> Self {
+        Self::ApplicationJson
+    }
+}
+
+impl MediaType {
+    /// Parses a byte slice into a MediaType structure for a HTTP request. MediaType
+    /// must be ASCII, so also UTF-8 valid.
+    ///
+    /// # Errors
+    /// The function returns `InvalidRequest` when parsing the byte stream fails or
+    /// unsupported MediaType found.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use micro_http::MediaType;
+    ///
+    /// assert!(MediaType::try_from(b"application/json").is_ok());
+    /// assert!(MediaType::try_from(b"application/json2").is_err());
+    /// ```
+    pub fn try_from(bytes: &[u8]) -> Result<Self, RequestError> {
+        if bytes.is_empty() {
+            return Err(RequestError::InvalidRequest);
+        }
+        let utf8_slice =
+            String::from_utf8(bytes.to_vec()).map_err(|_| RequestError::InvalidRequest)?;
+        match utf8_slice.as_str().trim() {
+            "text/plain" => Ok(Self::PlainText),
+            "application/json" => Ok(Self::ApplicationJson),
+            _ => Err(RequestError::InvalidRequest),
+        }
+    }
+
+    /// Returns a static string representation of the object.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use micro_http::MediaType;
+    ///
+    /// let media_type = MediaType::ApplicationJson;
+    /// assert_eq!(media_type.as_str(), "application/json");
+    /// ```
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::PlainText => "text/plain",
+            Self::ApplicationJson => "application/json",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    impl Headers {
+        pub fn new(content_length: u32, expect: bool, chunked: bool) -> Self {
+            Self {
+                content_length,
+                expect,
+                chunked,
+                accept: MediaType::PlainText,
+                custom_entries: HashMap::default(),
+            }
+        }
+    }
+
+    #[test]
+    fn test_default() {
+        let headers = Headers::default();
+        assert_eq!(headers.content_length(), 0);
+        assert!(!headers.chunked());
+        assert!(!headers.expect());
+        assert_eq!(headers.accept(), MediaType::PlainText);
+        assert_eq!(headers.custom_entries(), &HashMap::default());
+    }
+
+    #[test]
+    fn test_try_from_media() {
+        assert_eq!(
+            MediaType::try_from(b"application/json").unwrap(),
+            MediaType::ApplicationJson
+        );
+
+        assert_eq!(
+            MediaType::try_from(b"text/plain").unwrap(),
+            MediaType::PlainText
+        );
+
+        assert_eq!(
+            MediaType::try_from(b"").unwrap_err(),
+            RequestError::InvalidRequest
+        );
+
+        assert_eq!(
+            MediaType::try_from(b"application/json-patch").unwrap_err(),
+            RequestError::InvalidRequest
+        );
+    }
+
+    #[test]
+    fn test_media_as_str() {
+        let media_type = MediaType::ApplicationJson;
+        assert_eq!(media_type.as_str(), "application/json");
+
+        let media_type = MediaType::PlainText;
+        assert_eq!(media_type.as_str(), "text/plain");
+    }
+
+    #[test]
+    fn test_try_from_encoding() {
+        assert_eq!(
+            Encoding::try_from(b"").unwrap_err(),
+            RequestError::InvalidRequest
+        );
+
+        assert_eq!(
+            Encoding::try_from(b"identity;q=0").unwrap_err(),
+            RequestError::HeaderError(HttpHeaderError::InvalidValue(
+                "Accept-Encoding".to_string(),
+                "identity;q=0".to_string()
+            ))
+        );
+
+        assert!(Encoding::try_from(b"identity;q").is_ok());
+
+        assert_eq!(
+            Encoding::try_from(b"*;q=0").unwrap_err(),
+            RequestError::HeaderError(HttpHeaderError::InvalidValue(
+                "Accept-Encoding".to_string(),
+                "*;q=0".to_string()
+            ))
+        );
+
+        let bytes: [u8; 10] = [130, 140, 150, 130, 140, 150, 130, 140, 150, 160];
+        assert!(Encoding::try_from(&bytes[..]).is_err());
+
+        assert!(Encoding::try_from(b"identity;q=1").is_ok());
+        assert!(Encoding::try_from(b"identity;q=0.1").is_ok());
+        assert!(Encoding::try_from(b"deflate, identity, *;q=0").is_ok());
+        assert!(Encoding::try_from(b"br").is_ok());
+        assert!(Encoding::try_from(b"compress").is_ok());
+        assert!(Encoding::try_from(b"gzip").is_ok());
+    }
+
+    #[test]
+    fn test_try_from_headers() {
+        // Valid headers.
+        let headers =  Headers::try_from(
+            b"Last-Modified: Tue, 15 Nov 1994 12:45:26 GMT\r\nAccept: application/json\r\nContent-Length: 55\r\n\r\n"
+        )
+            .unwrap();
+        assert_eq!(headers.content_length, 55);
+        assert_eq!(headers.accept, MediaType::ApplicationJson);
+        assert_eq!(
+            headers.custom_entries().get("Last-Modified").unwrap(),
+            "Tue, 15 Nov 1994 12:45:26 GMT"
+        );
+        assert_eq!(headers.custom_entries().len(), 1);
+
+        // Valid headers. (${HEADER_NAME} : WHITESPACE ${HEADER_VALUE})
+        // Any number of whitespace characters should be accepted including zero.
+        let headers =  Headers::try_from(
+            b"Last-Modified: Tue, 15 Nov 1994 12:45:26 GMT\r\nAccept:text/plain\r\nContent-Length:   49\r\n\r\n"
+        )
+            .unwrap();
+        assert_eq!(headers.content_length, 49);
+        assert_eq!(headers.accept, MediaType::PlainText);
+
+        // Valid headers.
+        let headers = Headers::try_from(
+            b"Last-Modified: Tue, 15 Nov 1994 12:45:26 GMT\r\nContent-Length: 29\r\n\r\n",
+        )
+        .unwrap();
+        assert_eq!(headers.content_length, 29);
+
+        // Custom headers only.
+        let headers = Headers::try_from(
+            b"Last-Modified: Tue, 15 Nov 1994 12:45:26 GMT\r\nfoo: bar\r\nbar: 15\r\n\r\n",
+        )
+        .unwrap();
+        let custom_entries = headers.custom_entries();
+        assert_eq!(custom_entries.get("foo").unwrap(), "bar");
+        assert_eq!(custom_entries.get("bar").unwrap(), "15");
+        assert_eq!(custom_entries.len(), 3);
+
+        // Valid headers, invalid value.
+        assert_eq!(
+            Headers::try_from(
+                b"Last-Modified: Tue, 15 Nov 1994 12:45:26 GMT\r\nContent-Length: -55\r\n\r\n"
+            )
+            .unwrap_err(),
+            RequestError::HeaderError(HttpHeaderError::InvalidValue(
+                "Content-Length".to_string(),
+                " -55".to_string()
+            ))
+        );
+
+        let bytes: [u8; 10] = [130, 140, 150, 130, 140, 150, 130, 140, 150, 160];
+        // Invalid headers.
+        assert!(Headers::try_from(&bytes[..]).is_err());
+    }
+
+    #[test]
+    fn test_parse_header_line() {
+        let mut header = Headers::default();
+
+        // Invalid header syntax.
+        assert_eq!(
+            header.parse_header_line(b"Expect"),
+            Err(RequestError::HeaderError(HttpHeaderError::InvalidFormat(
+                "Expect".to_string()
+            )))
+        );
+
+        // Invalid content length.
+        assert_eq!(
+            header.parse_header_line(b"Content-Length: five"),
+            Err(RequestError::HeaderError(HttpHeaderError::InvalidValue(
+                "Content-Length".to_string(),
+                " five".to_string()
+            )))
+        );
+
+        // Invalid transfer encoding.
+        assert_eq!(
+            header.parse_header_line(b"Transfer-Encoding: gzip"),
+            Err(RequestError::HeaderError(
+                HttpHeaderError::UnsupportedValue(
+                    "Transfer-Encoding".to_string(),
+                    " gzip".to_string()
+                )
+            ))
+        );
+
+        // Invalid expect.
+        assert_eq!(
+            header
+                .parse_header_line(b"Expect: 102-processing")
+                .unwrap_err(),
+            RequestError::HeaderError(HttpHeaderError::UnsupportedValue(
+                "Expect".to_string(),
+                " 102-processing".to_string()
+            ))
+        );
+
+        // Unsupported media type.
+        assert_eq!(
+            header
+                .parse_header_line(b"Content-Type: application/json-patch")
+                .unwrap_err(),
+            RequestError::HeaderError(HttpHeaderError::UnsupportedValue(
+                "Content-Type".to_string(),
+                " application/json-patch".to_string()
+            ))
+        );
+
+        // Invalid input format.
+        let input: [u8; 10] = [130, 140, 150, 130, 140, 150, 130, 140, 150, 160];
+        assert_eq!(
+            header.parse_header_line(&input[..]).unwrap_err(),
+            RequestError::HeaderError(HttpHeaderError::InvalidUtf8String(
+                String::from_utf8(input.to_vec()).unwrap_err().utf8_error()
+            ))
+        );
+
+        // Test valid transfer encoding.
+        assert!(header
+            .parse_header_line(b"Transfer-Encoding: chunked")
+            .is_ok());
+        assert!(header.chunked());
+
+        // Test valid expect.
+        assert!(header.parse_header_line(b"Expect: 100-continue").is_ok());
+        assert!(header.expect());
+
+        // Test valid media type.
+        assert!(header
+            .parse_header_line(b"Content-Type: application/json")
+            .is_ok());
+
+        // Test valid accept media type.
+        assert!(header
+            .parse_header_line(b"Accept: application/json")
+            .is_ok());
+        assert_eq!(header.accept, MediaType::ApplicationJson);
+        assert!(header.parse_header_line(b"Accept: text/plain").is_ok());
+        assert_eq!(header.accept, MediaType::PlainText);
+
+        // Test invalid accept media type.
+        assert!(header
+            .parse_header_line(b"Accept: application/json-patch")
+            .is_err());
+
+        // Invalid content length.
+        assert_eq!(
+            header.parse_header_line(b"Content-Length: -1"),
+            Err(RequestError::HeaderError(HttpHeaderError::InvalidValue(
+                "Content-Length".to_string(),
+                " -1".to_string()
+            )))
+        );
+
+        assert!(header
+            .parse_header_line(b"Accept-Encoding: deflate")
+            .is_ok());
+        assert_eq!(
+            header.parse_header_line(b"Accept-Encoding: compress, identity;q=0"),
+            Err(RequestError::HeaderError(HttpHeaderError::InvalidValue(
+                "Accept-Encoding".to_string(),
+                " identity;q=0".to_string()
+            )))
+        );
+
+        // Test custom header.
+        assert_eq!(header.custom_entries().len(), 0);
+        assert!(header.parse_header_line(b"Custom-Header: foo").is_ok());
+        assert_eq!(
+            header.custom_entries().get("Custom-Header").unwrap(),
+            &"foo".to_string()
+        );
+        assert_eq!(header.custom_entries().len(), 1);
+    }
+
+    #[test]
+    fn test_parse_header_whitespace() {
+        let mut header = Headers::default();
+        // Test that any number of whitespace characters are accepted before the header value.
+        // For Content-Length
+        assert!(header.parse_header_line(b"Content-Length:24").is_ok());
+        assert!(header.parse_header_line(b"Content-Length:   24").is_ok());
+
+        // For ContentType
+        assert!(header
+            .parse_header_line(b"Content-Type:application/json")
+            .is_ok());
+        assert!(header
+            .parse_header_line(b"Content-Type:    application/json")
+            .is_ok());
+
+        // For Accept
+        assert!(header.parse_header_line(b"Accept:application/json").is_ok());
+        assert!(header
+            .parse_header_line(b"Accept:  application/json")
+            .is_ok());
+
+        // For Transfer-Encoding
+        assert!(header
+            .parse_header_line(b"Transfer-Encoding:chunked")
+            .is_ok());
+        assert!(header.chunked());
+        assert!(header
+            .parse_header_line(b"Transfer-Encoding:    chunked")
+            .is_ok());
+        assert!(header.chunked());
+
+        // For Server
+        assert!(header.parse_header_line(b"Server:xxx.yyy.zzz").is_ok());
+        assert!(header.parse_header_line(b"Server:   xxx.yyy.zzz").is_ok());
+
+        // For Expect
+        assert!(header.parse_header_line(b"Expect:100-continue").is_ok());
+        assert!(header.parse_header_line(b"Expect:    100-continue").is_ok());
+
+        // Test that custom headers' names and values are trimmed before being stored
+        // inside the HashMap.
+        assert!(header.parse_header_line(b"Foo:bar").is_ok());
+        assert_eq!(header.custom_entries().get("Foo").unwrap(), "bar");
+        assert!(header.parse_header_line(b"  Bar  :  foo  ").is_ok());
+        assert_eq!(header.custom_entries().get("Bar").unwrap(), "foo");
+    }
+
+    #[test]
+    fn test_header_try_from() {
+        // Bad header.
+        assert_eq!(
+            Header::try_from(b"Encoding").unwrap_err(),
+            RequestError::HeaderError(HttpHeaderError::UnsupportedName("encoding".to_string()))
+        );
+
+        // Invalid encoding.
+        let input: [u8; 10] = [130, 140, 150, 130, 140, 150, 130, 140, 150, 160];
+        assert_eq!(
+            Header::try_from(&input[..]).unwrap_err(),
+            RequestError::InvalidRequest
+        );
+
+        // Test valid headers.
+        let header = Header::try_from(b"Expect").unwrap();
+        assert_eq!(header.raw(), b"Expect");
+
+        let header = Header::try_from(b"Transfer-Encoding").unwrap();
+        assert_eq!(header.raw(), b"Transfer-Encoding");
+
+        let header = Header::try_from(b"content-length").unwrap();
+        assert_eq!(header.raw(), b"Content-Length");
+
+        let header = Header::try_from(b"Accept").unwrap();
+        assert_eq!(header.raw(), b"Accept");
+    }
+
+    #[test]
+    fn test_set_accept() {
+        let mut headers = Headers::default();
+        assert_eq!(headers.accept(), MediaType::PlainText);
+
+        headers.set_accept(MediaType::ApplicationJson);
+        assert_eq!(headers.accept(), MediaType::ApplicationJson);
+    }
+}

--- a/crates/db-micro-http/src/common/mod.rs
+++ b/crates/db-micro-http/src/common/mod.rs
@@ -1,0 +1,562 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::fmt::{Display, Error, Formatter};
+use std::str::Utf8Error;
+
+pub mod headers;
+
+pub mod ascii {
+    pub const CR: u8 = b'\r';
+    pub const COLON: u8 = b':';
+    pub const LF: u8 = b'\n';
+    pub const SP: u8 = b' ';
+    pub const CRLF_LEN: usize = 2;
+}
+
+///Errors associated with a header that is invalid.
+#[derive(Debug, PartialEq)]
+pub enum HttpHeaderError {
+    /// The header is misformatted.
+    InvalidFormat(String),
+    /// The specified header contains illegal characters.
+    InvalidUtf8String(Utf8Error),
+    ///The value specified is not valid.
+    InvalidValue(String, String),
+    /// The content length specified is longer than the limit imposed by Micro Http.
+    SizeLimitExceeded(String),
+    /// The requested feature is not currently supported.
+    UnsupportedFeature(String, String),
+    /// The header specified is not supported.
+    UnsupportedName(String),
+    /// The value for the specified header is not supported.
+    UnsupportedValue(String, String),
+}
+
+impl Display for HttpHeaderError {
+    fn fmt(&self, f: &mut Formatter) -> Result<(), Error> {
+        match self {
+            Self::InvalidFormat(header_key) => {
+                write!(f, "Header is incorrectly formatted. Key: {}", header_key)
+            }
+            Self::InvalidUtf8String(header_key) => {
+                write!(f, "Header contains invalid characters. Key: {}", header_key)
+            }
+            Self::InvalidValue(header_name, value) => {
+                write!(f, "Invalid value. Key:{}; Value:{}", header_name, value)
+            }
+            Self::SizeLimitExceeded(inner) => {
+                write!(f, "Invalid content length. Header: {}", inner)
+            }
+            Self::UnsupportedFeature(header_key, header_value) => write!(
+                f,
+                "Unsupported feature. Key: {}; Value: {}",
+                header_key, header_value
+            ),
+            Self::UnsupportedName(inner) => write!(f, "Unsupported header name. Key: {}", inner),
+            Self::UnsupportedValue(header_key, header_value) => write!(
+                f,
+                "Unsupported value. Key:{}; Value:{}",
+                header_key, header_value
+            ),
+        }
+    }
+}
+
+/// Errors associated with parsing the HTTP Request from a u8 slice.
+#[derive(Debug, PartialEq)]
+pub enum RequestError {
+    /// No request was pending while the request body was being parsed.
+    BodyWithoutPendingRequest,
+    /// Header specified is either invalid or not supported by this HTTP implementation.
+    HeaderError(HttpHeaderError),
+    /// No request was pending while the request headers were being parsed.
+    HeadersWithoutPendingRequest,
+    /// The HTTP Method is not supported or it is invalid.
+    InvalidHttpMethod(&'static str),
+    /// The HTTP Version in the Request is not supported or it is invalid.
+    InvalidHttpVersion(&'static str),
+    /// The Request is invalid and cannot be served.
+    InvalidRequest,
+    /// Request URI is invalid.
+    InvalidUri(&'static str),
+    /// Overflow occurred when parsing a request.
+    Overflow,
+    /// Underflow occurred when parsing a request.
+    Underflow,
+    /// Payload too large.
+    SizeLimitExceeded(usize, usize),
+}
+
+impl Display for RequestError {
+    fn fmt(&self, f: &mut Formatter) -> Result<(), Error> {
+        match self {
+            Self::BodyWithoutPendingRequest => write!(
+                f,
+                "No request was pending while the request body was being parsed."
+            ),
+            Self::HeaderError(inner) => write!(f, "Invalid header. Reason: {}", inner),
+            Self::HeadersWithoutPendingRequest => write!(
+                f,
+                "No request was pending while the request headers were being parsed."
+            ),
+            Self::InvalidHttpMethod(inner) => write!(f, "Invalid HTTP Method: {}", inner),
+            Self::InvalidHttpVersion(inner) => write!(f, "Invalid HTTP Version: {}", inner),
+            Self::InvalidRequest => write!(f, "Invalid request."),
+            Self::InvalidUri(inner) => write!(f, "Invalid URI: {}", inner),
+            Self::Overflow => write!(f, "Overflow occurred when parsing a request."),
+            Self::Underflow => write!(f, "Underflow occurred when parsing a request."),
+            Self::SizeLimitExceeded(limit, size) => write!(
+                f,
+                "Request payload with size {} is larger than the limit of {} \
+                 allowed by server.",
+                size, limit
+            ),
+        }
+    }
+}
+
+/// Errors associated with a HTTP Connection.
+#[derive(Debug)]
+pub enum ConnectionError {
+    /// Attempted to read or write on a closed connection.
+    ConnectionClosed,
+    /// Attempted to write on a stream when there was nothing to write.
+    InvalidWrite,
+    /// The request parsing has failed.
+    ParseError(RequestError),
+    /// Could not perform a read operation from stream successfully.
+    StreamReadError(vmm_sys_util::errno::Error),
+    /// Could not perform a write operation to stream successfully.
+    StreamWriteError(std::io::Error),
+}
+
+impl Display for ConnectionError {
+    fn fmt(&self, f: &mut Formatter) -> Result<(), Error> {
+        match self {
+            Self::ConnectionClosed => write!(f, "Connection closed."),
+            Self::InvalidWrite => write!(f, "Invalid write attempt."),
+            Self::ParseError(inner) => write!(f, "Parsing error: {}", inner),
+            Self::StreamReadError(inner) => write!(f, "Reading stream error: {}", inner),
+            Self::StreamWriteError(inner) => write!(f, "Writing stream error: {}", inner),
+        }
+    }
+}
+
+/// Errors pertaining to `HttpRoute`.
+#[derive(Debug)]
+#[allow(dead_code)]
+pub enum RouteError {
+    /// Handler for http routing path already exists.
+    HandlerExist(String),
+}
+
+impl Display for RouteError {
+    fn fmt(&self, f: &mut Formatter) -> Result<(), Error> {
+        match self {
+            RouteError::HandlerExist(p) => write!(f, "handler for {} already exists", p),
+        }
+    }
+}
+
+/// Errors pertaining to `HttpServer`.
+#[derive(Debug)]
+pub enum ServerError {
+    /// Error from one of the connections.
+    ConnectionError(ConnectionError),
+    /// Epoll operations failed.
+    IOError(std::io::Error),
+    /// Overflow occured while processing messages.
+    Overflow,
+    /// Server maximum capacity has been reached.
+    ServerFull,
+    /// Underflow occured while processing mesagges.
+    Underflow,
+}
+
+impl Display for ServerError {
+    fn fmt(&self, f: &mut Formatter) -> Result<(), Error> {
+        match self {
+            Self::ConnectionError(inner) => write!(f, "Connection error: {}", inner),
+            Self::IOError(inner) => write!(f, "IO error: {}", inner),
+            Self::Overflow => write!(f, "Overflow occured while processing messages."),
+            Self::ServerFull => write!(f, "Server is full."),
+            Self::Underflow => write!(f, "Underflow occured while processing messages."),
+        }
+    }
+}
+
+/// The Body associated with an HTTP Request or Response.
+///
+/// ## Examples
+/// ```
+/// use micro_http::Body;
+/// let body = Body::new("This is a test body.".to_string());
+/// assert_eq!(body.raw(), b"This is a test body.");
+/// assert_eq!(body.len(), 20);
+/// ```
+#[derive(Clone, Debug, PartialEq)]
+pub struct Body {
+    /// Body of the HTTP message as bytes.
+    pub body: Vec<u8>,
+}
+
+impl Body {
+    /// Creates a new `Body` from a `String` input.
+    pub fn new<T: Into<Vec<u8>>>(body: T) -> Self {
+        Self { body: body.into() }
+    }
+
+    /// Returns the body as an `u8 slice`.
+    pub fn raw(&self) -> &[u8] {
+        self.body.as_slice()
+    }
+
+    /// Returns the length of the `Body`.
+    pub fn len(&self) -> usize {
+        self.body.len()
+    }
+
+    /// Checks if the body is empty, ie with zero length
+    pub fn is_empty(&self) -> bool {
+        self.body.len() == 0
+    }
+}
+
+/// Supported HTTP Methods.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum Method {
+    /// GET Method.
+    Get,
+    /// PUT Method.
+    Put,
+    /// PATCH Method.
+    Patch,
+}
+
+impl Method {
+    /// Returns a `Method` object if the parsing of `bytes` is successful.
+    ///
+    /// The method is case sensitive. A call to try_from with the input b"get" will return
+    /// an error, but when using the input b"GET", it returns Method::Get.
+    ///
+    /// # Errors
+    /// `InvalidHttpMethod` is returned if the specified HTTP method is unsupported.
+    pub fn try_from(bytes: &[u8]) -> Result<Self, RequestError> {
+        match bytes {
+            b"GET" => Ok(Self::Get),
+            b"PUT" => Ok(Self::Put),
+            b"PATCH" => Ok(Self::Patch),
+            _ => Err(RequestError::InvalidHttpMethod("Unsupported HTTP method.")),
+        }
+    }
+
+    /// Returns an `u8 slice` corresponding to the Method.
+    pub fn raw(self) -> &'static [u8] {
+        match self {
+            Self::Get => b"GET",
+            Self::Put => b"PUT",
+            Self::Patch => b"PATCH",
+        }
+    }
+
+    /// Returns an &str corresponding to the Method.
+    pub fn to_str(self) -> &'static str {
+        match self {
+            Method::Get => "GET",
+            Method::Put => "PUT",
+            Method::Patch => "PATCH",
+        }
+    }
+}
+
+/// Supported HTTP Versions.
+///
+/// # Examples
+/// ```
+/// use micro_http::Version;
+/// let version = Version::try_from(b"HTTP/1.1");
+/// assert!(version.is_ok());
+///
+/// let version = Version::try_from(b"http/1.1");
+/// assert!(version.is_err());
+/// ```
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum Version {
+    /// HTTP/1.0
+    Http10,
+    /// HTTP/1.1
+    Http11,
+}
+
+impl Default for Version {
+    /// Returns the default HTTP version = HTTP/1.1.
+    fn default() -> Self {
+        Self::Http11
+    }
+}
+
+impl Version {
+    /// HTTP Version as an `u8 slice`.
+    pub fn raw(self) -> &'static [u8] {
+        match self {
+            Self::Http10 => b"HTTP/1.0",
+            Self::Http11 => b"HTTP/1.1",
+        }
+    }
+
+    /// Creates a new HTTP Version from an `u8 slice`.
+    ///
+    /// The supported versions are HTTP/1.0 and HTTP/1.1.
+    /// The version is case sensitive and the accepted input is upper case.
+    ///
+    /// # Errors
+    /// Returns a `InvalidHttpVersion` when the HTTP version is not supported.
+    pub fn try_from(bytes: &[u8]) -> Result<Self, RequestError> {
+        match bytes {
+            b"HTTP/1.0" => Ok(Self::Http10),
+            b"HTTP/1.1" => Ok(Self::Http11),
+            _ => Err(RequestError::InvalidHttpVersion(
+                "Unsupported HTTP version.",
+            )),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    impl PartialEq for ConnectionError {
+        fn eq(&self, other: &Self) -> bool {
+            use self::ConnectionError::*;
+            match (self, other) {
+                (ParseError(ref e), ParseError(ref other_e)) => e.eq(other_e),
+                (ConnectionClosed, ConnectionClosed) => true,
+                (StreamReadError(ref e), StreamReadError(ref other_e)) => {
+                    format!("{}", e).eq(&format!("{}", other_e))
+                }
+                (StreamWriteError(ref e), StreamWriteError(ref other_e)) => {
+                    format!("{}", e).eq(&format!("{}", other_e))
+                }
+                (InvalidWrite, InvalidWrite) => true,
+                _ => false,
+            }
+        }
+    }
+
+    #[test]
+    fn test_version() {
+        // Tests for raw()
+        assert_eq!(Version::Http10.raw(), b"HTTP/1.0");
+        assert_eq!(Version::Http11.raw(), b"HTTP/1.1");
+
+        // Tests for try_from()
+        assert_eq!(Version::try_from(b"HTTP/1.0").unwrap(), Version::Http10);
+        assert_eq!(Version::try_from(b"HTTP/1.1").unwrap(), Version::Http11);
+        assert_eq!(
+            Version::try_from(b"HTTP/2.0").unwrap_err(),
+            RequestError::InvalidHttpVersion("Unsupported HTTP version.")
+        );
+
+        // Test for default()
+        assert_eq!(Version::default(), Version::Http11);
+    }
+
+    #[test]
+    fn test_method() {
+        // Test for raw
+        assert_eq!(Method::Get.raw(), b"GET");
+        assert_eq!(Method::Put.raw(), b"PUT");
+        assert_eq!(Method::Patch.raw(), b"PATCH");
+
+        // Tests for try_from
+        assert_eq!(Method::try_from(b"GET").unwrap(), Method::Get);
+        assert_eq!(Method::try_from(b"PUT").unwrap(), Method::Put);
+        assert_eq!(Method::try_from(b"PATCH").unwrap(), Method::Patch);
+        assert_eq!(
+            Method::try_from(b"POST").unwrap_err(),
+            RequestError::InvalidHttpMethod("Unsupported HTTP method.")
+        );
+    }
+
+    #[test]
+    fn test_body() {
+        let body = Body::new("".to_string());
+        // Test for is_empty
+        assert!(body.is_empty());
+        let body = Body::new("This is a body.".to_string());
+        // Test for len
+        assert_eq!(body.len(), 15);
+        // Test for raw
+        assert_eq!(body.raw(), b"This is a body.");
+    }
+
+    #[test]
+    fn test_display_request_error() {
+        assert_eq!(
+            format!("{}", RequestError::BodyWithoutPendingRequest),
+            "No request was pending while the request body was being parsed."
+        );
+        assert_eq!(
+            format!("{}", RequestError::HeadersWithoutPendingRequest),
+            "No request was pending while the request headers were being parsed."
+        );
+        assert_eq!(
+            format!("{}", RequestError::InvalidHttpMethod("test")),
+            "Invalid HTTP Method: test"
+        );
+        assert_eq!(
+            format!("{}", RequestError::InvalidHttpVersion("test")),
+            "Invalid HTTP Version: test"
+        );
+        assert_eq!(
+            format!("{}", RequestError::InvalidRequest),
+            "Invalid request."
+        );
+        assert_eq!(
+            format!("{}", RequestError::InvalidUri("test")),
+            "Invalid URI: test"
+        );
+        assert_eq!(
+            format!("{}", RequestError::Overflow),
+            "Overflow occurred when parsing a request."
+        );
+        assert_eq!(
+            format!("{}", RequestError::Underflow),
+            "Underflow occurred when parsing a request."
+        );
+        assert_eq!(
+            format!("{}", RequestError::SizeLimitExceeded(4, 10)),
+            "Request payload with size 10 is larger than the limit of 4 allowed by server."
+        );
+    }
+
+    #[test]
+    fn test_display_header_error() {
+        assert_eq!(
+            format!(
+                "{}",
+                RequestError::HeaderError(HttpHeaderError::InvalidFormat("test".to_string()))
+            ),
+            "Invalid header. Reason: Header is incorrectly formatted. Key: test"
+        );
+        let value = String::from_utf8(vec![0, 159]);
+        assert_eq!(
+            format!(
+                "{}",
+                RequestError::HeaderError(HttpHeaderError::InvalidUtf8String(
+                    value.unwrap_err().utf8_error()
+                ))
+            ),
+            "Invalid header. Reason: Header contains invalid characters. Key: invalid utf-8 sequence of 1 bytes from index 1"
+        );
+        assert_eq!(
+            format!(
+                "{}",
+                RequestError::HeaderError(HttpHeaderError::SizeLimitExceeded("test".to_string()))
+            ),
+            "Invalid header. Reason: Invalid content length. Header: test"
+        );
+        assert_eq!(
+            format!(
+                "{}",
+                RequestError::HeaderError(HttpHeaderError::UnsupportedFeature(
+                    "test".to_string(),
+                    "test".to_string()
+                ))
+            ),
+            "Invalid header. Reason: Unsupported feature. Key: test; Value: test"
+        );
+        assert_eq!(
+            format!(
+                "{}",
+                RequestError::HeaderError(HttpHeaderError::UnsupportedName("test".to_string()))
+            ),
+            "Invalid header. Reason: Unsupported header name. Key: test"
+        );
+        assert_eq!(
+            format!(
+                "{}",
+                RequestError::HeaderError(HttpHeaderError::UnsupportedValue(
+                    "test".to_string(),
+                    "test".to_string()
+                ))
+            ),
+            "Invalid header. Reason: Unsupported value. Key:test; Value:test"
+        );
+    }
+
+    #[test]
+    fn test_display_connection_error() {
+        assert_eq!(
+            format!("{}", ConnectionError::ConnectionClosed),
+            "Connection closed."
+        );
+        assert_eq!(
+            format!(
+                "{}",
+                ConnectionError::ParseError(RequestError::InvalidRequest)
+            ),
+            "Parsing error: Invalid request."
+        );
+        assert_eq!(
+            format!("{}", ConnectionError::InvalidWrite),
+            "Invalid write attempt."
+        );
+        assert_eq!(
+            format!(
+                "{}",
+                ConnectionError::StreamWriteError(std::io::Error::from_raw_os_error(11))
+            ),
+            "Writing stream error: Resource temporarily unavailable (os error 11)"
+        );
+    }
+
+    #[test]
+    fn test_display_server_error() {
+        assert_eq!(
+            format!(
+                "{}",
+                ServerError::ConnectionError(ConnectionError::ConnectionClosed)
+            ),
+            "Connection error: Connection closed."
+        );
+        assert_eq!(
+            format!(
+                "{}",
+                ServerError::IOError(std::io::Error::from_raw_os_error(11))
+            ),
+            "IO error: Resource temporarily unavailable (os error 11)"
+        );
+        assert_eq!(
+            format!("{}", ServerError::Overflow),
+            "Overflow occured while processing messages."
+        );
+        assert_eq!(format!("{}", ServerError::ServerFull), "Server is full.");
+        assert_eq!(
+            format!("{}", ServerError::Underflow),
+            "Underflow occured while processing messages."
+        );
+    }
+
+    #[test]
+    fn test_display_route_error() {
+        assert_eq!(
+            format!("{}", RouteError::HandlerExist("test".to_string())),
+            "handler for test already exists"
+        );
+    }
+
+    #[test]
+    fn test_method_to_str() {
+        let val = Method::Get;
+        assert_eq!(val.to_str(), "GET");
+
+        let val = Method::Put;
+        assert_eq!(val.to_str(), "PUT");
+
+        let val = Method::Patch;
+        assert_eq!(val.to_str(), "PATCH");
+    }
+}

--- a/crates/db-micro-http/src/connection.rs
+++ b/crates/db-micro-http/src/connection.rs
@@ -1,0 +1,1278 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::VecDeque;
+use std::fs::File;
+use std::io::{Read, Write};
+use std::os::unix::io::FromRawFd;
+
+use crate::common::ascii::{CR, CRLF_LEN, LF};
+use crate::common::Body;
+pub use crate::common::{ConnectionError, HttpHeaderError, RequestError};
+use crate::headers::Headers;
+use crate::request::{find, Request, RequestLine};
+use crate::response::{Response, StatusCode};
+use crate::server::MAX_PAYLOAD_SIZE;
+use vmm_sys_util::sock_ctrl_msg::ScmSocket;
+
+const BUFFER_SIZE: usize = 1024;
+const SCM_MAX_FD: usize = 253;
+
+/// Describes the state machine of an HTTP connection.
+enum ConnectionState {
+    WaitingForRequestLine,
+    WaitingForHeaders,
+    WaitingForBody,
+    RequestReady,
+}
+
+/// A wrapper over a HTTP Connection.
+pub struct HttpConnection<T> {
+    /// A partial request that is still being received.
+    pending_request: Option<Request>,
+    /// Stream implementing `Read` and `Write`, capable of sending and
+    /// receiving bytes.
+    stream: T,
+    /// The state of the connection regarding the current request that
+    /// is being processed.
+    state: ConnectionState,
+    /// Buffer where we store the bytes we read from the stream.
+    buffer: [u8; BUFFER_SIZE],
+    /// The index in the buffer from where we have to start reading in
+    /// the next `try_read` call.
+    read_cursor: usize,
+    /// Contains all bytes pertaining to the body of the request that
+    /// is currently being processed.
+    body_vec: Vec<u8>,
+    /// Represents how many bytes from the body of the request are still
+    /// to be read.
+    body_bytes_to_be_read: u32,
+    /// A queue of all requests that have been fully received and parsed.
+    parsed_requests: VecDeque<Request>,
+    /// A queue of requests that are waiting to be sent.
+    response_queue: VecDeque<Response>,
+    /// A buffer containing the bytes of a response that is currently
+    /// being sent.
+    response_buffer: Option<Vec<u8>>,
+    /// The list of files that has been received and which must be associated
+    /// with the pending request.
+    files: Vec<File>,
+    /// Optional payload max size.
+    payload_max_size: usize,
+}
+
+impl<T: Read + Write + ScmSocket> HttpConnection<T> {
+    /// Creates an empty connection.
+    pub fn new(stream: T) -> Self {
+        Self {
+            pending_request: None,
+            stream,
+            state: ConnectionState::WaitingForRequestLine,
+            buffer: [0; BUFFER_SIZE],
+            read_cursor: 0,
+            body_vec: vec![],
+            body_bytes_to_be_read: 0,
+            parsed_requests: VecDeque::new(),
+            response_queue: VecDeque::new(),
+            response_buffer: None,
+            files: Vec::new(),
+            payload_max_size: MAX_PAYLOAD_SIZE,
+        }
+    }
+
+    /// This function sets the limit for PUT/PATCH requests. It overwrites the
+    /// default limit of 0.05MiB with the one allowed by server.
+    pub fn set_payload_max_size(&mut self, request_payload_max_size: usize) {
+        self.payload_max_size = request_payload_max_size;
+    }
+
+    /// Tries to read new bytes from the stream and automatically update the request.
+    /// Meant to be used only with non-blocking streams and an `EPOLL` structure.
+    /// Should be called whenever an `EPOLLIN` event is signaled.
+    ///
+    /// # Errors
+    /// `StreamError` is returned when an IO operation fails.
+    /// `ConnectionClosed` is returned when a client prematurely closes the connection.
+    /// `ParseError` is returned when a parsing operation fails.
+    pub fn try_read(&mut self) -> Result<(), ConnectionError> {
+        // Read some bytes from the stream, which will be appended to what is already
+        // present in the buffer from a previous call of `try_read`. There are already
+        // `read_cursor` bytes present in the buffer.
+        let end_cursor = self.read_bytes()?;
+
+        let mut line_start_index = 0;
+        loop {
+            match self.state {
+                ConnectionState::WaitingForRequestLine => {
+                    if !self.parse_request_line(&mut line_start_index, end_cursor)? {
+                        return Ok(());
+                    }
+                }
+                ConnectionState::WaitingForHeaders => {
+                    if !self.parse_headers(&mut line_start_index, end_cursor)? {
+                        return Ok(());
+                    }
+                }
+                ConnectionState::WaitingForBody => {
+                    if !self.parse_body(&mut line_start_index, end_cursor)? {
+                        return Ok(());
+                    }
+                }
+                ConnectionState::RequestReady => {
+                    // This request is ready to be passed for handling.
+                    // Update the state machine to expect a new request and push this request into
+                    // the `parsed_requests` queue.
+                    self.state = ConnectionState::WaitingForRequestLine;
+                    self.body_bytes_to_be_read = 0;
+                    let mut pending_request = self.pending_request.take().unwrap();
+                    pending_request.files = self.files.drain(..).collect();
+                    self.parsed_requests.push_back(pending_request);
+                }
+            };
+        }
+    }
+
+    /// Reads a maximum of 1024 bytes from the stream into `buffer`.
+    /// The return value represents the end index of what we have just appended.
+    ///
+    /// # Errors
+    /// `StreamError` is returned if any error occurred while reading the stream.
+    /// `ConnectionClosed` is returned if the client closed the connection.
+    /// `Overflow` is returned if an arithmetic overflow occurs while parsing the request.
+    fn read_bytes(&mut self) -> Result<usize, ConnectionError> {
+        if self.read_cursor >= BUFFER_SIZE {
+            return Err(ConnectionError::ParseError(RequestError::Overflow));
+        }
+        // Append new bytes to what we already have in the buffer.
+        // The slice access is safe, the index is checked above.
+        let (bytes_read, new_files) = self.recv_with_fds()?;
+
+        // Update the internal list of files that must be associated with the
+        // request.
+        self.files.extend(new_files);
+
+        // If the read returned 0 then the client has closed the connection.
+        if bytes_read == 0 {
+            return Err(ConnectionError::ConnectionClosed);
+        }
+        bytes_read
+            .checked_add(self.read_cursor)
+            .ok_or(ConnectionError::ParseError(RequestError::Overflow))
+    }
+
+    /// Receive data along with optional files descriptors.
+    /// It is a wrapper around the same function from vmm-sys-util.
+    ///
+    /// # Errors
+    /// `StreamError` is returned if any error occurred while reading the stream.
+    fn recv_with_fds(&mut self) -> Result<(usize, Vec<File>), ConnectionError> {
+        let buf = &mut self.buffer[self.read_cursor..];
+        // We must allocate the maximum number of receivable file descriptors
+        // if don't want to miss any of them. Allocating a too small number
+        // would lead to the incapacity of receiving the file descriptors.
+        let mut fds = [0; SCM_MAX_FD];
+        let mut iovecs = [libc::iovec {
+            iov_base: buf.as_mut_ptr() as *mut libc::c_void,
+            iov_len: buf.len(),
+        }];
+
+        // Safe because we have mutably borrowed buf and it's safe to write
+        // arbitrary data to a slice.
+        let (read_count, fd_count) = unsafe {
+            self.stream
+                .recv_with_fds(&mut iovecs, &mut fds)
+                .map_err(ConnectionError::StreamReadError)?
+        };
+
+        Ok((
+            read_count,
+            fds.iter()
+                .take(fd_count)
+                .map(|fd| {
+                    // Safe because all fds are owned by us after they have been
+                    // received through the socket.
+                    unsafe { File::from_raw_fd(*fd) }
+                })
+                .collect(),
+        ))
+    }
+
+    /// Parses bytes in `buffer` for a valid request line.
+    /// Returns `false` if there are no more bytes to be parsed in the buffer.
+    ///
+    /// # Errors
+    /// `ParseError` is returned if unable to parse request line or line longer than BUFFER_SIZE.
+    fn parse_request_line(
+        &mut self,
+        start: &mut usize,
+        end: usize,
+    ) -> Result<bool, ConnectionError> {
+        if end < *start {
+            return Err(ConnectionError::ParseError(RequestError::Underflow));
+        }
+        if end > self.buffer.len() {
+            return Err(ConnectionError::ParseError(RequestError::Overflow));
+        }
+        // The slice access is safe because `end` is checked to be smaller than the buffer size
+        // and larger than `start`.
+        match find(&self.buffer[*start..end], &[CR, LF]) {
+            Some(line_end_index) => {
+                // The unchecked addition `start + line_end_index` is safe because `line_end_index`
+                // is returned by `find` and thus guaranteed to be in-bounds. This also makes the
+                // slice access safe.
+                let line = &self.buffer[*start..(*start + line_end_index)];
+
+                // The unchecked addition is safe because of the previous `find()`.
+                *start = *start + line_end_index + CRLF_LEN;
+
+                // Form the request with a valid request line, which is the bare minimum
+                // for a valid request.
+                self.pending_request = Some(Request {
+                    request_line: RequestLine::try_from(line)
+                        .map_err(ConnectionError::ParseError)?,
+                    headers: Headers::default(),
+                    body: None,
+                    files: Vec::new(),
+                });
+                self.state = ConnectionState::WaitingForHeaders;
+                Ok(true)
+            }
+            None => {
+                // The request line is longer than BUFFER_SIZE bytes, so the request is invalid.
+                if end == BUFFER_SIZE && *start == 0 {
+                    return Err(ConnectionError::ParseError(RequestError::InvalidRequest));
+                } else {
+                    // Move the incomplete request line to the beginning of the buffer and wait
+                    // for the next `try_read` call to complete it.
+                    // This can only happen if another request was sent before this one, as the
+                    // limit for the length of a request line in this implementation is 1024 bytes.
+                    self.shift_buffer_left(*start, end)
+                        .map_err(ConnectionError::ParseError)?;
+                }
+                Ok(false)
+            }
+        }
+    }
+
+    /// Parses bytes in `buffer` for header fields.
+    /// Returns `false` if there are no more bytes to be parsed in the buffer.
+    ///
+    /// # Errors
+    /// `ParseError` is returned if unable to parse header or line longer than BUFFER_SIZE.
+    fn parse_headers(
+        &mut self,
+        line_start_index: &mut usize,
+        end_cursor: usize,
+    ) -> Result<bool, ConnectionError> {
+        if end_cursor > self.buffer.len() {
+            return Err(ConnectionError::ParseError(RequestError::Overflow));
+        }
+        if end_cursor < *line_start_index {
+            return Err(ConnectionError::ParseError(RequestError::Underflow));
+        }
+        // Safe to access the slice as the bounds are checked above.
+        match find(&self.buffer[*line_start_index..end_cursor], &[CR, LF]) {
+            // `line_start_index` points to the end of the most recently found CR LF
+            // sequence. That means that if we found the next CR LF sequence at this index,
+            // they are, in fact, a CR LF CR LF sequence, which marks the end of the header
+            // fields, per HTTP specification.
+
+            // We have found the end of the header.
+            Some(0) => {
+                // The current state is `WaitingForHeaders`, ensuring a valid request formed from a
+                // request line.
+                let request = self
+                    .pending_request
+                    .as_mut()
+                    .ok_or(ConnectionError::ParseError(
+                        RequestError::HeadersWithoutPendingRequest,
+                    ))?;
+                if request.headers.content_length() == 0 {
+                    self.state = ConnectionState::RequestReady;
+                } else {
+                    if request.headers.content_length() as usize > self.payload_max_size {
+                        return Err(ConnectionError::ParseError(
+                            RequestError::SizeLimitExceeded(
+                                self.payload_max_size,
+                                request.headers.content_length() as usize,
+                            ),
+                        ));
+                    }
+                    if request.headers.expect() {
+                        // Send expect.
+                        let expect_response =
+                            Response::new(request.http_version(), StatusCode::Continue);
+                        self.response_queue.push_back(expect_response);
+                    }
+
+                    self.body_bytes_to_be_read = request.headers.content_length();
+                    request.body = Some(Body::new(vec![]));
+                    self.state = ConnectionState::WaitingForBody;
+                }
+
+                // Update the index for the next header.
+                *line_start_index = line_start_index
+                    .checked_add(CRLF_LEN)
+                    .ok_or(ConnectionError::ParseError(RequestError::Overflow))?;
+                Ok(true)
+            }
+            // We have found the end of a header line.
+            Some(relative_line_end_index) => {
+                let request = self
+                    .pending_request
+                    .as_mut()
+                    .ok_or(ConnectionError::ParseError(
+                        RequestError::HeadersWithoutPendingRequest,
+                    ))?;
+                // The `line_end_index` relative to the whole buffer.
+                let line_end_index = relative_line_end_index
+                    .checked_add(*line_start_index)
+                    .ok_or(ConnectionError::ParseError(RequestError::Overflow))?;
+
+                // Get the line slice and parse it.
+                // The slice access is safe because `line_end_index` is a sum of `line_end_index`
+                // and something else, and `line_end_index` itself is guaranteed to be within
+                // `self.buffer`'s bounds by the `find()`.
+                let line = &self.buffer[*line_start_index..line_end_index];
+                match request.headers.parse_header_line(line) {
+                    // If a header is unsupported we ignore it.
+                    Ok(_)
+                    | Err(RequestError::HeaderError(HttpHeaderError::UnsupportedValue(_, _))) => {}
+                    // If parsing the header invalidates the request, we propagate
+                    // the error.
+                    Err(e) => return Err(ConnectionError::ParseError(e)),
+                };
+
+                // Update the `line_start_index` to where we finished parsing.
+                *line_start_index = line_end_index
+                    .checked_add(CRLF_LEN)
+                    .ok_or(ConnectionError::ParseError(RequestError::Overflow))?;
+                Ok(true)
+            }
+            // If we have an incomplete header line.
+            None => {
+                // If we have parsed BUFFER_SIZE bytes and still haven't found the header
+                // line end sequence.
+                if *line_start_index == 0 && end_cursor == BUFFER_SIZE {
+                    // Header line is longer than BUFFER_SIZE bytes, so it is invalid.
+                    let utf8_string = String::from_utf8_lossy(&self.buffer);
+                    return Err(ConnectionError::ParseError(RequestError::HeaderError(
+                        HttpHeaderError::SizeLimitExceeded(utf8_string.to_string()),
+                    )));
+                }
+                // Move the incomplete header line from the end of the buffer to
+                // the beginning, so that we can append the rest of the line and
+                // parse it in the next `try_read` call.
+                self.shift_buffer_left(*line_start_index, end_cursor)
+                    .map_err(ConnectionError::ParseError)?;
+                Ok(false)
+            }
+        }
+    }
+
+    /// Parses bytes in `buffer` to be put into the request body, if there should be one.
+    /// Returns `false` if there are no more bytes to be parsed in the buffer.
+    ///
+    /// # Errors
+    /// `ParseError` is returned when the body is larger than the specified content-length.
+    fn parse_body(
+        &mut self,
+        line_start_index: &mut usize,
+        end_cursor: usize,
+    ) -> Result<bool, ConnectionError> {
+        // If what we have just read is not enough to complete the request and
+        // there are more bytes pertaining to the body of the request.
+        if end_cursor > self.buffer.len() {
+            return Err(ConnectionError::ParseError(RequestError::Overflow));
+        }
+        let start_to_end = end_cursor
+            .checked_sub(*line_start_index)
+            .ok_or(ConnectionError::ParseError(RequestError::Underflow))?
+            as u32;
+        if self.body_bytes_to_be_read > start_to_end {
+            // Append everything that we read to our current incomplete body and update
+            // `body_bytes_to_be_read`.
+            // The slice access is safe, otherwise `checked_sub` would have failed.
+            self.body_vec
+                .extend_from_slice(&self.buffer[*line_start_index..end_cursor]);
+            // Safe to subtract directly as the `if` condition prevents underflow.
+            self.body_bytes_to_be_read -= start_to_end;
+
+            // Clear the buffer and reset the starting index.
+            for i in 0..BUFFER_SIZE {
+                self.buffer[i] = 0;
+            }
+            self.read_cursor = 0;
+
+            return Ok(false);
+        }
+
+        // Append only the remaining necessary bytes to the body of the request.
+        let line_end = line_start_index
+            .checked_add(self.body_bytes_to_be_read as usize)
+            .ok_or(ConnectionError::ParseError(RequestError::Overflow))?;
+        // The slice access is safe as `line_end` is a sum of `line_start_index` + something else.
+        self.body_vec
+            .extend_from_slice(&self.buffer[*line_start_index..line_end]);
+        *line_start_index = line_end;
+        self.body_bytes_to_be_read = 0;
+
+        let request = self
+            .pending_request
+            .as_mut()
+            .ok_or(ConnectionError::ParseError(
+                RequestError::BodyWithoutPendingRequest,
+            ))?;
+        // If there are no more bytes to be read for this request.
+        // Assign the body of the request.
+        let placeholder: Vec<_> = self
+            .body_vec
+            .drain(..request.headers.content_length() as usize)
+            .collect();
+        request.body = Some(Body::new(placeholder));
+
+        // If we read more bytes than we should have into the body of the request.
+        if !self.body_vec.is_empty() {
+            return Err(ConnectionError::ParseError(RequestError::InvalidRequest));
+        }
+
+        self.state = ConnectionState::RequestReady;
+        Ok(true)
+    }
+
+    /// Tries to write the first available response to the provided stream.
+    /// Meant to be used only with non-blocking streams and an `EPOLL` structure.
+    /// Should be called whenever an `EPOLLOUT` event is signaled. If no bytes
+    /// were written to the stream or error occurred while trying to write to stream,
+    /// we will discard all responses from response_queue because there is no way
+    /// to deliver it to client.
+    ///
+    /// # Errors
+    /// `StreamError` is returned when an IO operation fails.
+    /// `ConnectionClosed` is returned when trying to write on a closed connection.
+    /// `InvalidWrite` is returned when trying to write on a connection with an
+    /// empty outgoing buffer.
+    pub fn try_write(&mut self) -> Result<(), ConnectionError> {
+        if self.response_buffer.is_none() {
+            if let Some(response) = self.response_queue.pop_front() {
+                let mut response_buffer_vec: Vec<u8> = Vec::new();
+                response
+                    .write_all(&mut response_buffer_vec)
+                    .map_err(ConnectionError::StreamWriteError)?;
+                self.response_buffer = Some(response_buffer_vec);
+            } else {
+                return Err(ConnectionError::InvalidWrite);
+            }
+        }
+
+        let mut response_fully_written = false;
+        let mut connection_closed = false;
+
+        if let Some(response_buffer_vec) = self.response_buffer.as_mut() {
+            let bytes_to_be_written = response_buffer_vec.len();
+            match self.stream.write(response_buffer_vec.as_slice()) {
+                Ok(0) => connection_closed = true,
+                Ok(bytes_written) => {
+                    if bytes_written != bytes_to_be_written {
+                        response_buffer_vec.drain(..bytes_written);
+                    } else {
+                        response_fully_written = true;
+                    }
+                }
+                Err(e) if e.kind() == std::io::ErrorKind::Interrupted => {}
+                Err(_) => connection_closed = true,
+            }
+        }
+
+        if connection_closed {
+            self.clear_write_buffer();
+            return Err(ConnectionError::ConnectionClosed);
+        } else if response_fully_written {
+            self.response_buffer.take();
+        }
+
+        Ok(())
+    }
+
+    /// Discards all pending writes from the connection.
+    pub fn clear_write_buffer(&mut self) {
+        self.response_queue.clear();
+        self.response_buffer.take();
+    }
+
+    /// Send a response back to the source of a request.
+    pub fn enqueue_response(&mut self, response: Response) {
+        self.response_queue.push_back(response);
+    }
+
+    fn shift_buffer_left(
+        &mut self,
+        line_start_index: usize,
+        end_cursor: usize,
+    ) -> Result<(), RequestError> {
+        if end_cursor > self.buffer.len() {
+            return Err(RequestError::Overflow);
+        }
+        // We don't want to shift something that is already at the beginning.
+        let delta_bytes = end_cursor
+            .checked_sub(line_start_index)
+            .ok_or(RequestError::Underflow)?;
+        if line_start_index != 0 {
+            // Move the bytes from `line_start_index` to the beginning of the buffer.
+            for cursor in 0..delta_bytes {
+                // The unchecked addition is safe, guaranteed by the result of the substraction
+                // above.
+                // The slice access is safe, as `line_start_index + cursor` is <= `end_cursor`,
+                // checked at the start of the function.
+                self.buffer[cursor] = self.buffer[line_start_index + cursor];
+            }
+
+            // Clear the rest of the buffer.
+            for cursor in delta_bytes..end_cursor {
+                self.buffer[cursor] = 0;
+            }
+        }
+
+        // Update `read_cursor`.
+        self.read_cursor = delta_bytes;
+        Ok(())
+    }
+
+    /// Returns the first parsed request in the queue or `None` if the queue
+    /// is empty.
+    pub fn pop_parsed_request(&mut self) -> Option<Request> {
+        self.parsed_requests.pop_front()
+    }
+
+    /// Returns `true` if there are bytes waiting to be written into the stream.
+    pub fn pending_write(&self) -> bool {
+        self.response_buffer.is_some() || !self.response_queue.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::{Seek, SeekFrom};
+    use std::net::Shutdown;
+    use std::os::unix::io::IntoRawFd;
+    use std::os::unix::net::UnixStream;
+
+    use super::*;
+    use crate::common::{Method, Version};
+    use crate::server::MAX_PAYLOAD_SIZE;
+
+    use vmm_sys_util::tempfile::TempFile;
+
+    #[test]
+    fn test_try_read_expect() {
+        // Test request with `Expect` header.
+        let (mut sender, receiver) = UnixStream::pair().unwrap();
+        receiver.set_nonblocking(true).expect("Can't modify socket");
+        let mut conn = HttpConnection::new(receiver);
+        sender
+            .write_all(
+                b"PATCH http://localhost/home HTTP/1.1\r\n\
+                                 Expect: 100-continue\r\n\
+                                 Content-Length: 26\r\n\
+                                 Transfer-Encoding: chunked\r\n\r\n",
+            )
+            .unwrap();
+        assert!(conn.try_read().is_ok());
+
+        sender.write_all(b"this is not\n\r\na json \nbody").unwrap();
+        conn.try_read().unwrap();
+        let request = conn.pop_parsed_request().unwrap();
+
+        let expected_request = Request {
+            request_line: RequestLine::new(Method::Patch, "http://localhost/home", Version::Http11),
+            headers: Headers::new(26, true, true),
+            body: Some(Body::new(b"this is not\n\r\na json \nbody".to_vec())),
+            files: Vec::new(),
+        };
+
+        assert_eq!(request, expected_request);
+    }
+
+    #[test]
+    fn test_try_read_long_headers() {
+        // Long request headers.
+        let (mut sender, receiver) = UnixStream::pair().unwrap();
+        receiver.set_nonblocking(true).expect("Can't modify socket");
+        let mut conn = HttpConnection::new(receiver);
+        sender
+            .write_all(
+                b"PATCH http://localhost/home HTTP/1.1\r\n\
+                                 Expect: 100-continue\r\n\
+                                 Transfer-Encoding: chunked\r\n",
+            )
+            .unwrap();
+
+        for i in 0..90 {
+            sender.write_all(b"Custom-Header-Testing: 1").unwrap();
+            sender.write_all(i.to_string().as_bytes()).unwrap();
+            sender.write_all(b"\r\n").unwrap();
+        }
+        sender
+            .write_all(b"Content-Length: 26\r\n\r\nthis is not\n\r\na json \nbody")
+            .unwrap();
+        assert!(conn.try_read().is_ok());
+        assert!(conn.try_read().is_ok());
+        assert!(conn.try_read().is_ok());
+        let request = conn.pop_parsed_request().unwrap();
+
+        let expected_request = Request {
+            request_line: RequestLine::new(Method::Patch, "http://localhost/home", Version::Http11),
+            headers: Headers::new(26, true, true),
+            body: Some(Body::new(b"this is not\n\r\na json \nbody".to_vec())),
+            files: Vec::new(),
+        };
+        assert_eq!(request, expected_request);
+    }
+
+    #[test]
+    fn test_try_read_split_ending() {
+        // Long request with '\r\n' on BUFFER_SIZEth and 1025th positions in the request.
+        let (mut sender, receiver) = UnixStream::pair().unwrap();
+        receiver.set_nonblocking(true).expect("Can't modify socket");
+        let mut conn = HttpConnection::new(receiver);
+        sender
+            .write_all(
+                b"PATCH http://localhost/home HTTP/1.1\r\n\
+                                 Expect: 100-continue\r\n\
+                                 Transfer-Encoding: chunked\r\n",
+            )
+            .unwrap();
+
+        for i in 0..32 {
+            sender.write_all(b"Custom-Header-Testing: 1").unwrap();
+            sender.write_all(i.to_string().as_bytes()).unwrap();
+            sender.write_all(b"\r\n").unwrap();
+        }
+        sender
+            .write_all(b"Head: aaaaa\r\nContent-Length: 26\r\n\r\nthis is not\n\r\na json \nbody")
+            .unwrap();
+        assert!(conn.try_read().is_ok());
+        conn.try_read().unwrap();
+        let request = conn.pop_parsed_request().unwrap();
+        let expected_request = Request {
+            request_line: RequestLine::new(Method::Patch, "http://localhost/home", Version::Http11),
+            headers: Headers::new(26, true, true),
+            body: Some(Body::new(b"this is not\n\r\na json \nbody".to_vec())),
+            files: Vec::new(),
+        };
+        assert_eq!(request, expected_request);
+    }
+
+    #[test]
+    fn test_try_read_invalid_request() {
+        // Invalid request.
+        let (mut sender, receiver) = UnixStream::pair().unwrap();
+        receiver.set_nonblocking(true).expect("Can't modify socket");
+        let mut conn = HttpConnection::new(receiver);
+        sender
+            .write_all(
+                b"PATCH http://localhost/home HTTP/1.1\r\n\
+                                 Expect: 100-continue\r\n\
+                                 Transfer-Encoding: chunked\r\n",
+            )
+            .unwrap();
+
+        for i in 0..40 {
+            sender.write_all(b"Custom-Header-Testing: 1").unwrap();
+            sender.write_all(i.to_string().as_bytes()).unwrap();
+            sender.write_all(b"\r\n").unwrap();
+        }
+        sender
+            .write_all(b"Content-Length: alpha\r\n\r\nthis is not\n\r\na json \nbody")
+            .unwrap();
+        assert!(conn.try_read().is_ok());
+        let request_error = conn.try_read().unwrap_err();
+        assert_eq!(
+            request_error,
+            ConnectionError::ParseError(RequestError::HeaderError(HttpHeaderError::InvalidValue(
+                "Content-Length".to_string(),
+                " alpha".to_string()
+            )))
+        );
+    }
+
+    #[test]
+    fn test_try_read_long_request_body() {
+        // Long request body.
+        let (mut sender, receiver) = UnixStream::pair().unwrap();
+        receiver.set_nonblocking(true).expect("Can't modify socket");
+        let mut conn = HttpConnection::new(receiver);
+        sender
+            .write_all(
+                b"PATCH http://localhost/home HTTP/1.1\r\n\
+                                 Expect: 100-continue\r\n\
+                                 Transfer-Encoding: chunked\r\n\
+                                 Content-Length: 1400\r\n\r\n",
+            )
+            .unwrap();
+
+        let mut request_body: Vec<u8> = Vec::with_capacity(1400);
+        for _ in 0..100 {
+            request_body.write_all(b"This is a test").unwrap();
+        }
+        sender.write_all(request_body.as_slice()).unwrap();
+        assert!(conn.try_read().is_ok());
+        conn.try_read().unwrap();
+        let request = conn.pop_parsed_request().unwrap();
+        let expected_request = Request {
+            request_line: RequestLine::new(Method::Patch, "http://localhost/home", Version::Http11),
+            headers: Headers::new(1400, true, true),
+            body: Some(Body::new(request_body)),
+            files: Vec::new(),
+        };
+
+        assert_eq!(request, expected_request);
+    }
+
+    #[test]
+    fn test_try_read_large_req_line() {
+        // Request line longer than BUFFER_SIZE bytes.
+        let (mut sender, receiver) = UnixStream::pair().unwrap();
+        receiver.set_nonblocking(true).expect("Can't modify socket");
+        let mut conn = HttpConnection::new(receiver);
+        sender.write_all(b"PATCH http://localhost/home").unwrap();
+
+        let mut request_body: Vec<u8> = Vec::with_capacity(1400);
+        for _ in 0..200 {
+            request_body.write_all(b"/home").unwrap();
+        }
+        sender.write_all(request_body.as_slice()).unwrap();
+        assert_eq!(
+            conn.try_read().unwrap_err(),
+            ConnectionError::ParseError(RequestError::InvalidRequest)
+        );
+    }
+
+    #[test]
+    fn test_try_read_large_header_line() {
+        // Header line longer than BUFFER_SIZE bytes.
+        let (mut sender, receiver) = UnixStream::pair().unwrap();
+        receiver.set_nonblocking(true).expect("Can't modify socket");
+        let mut conn = HttpConnection::new(receiver);
+        sender
+            .write_all(b"PATCH http://localhost/home HTTP/1.1\r\nhead: ")
+            .unwrap();
+
+        let mut request_body: Vec<u8> = Vec::with_capacity(1030);
+        for _ in 0..86 {
+            request_body.write_all(b"abcdefghijkl").unwrap();
+        }
+        request_body.write_all(b"\r\n\r\n").unwrap();
+        sender.write_all(request_body.as_slice()).unwrap();
+        assert!(conn.try_read().is_ok());
+
+        let expected_msg = &format!("head: {}", String::from_utf8(request_body).unwrap())[..1024];
+        assert_eq!(
+            conn.try_read().unwrap_err(),
+            ConnectionError::ParseError(RequestError::HeaderError(
+                HttpHeaderError::SizeLimitExceeded(expected_msg.to_string())
+            ))
+        );
+    }
+
+    #[test]
+    fn test_try_read_no_body_request() {
+        // Request without body.
+        let (mut sender, receiver) = UnixStream::pair().unwrap();
+        receiver.set_nonblocking(true).expect("Can't modify socket");
+        let mut conn = HttpConnection::new(receiver);
+        sender
+            .write_all(
+                b"PATCH http://localhost/home HTTP/1.1\r\n\
+                                 Expect: 100-continue\r\n\
+                                 Transfer-Encoding: chunked\r\n\r\n",
+            )
+            .unwrap();
+        conn.try_read().unwrap();
+        let request = conn.pop_parsed_request().unwrap();
+        let expected_request = Request {
+            request_line: RequestLine::new(Method::Patch, "http://localhost/home", Version::Http11),
+            headers: Headers::new(0, true, true),
+            body: None,
+            files: Vec::new(),
+        };
+        assert_eq!(request, expected_request);
+    }
+
+    #[test]
+    fn test_try_read_segmented_req_line() {
+        // Segmented request line.
+        let (mut sender, receiver) = UnixStream::pair().unwrap();
+        receiver.set_nonblocking(true).expect("Can't modify socket");
+        let mut conn = HttpConnection::new(receiver);
+        sender.write_all(b"PATCH http://local").unwrap();
+        assert!(conn.try_read().is_ok());
+
+        sender.write_all(b"host/home HTTP/1.1\r\n\r\n").unwrap();
+
+        conn.try_read().unwrap();
+        let request = conn.pop_parsed_request().unwrap();
+        let expected_request = Request {
+            request_line: RequestLine::new(Method::Patch, "http://localhost/home", Version::Http11),
+            headers: Headers::new(0, false, false),
+            body: None,
+            files: Vec::new(),
+        };
+        assert_eq!(request, expected_request);
+    }
+
+    #[test]
+    fn test_try_read_long_req_line_b2b() {
+        // Long request line after another request.
+        let (mut sender, receiver) = UnixStream::pair().unwrap();
+        receiver.set_nonblocking(true).expect("Can't modify socket");
+        let mut conn = HttpConnection::new(receiver);
+        // Req line 23 + 10*x + 13 = 36 + 10* x    984 free in first try read
+        sender
+            .write_all(b"PATCH http://localhost/home HTTP/1.1\r\n\r\nPATCH http://localhost/")
+            .unwrap();
+
+        let mut request_line: Vec<u8> = Vec::with_capacity(980);
+        for _ in 0..98 {
+            request_line.write_all(b"localhost/").unwrap();
+        }
+        request_line.write_all(b" HTTP/1.1\r\n\r\n").unwrap();
+        sender.write_all(request_line.as_slice()).unwrap();
+
+        conn.try_read().unwrap();
+        let request = conn.pop_parsed_request().unwrap();
+        let expected_request = Request {
+            request_line: RequestLine::new(Method::Patch, "http://localhost/home", Version::Http11),
+            headers: Headers::new(0, false, false),
+            body: None,
+            files: Vec::new(),
+        };
+        assert_eq!(request, expected_request);
+
+        conn.try_read().unwrap();
+        let request = conn.pop_parsed_request().unwrap();
+        let mut expected_request_as_bytes = Vec::new();
+        expected_request_as_bytes
+            .write_all(b"http://localhost/")
+            .unwrap();
+        expected_request_as_bytes.append(request_line.as_mut());
+        let expected_request = Request {
+            request_line: RequestLine::new(
+                Method::Patch,
+                std::str::from_utf8(&expected_request_as_bytes[..997]).unwrap(),
+                Version::Http11,
+            ),
+            headers: Headers::new(0, false, false),
+            body: None,
+            files: Vec::new(),
+        };
+        assert_eq!(request, expected_request);
+    }
+
+    #[test]
+    fn test_try_read_double_request() {
+        // Double request in a single read.
+        let (mut sender, receiver) = UnixStream::pair().unwrap();
+        receiver.set_nonblocking(true).expect("Can't modify socket");
+        let mut conn = HttpConnection::new(receiver);
+        sender
+            .write_all(
+                b"PATCH http://localhost/home HTTP/1.1\r\n\
+                                 Transfer-Encoding: chunked\r\n\
+                                 Content-Length: 26\r\n\r\nthis is not\n\r\na json \nbody",
+            )
+            .unwrap();
+        sender
+            .write_all(
+                b"PUT http://farhost/away HTTP/1.1\r\nContent-Length: 23\r\n\r\nthis is another request",
+            )
+            .unwrap();
+
+        let expected_request_first = Request {
+            request_line: RequestLine::new(Method::Patch, "http://localhost/home", Version::Http11),
+            headers: Headers::new(26, false, true),
+            body: Some(Body::new(b"this is not\n\r\na json \nbody".to_vec())),
+            files: Vec::new(),
+        };
+
+        conn.try_read().unwrap();
+        let request_first = conn.pop_parsed_request().unwrap();
+        let request_second = conn.pop_parsed_request().unwrap();
+
+        let expected_request_second = Request {
+            request_line: RequestLine::new(Method::Put, "http://farhost/away", Version::Http11),
+            headers: Headers::new(23, false, false),
+            body: Some(Body::new(b"this is another request".to_vec())),
+            files: Vec::new(),
+        };
+        assert_eq!(request_first, expected_request_first);
+        assert_eq!(request_second, expected_request_second);
+    }
+
+    #[test]
+    fn test_try_read_connection_closed() {
+        // Connection abruptly closed.
+        let (mut sender, receiver) = UnixStream::pair().unwrap();
+        receiver.set_nonblocking(true).expect("Can't modify socket");
+        let mut conn = HttpConnection::new(receiver);
+        sender
+            .write_all(
+                b"PATCH http://localhost/home HTTP/1.1\r\n\
+                                 Transfer-Encoding: chunked\r\n\
+                                 Content-Len",
+            )
+            .unwrap();
+
+        conn.try_read().unwrap();
+        sender.shutdown(std::net::Shutdown::Both).unwrap();
+
+        assert_eq!(
+            conn.try_read().unwrap_err(),
+            ConnectionError::ConnectionClosed
+        );
+    }
+
+    #[test]
+    fn test_enqueue_response() {
+        // Response without body.
+        let (sender, mut receiver) = UnixStream::pair().unwrap();
+        receiver.set_nonblocking(true).expect("Can't modify socket");
+        let mut conn = HttpConnection::new(sender);
+
+        let response = Response::new(Version::Http11, StatusCode::OK);
+        let mut expected_response: Vec<u8> = vec![];
+        response.write_all(&mut expected_response).unwrap();
+
+        conn.enqueue_response(response);
+        assert!(conn.try_write().is_ok());
+
+        let mut response_buffer = vec![0u8; expected_response.len()];
+        receiver.read_exact(&mut response_buffer).unwrap();
+        assert_eq!(response_buffer, expected_response);
+
+        // Response with body.
+        let (sender, mut receiver) = UnixStream::pair().unwrap();
+        receiver.set_nonblocking(true).expect("Can't modify socket");
+        let mut conn = HttpConnection::new(sender);
+        let mut response = Response::new(Version::Http11, StatusCode::OK);
+        let mut body: Vec<u8> = vec![];
+        body.write_all(br#"{ "json": "body", "hello": "world" }"#)
+            .unwrap();
+        response.set_body(Body::new(body));
+        let mut expected_response: Vec<u8> = vec![];
+        response.write_all(&mut expected_response).unwrap();
+
+        conn.enqueue_response(response);
+        assert!(conn.try_write().is_ok());
+
+        let mut response_buffer = vec![0u8; expected_response.len()];
+        receiver.read_exact(&mut response_buffer).unwrap();
+        assert_eq!(response_buffer, expected_response);
+    }
+
+    #[test]
+    fn test_try_read_negative_content_len() {
+        // Request with negative `Content-Length` header.
+        let (mut sender, receiver) = UnixStream::pair().unwrap();
+        receiver.set_nonblocking(true).expect("Can't modify socket");
+        let mut conn = HttpConnection::new(receiver);
+        sender
+            .write_all(
+                b"PUT http://localhost/home HTTP/1.1\r\n\
+                                 Content-Length: -1\r\n\r\n",
+            )
+            .unwrap();
+        assert_eq!(
+            conn.try_read().unwrap_err(),
+            ConnectionError::ParseError(RequestError::HeaderError(HttpHeaderError::InvalidValue(
+                "Content-Length".to_string(),
+                " -1".to_string()
+            )))
+        );
+    }
+
+    #[test]
+    fn test_payload_size_limit() {
+        let (mut sender, receiver) = UnixStream::pair().unwrap();
+        receiver.set_nonblocking(true).expect("Can't modify socket");
+        let mut conn = HttpConnection::new(receiver);
+        conn.set_payload_max_size(5);
+        sender
+            .write_all(
+                b"PUT http://localhost/home HTTP/1.1\r\n\
+                                 Content-Length: 51200\r\n\r\naaaaaa",
+            )
+            .unwrap();
+        assert_eq!(
+            conn.try_read().unwrap_err(),
+            ConnectionError::ParseError(RequestError::SizeLimitExceeded(5, MAX_PAYLOAD_SIZE))
+        );
+    }
+
+    #[test]
+    fn test_read_bytes() {
+        let (mut sender, receiver) = UnixStream::pair().unwrap();
+        receiver.set_nonblocking(true).expect("Can't modify socket");
+        let mut conn = HttpConnection::new(receiver);
+
+        // Cursor positioned at buffer end. Read should fail.
+        conn.read_cursor = BUFFER_SIZE;
+        sender.write_all(b"hello\0").unwrap();
+        assert_eq!(
+            conn.read_bytes().unwrap_err(),
+            ConnectionError::ParseError(RequestError::Overflow)
+        );
+
+        // Cursor positioned before buffer end. Partial read should succeed.
+        conn.read_cursor = BUFFER_SIZE - 3;
+        sender.write_all(b"hello\0").unwrap();
+        assert_eq!(conn.read_bytes(), Ok(BUFFER_SIZE));
+
+        // Read the remaining 9 bytes - 3 left from the first "hello" and the 2nd full "hello".
+        conn.read_cursor = 0;
+        assert_eq!(conn.read_bytes(), Ok(9));
+        sender.shutdown(Shutdown::Write).unwrap();
+        assert_eq!(
+            conn.read_bytes().unwrap_err(),
+            ConnectionError::ConnectionClosed
+        );
+    }
+
+    #[test]
+    fn test_read_bytes_with_files() {
+        let (sender, receiver) = UnixStream::pair().unwrap();
+        receiver.set_nonblocking(true).expect("Can't modify socket");
+        let mut conn = HttpConnection::new(receiver);
+
+        // Create 3 files, edit the content and rewind back to the start.
+        let mut file1 = TempFile::new().unwrap().into_file();
+        let mut file2 = TempFile::new().unwrap().into_file();
+        let mut file3 = TempFile::new().unwrap().into_file();
+        file1.write_all(b"foo").unwrap();
+        file1.seek(SeekFrom::Start(0)).unwrap();
+        file2.write_all(b"bar").unwrap();
+        file2.seek(SeekFrom::Start(0)).unwrap();
+        file3.write_all(b"foobar").unwrap();
+        file3.seek(SeekFrom::Start(0)).unwrap();
+
+        // Send 2 file descriptors along with 3 bytes of data.
+        assert_eq!(
+            sender.send_with_fds(
+                &[[1, 2, 3].as_ref()],
+                &[file1.into_raw_fd(), file2.into_raw_fd()]
+            ),
+            Ok(3)
+        );
+
+        // Check we receive the right amount of data along with the right
+        // amount of file descriptors.
+        assert_eq!(conn.read_bytes(), Ok(3));
+        assert_eq!(conn.files.len(), 2);
+
+        // Check the content of the data received
+        assert_eq!(conn.buffer[0], 1);
+        assert_eq!(conn.buffer[1], 2);
+        assert_eq!(conn.buffer[2], 3);
+
+        // Check the file descriptors are usable by checking the content that
+        // can be read.
+        let mut buf = [0; 10];
+        assert_eq!(conn.files[0].read(&mut buf).unwrap(), 3);
+        assert_eq!(&buf[..3], b"foo");
+        assert_eq!(conn.files[1].read(&mut buf).unwrap(), 3);
+        assert_eq!(&buf[..3], b"bar");
+
+        // Send the 3rd file descriptor along with 1 byte of data.
+        assert_eq!(
+            sender.send_with_fds(&[[10].as_ref()], &[file3.into_raw_fd()]),
+            Ok(1)
+        );
+
+        // Check the amount of data along with the amount of file descriptors
+        // are updated.
+        assert_eq!(conn.read_bytes(), Ok(1));
+        assert_eq!(conn.files.len(), 3);
+
+        // Check the content of the new data received
+        assert_eq!(conn.buffer[0], 10);
+
+        // Check the latest file descriptor is usable by checking the content
+        // that can be read.
+        let mut buf = [0; 10];
+        assert_eq!(conn.files[2].read(&mut buf).unwrap(), 6);
+        assert_eq!(&buf[..6], b"foobar");
+
+        sender.shutdown(Shutdown::Write).unwrap();
+        assert_eq!(
+            conn.read_bytes().unwrap_err(),
+            ConnectionError::ConnectionClosed
+        );
+    }
+
+    #[test]
+    fn test_shift_buffer_left() {
+        let (_, receiver) = UnixStream::pair().unwrap();
+        let mut conn = HttpConnection::new(receiver);
+
+        assert_eq!(
+            conn.shift_buffer_left(0, conn.buffer.len() + 1)
+                .unwrap_err(),
+            RequestError::Overflow
+        );
+        assert_eq!(
+            conn.shift_buffer_left(1, 0).unwrap_err(),
+            RequestError::Underflow
+        );
+        assert!(conn.shift_buffer_left(1, conn.buffer.len()).is_ok());
+    }
+
+    #[test]
+    fn test_parse_request_line() {
+        let (_, receiver) = UnixStream::pair().unwrap();
+        let mut conn = HttpConnection::new(receiver);
+
+        // Error case: end past buffer end.
+        assert_eq!(
+            conn.parse_request_line(&mut 0, conn.buffer.len() + 1)
+                .unwrap_err(),
+            ConnectionError::ParseError(RequestError::Overflow)
+        );
+
+        // Error case: start is past end.
+        assert_eq!(
+            conn.parse_request_line(&mut 1, 0).unwrap_err(),
+            ConnectionError::ParseError(RequestError::Underflow)
+        );
+
+        // Error case: the request line is longer than BUFFER_SIZE.
+        assert_eq!(
+            conn.parse_request_line(&mut 0, BUFFER_SIZE).unwrap_err(),
+            ConnectionError::ParseError(RequestError::InvalidRequest)
+        );
+
+        // OK case.
+        assert_eq!(conn.parse_request_line(&mut 1, BUFFER_SIZE), Ok(false));
+
+        // Error case: invalid content.
+        conn.buffer[0..8].copy_from_slice(b"foo\r\nbar");
+        assert_eq!(
+            conn.parse_request_line(&mut 0, BUFFER_SIZE).unwrap_err(),
+            ConnectionError::ParseError(RequestError::InvalidRequest)
+        );
+
+        // OK case.
+        conn.buffer[0..29].copy_from_slice(b"GET http://foo/bar HTTP/1.1\r\n");
+        assert_eq!(conn.parse_request_line(&mut 0, BUFFER_SIZE), Ok(true));
+    }
+
+    #[test]
+    fn test_parse_headers() {
+        let (_, receiver) = UnixStream::pair().unwrap();
+        let mut conn = HttpConnection::new(receiver);
+
+        // Error case: end_cursor past buffer end.
+        assert_eq!(
+            conn.parse_headers(&mut 0, conn.buffer.len() + 1)
+                .unwrap_err(),
+            ConnectionError::ParseError(RequestError::Overflow)
+        );
+
+        // Error case: line_start_index is past end_cursor.
+        assert_eq!(
+            conn.parse_headers(&mut 1, 0).unwrap_err(),
+            ConnectionError::ParseError(RequestError::Underflow)
+        );
+
+        // Error case: no request pending.
+        // CRLF can be at the start of the buffer...
+        conn.buffer[0] = CR;
+        conn.buffer[1] = LF;
+        assert_eq!(
+            conn.parse_headers(&mut 0, BUFFER_SIZE).unwrap_err(),
+            ConnectionError::ParseError(RequestError::HeadersWithoutPendingRequest)
+        );
+        // ...or somewhere in the middle.
+        conn.buffer[0] = 0;
+        conn.buffer[1] = CR;
+        conn.buffer[2] = LF;
+        assert_eq!(
+            conn.parse_headers(&mut 0, BUFFER_SIZE).unwrap_err(),
+            ConnectionError::ParseError(RequestError::HeadersWithoutPendingRequest)
+        );
+
+        // Error case: invalid header.
+        conn.pending_request = Some(Request {
+            request_line: RequestLine::new(Method::Get, "http://foo/bar", Version::Http11),
+            headers: Headers::new(0, true, true),
+            body: None,
+            files: Vec::new(),
+        });
+        assert_eq!(
+            conn.parse_headers(&mut 0, BUFFER_SIZE).unwrap_err(),
+            ConnectionError::ParseError(RequestError::HeaderError(HttpHeaderError::InvalidFormat(
+                "\0".to_string()
+            )))
+        );
+
+        // OK case: incomplete header line.
+        let hdr = b"Custom-Header-Testing: 1";
+        conn.buffer[..hdr.len()].copy_from_slice(hdr);
+        assert_eq!(conn.parse_headers(&mut 0, hdr.len()), Ok(false));
+
+        // OK case: complete header line.
+        let hdr = b"Custom-Header-Testing: 1\r\n";
+        conn.buffer[..hdr.len()].copy_from_slice(hdr);
+        assert_eq!(conn.parse_headers(&mut 0, hdr.len()), Ok(true));
+
+        // OK case: complete header line, end of header.
+        let hdr = b"\r\n";
+        conn.buffer[..hdr.len()].copy_from_slice(hdr);
+        assert_eq!(conn.parse_headers(&mut 0, hdr.len()), Ok(true));
+    }
+
+    #[test]
+    fn test_parse_body() {
+        let (_, receiver) = UnixStream::pair().unwrap();
+        let mut conn = HttpConnection::new(receiver);
+
+        // Error case: end_cursor past buffer end.
+        assert_eq!(
+            conn.parse_body(&mut 0usize, conn.buffer.len() + 1)
+                .unwrap_err(),
+            ConnectionError::ParseError(RequestError::Overflow)
+        );
+
+        // Error case: line_start_index is past end_cursor.
+        assert_eq!(
+            conn.parse_body(&mut 1usize, 0usize).unwrap_err(),
+            ConnectionError::ParseError(RequestError::Underflow)
+        );
+
+        // OK case: consume the buffer.
+        conn.body_bytes_to_be_read = 1;
+        assert_eq!(conn.parse_body(&mut 0usize, 0usize), Ok(false));
+
+        // Error case: there's more body to be parsed, but no pending request set.
+        assert_eq!(
+            conn.parse_body(&mut 0, BUFFER_SIZE).unwrap_err(),
+            ConnectionError::ParseError(RequestError::BodyWithoutPendingRequest)
+        );
+
+        // Error case: read more bytes than we should have into the body of the request.
+        conn.pending_request = Some(Request {
+            request_line: RequestLine::new(Method::Get, "http://foo/bar", Version::Http11),
+            headers: Headers::new(0, true, true),
+            body: None,
+            files: Vec::new(),
+        });
+        conn.body_vec = vec![0xde, 0xad, 0xbe, 0xef];
+        assert_eq!(
+            conn.parse_body(&mut 0, BUFFER_SIZE).unwrap_err(),
+            ConnectionError::ParseError(RequestError::InvalidRequest)
+        );
+
+        // OK case.
+        conn.body_vec.clear();
+        assert_eq!(conn.parse_body(&mut 0, BUFFER_SIZE), Ok(true));
+    }
+}

--- a/crates/db-micro-http/src/lib.rs
+++ b/crates/db-micro-http/src/lib.rs
@@ -1,0 +1,125 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+#![deny(missing_docs)]
+//! Minimal implementation of the [HTTP/1.0](https://tools.ietf.org/html/rfc1945)
+//! and [HTTP/1.1](https://www.ietf.org/rfc/rfc2616.txt) protocols.
+//!
+//! HTTP/1.1 has a mandatory header **Host**, but as this crate is only used
+//! for parsing API requests, this header (if present) is ignored.
+//!
+//! This HTTP implementation is stateless thus it does not support chunking or
+//! compression.
+//!
+//! ## Supported Headers
+//! The **micro_http** crate has support for parsing the following **Request**
+//! headers:
+//! - Content-Length
+//! - Expect
+//! - Transfer-Encoding
+//!
+//! The **Response** does not have a public interface for adding headers, but whenever
+//! a write to the **Body** is made, the headers **ContentLength** and **MediaType**
+//! are automatically updated.
+//!
+//! ### Media Types
+//! The supported media types are:
+//! - text/plain
+//! - application/json
+//!
+//! ## Supported Methods
+//! The supported HTTP Methods are:
+//! - GET
+//! - PUT
+//! - PATCH
+//!
+//! ## Supported Status Codes
+//! The supported status codes are:
+//!
+//! - Continue - 100
+//! - OK - 200
+//! - No Content - 204
+//! - Bad Request - 400
+//! - Not Found - 404
+//! - Internal Server Error - 500
+//! - Not Implemented - 501
+//!
+//! ## Example for parsing an HTTP Request from a slice
+//! ```
+//! use micro_http::{Request, Version};
+//!
+//! let request_bytes = b"GET http://localhost/home HTTP/1.0\r\n\r\n";
+//! let http_request = Request::try_from(request_bytes, None).unwrap();
+//! assert_eq!(http_request.http_version(), Version::Http10);
+//! assert_eq!(http_request.uri().get_abs_path(), "/home");
+//! ```
+//!
+//! ## Example for creating an HTTP Response
+//! ```
+//! use micro_http::{Body, MediaType, Response, StatusCode, Version};
+//!
+//! let mut response = Response::new(Version::Http10, StatusCode::OK);
+//! let body = String::from("This is a test");
+//! response.set_body(Body::new(body.clone()));
+//! response.set_content_type(MediaType::PlainText);
+//!
+//! assert!(response.status() == StatusCode::OK);
+//! assert_eq!(response.body().unwrap(), Body::new(body));
+//! assert_eq!(response.http_version(), Version::Http10);
+//!
+//! let mut response_buf: [u8; 126] = [0; 126];
+//! assert!(response.write_all(&mut response_buf.as_mut()).is_ok());
+//! ```
+//!
+//! `HttpConnection` can be used for automatic data exchange and parsing when
+//! handling a client, but it only supports one stream.
+//!
+//! For handling multiple clients use `HttpServer`, which multiplexes `HttpConnection`s
+//! and offers an easy to use interface. The server can run in either blocking or
+//! non-blocking mode. Non-blocking is achieved by using `epoll` to make sure
+//! `requests` will never block when called.
+//!
+//! ## Example for using the server
+//!
+//! ```
+//! use micro_http::{HttpServer, Response, StatusCode};
+//!
+//! let path_to_socket = "/tmp/example.sock";
+//! std::fs::remove_file(path_to_socket).unwrap_or_default();
+//!
+//! // Start the server.
+//! let mut server = HttpServer::new(path_to_socket).unwrap();
+//! server.start_server().unwrap();
+//!
+//! // Connect a client to the server so it doesn't block in our example.
+//! let mut socket = std::os::unix::net::UnixStream::connect(path_to_socket).unwrap();
+//!
+//! // Server loop processing requests.
+//! loop {
+//!     for request in server.requests().unwrap() {
+//!         let response = request.process(|request| {
+//!             // Your code here.
+//!             Response::new(request.http_version(), StatusCode::NoContent)
+//!         });
+//!         server.respond(response);
+//!     }
+//!     // Break this example loop.
+//!     break;
+//! }
+//! ```
+
+mod common;
+mod connection;
+mod request;
+mod response;
+mod router;
+mod server;
+use crate::common::ascii;
+use crate::common::headers;
+
+pub use self::router::{EndpointHandler, HttpRoutes, RouteError};
+pub use crate::common::headers::{Encoding, Headers, MediaType};
+pub use crate::common::{Body, HttpHeaderError, Method, Version};
+pub use crate::connection::{ConnectionError, HttpConnection};
+pub use crate::request::{Request, RequestError};
+pub use crate::response::{Response, ResponseHeaders, StatusCode};
+pub use crate::server::{HttpServer, ServerError, ServerRequest, ServerResponse};

--- a/crates/db-micro-http/src/request.rs
+++ b/crates/db-micro-http/src/request.rs
@@ -1,0 +1,558 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::fs::File;
+use std::str::from_utf8;
+
+use crate::common::ascii::{CR, CRLF_LEN, LF, SP};
+pub use crate::common::HttpHeaderError;
+pub use crate::common::RequestError;
+use crate::common::{Body, Method, Version};
+use crate::headers::Headers;
+
+// This type represents the RequestLine raw parts: method, uri and version.
+type RequestLineParts<'a> = (&'a [u8], &'a [u8], &'a [u8]);
+
+/// Finds the first occurrence of `sequence` in the `bytes` slice.
+///
+/// Returns the starting position of the `sequence` in `bytes` or `None` if the
+/// `sequence` is not found.
+pub(crate) fn find(bytes: &[u8], sequence: &[u8]) -> Option<usize> {
+    bytes
+        .windows(sequence.len())
+        .position(|window| window == sequence)
+}
+
+/// Wrapper over HTTP URIs.
+///
+/// The `Uri` can not be used directly and it is only accessible from an HTTP Request.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Uri {
+    string: String,
+}
+
+impl Uri {
+    fn new(slice: &str) -> Self {
+        Self {
+            string: String::from(slice),
+        }
+    }
+
+    fn try_from(bytes: &[u8]) -> Result<Self, RequestError> {
+        if bytes.is_empty() {
+            return Err(RequestError::InvalidUri("Empty URI not allowed."));
+        }
+        let utf8_slice =
+            from_utf8(bytes).map_err(|_| RequestError::InvalidUri("Cannot parse URI as UTF-8."))?;
+        Ok(Self::new(utf8_slice))
+    }
+
+    /// Returns the absolute path of the `Uri`.
+    ///
+    /// URIs can be represented in absolute form or relative form. The absolute form includes
+    /// the HTTP scheme, followed by the absolute path as follows:
+    /// "http:" "//" host [ ":" port ] [ abs_path ]
+    /// The relative URIs can be one of net_path | abs_path | rel_path.
+    /// This method only handles absolute URIs and relative URIs specified by abs_path.
+    /// The abs_path is expected to start with '/'.
+    ///
+    /// # Errors
+    /// Returns an empty byte array when the host or the path are empty/invalid.
+    pub fn get_abs_path(&self) -> &str {
+        const HTTP_SCHEME_PREFIX: &str = "http://";
+
+        if self.string.starts_with(HTTP_SCHEME_PREFIX) {
+            // Slice access is safe because we checked above that `self.string` size <= `HTTP_SCHEME_PREFIX.len()`.
+            let without_scheme = &self.string[HTTP_SCHEME_PREFIX.len()..];
+            if without_scheme.is_empty() {
+                return "";
+            }
+            // The host in this case includes the port and contains the bytes after http:// up to
+            // the next '/'.
+            match without_scheme.bytes().position(|byte| byte == b'/') {
+                // Slice access is safe because `position` validates that `len` is a valid index.
+                Some(len) => &without_scheme[len..],
+                None => "",
+            }
+        } else {
+            if self.string.starts_with('/') {
+                return self.string.as_str();
+            }
+
+            ""
+        }
+    }
+}
+
+/// Wrapper over an HTTP Request Line.
+#[derive(Debug, PartialEq)]
+pub struct RequestLine {
+    method: Method,
+    uri: Uri,
+    http_version: Version,
+}
+
+impl RequestLine {
+    fn parse_request_line(
+        request_line: &[u8],
+    ) -> std::result::Result<RequestLineParts, RequestError> {
+        if let Some(method_end) = find(request_line, &[SP]) {
+            // The slice access is safe because `find` validates that `method_end` < `request_line` size.
+            let method = &request_line[..method_end];
+
+            // `uri_start` <= `request_line` size.
+            let uri_start = method_end.checked_add(1).ok_or(RequestError::Overflow)?;
+
+            // Slice access is safe because `uri_start` <= `request_line` size.
+            // If `uri_start` == `request_line` size, then `uri_and_version` will be an empty slice.
+            let uri_and_version = &request_line[uri_start..];
+
+            if let Some(uri_end) = find(uri_and_version, &[SP]) {
+                // Slice access is safe because `find` validates that `uri_end` < `uri_and_version` size.
+                let uri = &uri_and_version[..uri_end];
+
+                // `version_start` <= `uri_and_version` size.
+                let version_start = uri_end.checked_add(1).ok_or(RequestError::Overflow)?;
+
+                // Slice access is safe because `version_start` <= `uri_and_version` size.
+                let version = &uri_and_version[version_start..];
+
+                return Ok((method, uri, version));
+            }
+        }
+
+        // Request Line can be valid only if it contains the method, uri and version separated with SP.
+        Err(RequestError::InvalidRequest)
+    }
+
+    /// Tries to parse a byte stream in a request line. Fails if the request line is malformed.
+    ///
+    /// # Errors
+    /// `InvalidHttpMethod` is returned if the specified HTTP method is unsupported.
+    /// `InvalidHttpVersion` is returned if the specified HTTP version is unsupported.
+    /// `InvalidUri` is returned if the specified Uri is not valid.
+    pub fn try_from(request_line: &[u8]) -> Result<Self, RequestError> {
+        let (method, uri, version) = Self::parse_request_line(request_line)?;
+
+        Ok(Self {
+            method: Method::try_from(method)?,
+            uri: Uri::try_from(uri)?,
+            http_version: Version::try_from(version)?,
+        })
+    }
+
+    // Returns the minimum length of a valid request. The request must contain
+    // the method (GET), the URI (minimum 1 character), the HTTP version(HTTP/DIGIT.DIGIT) and
+    // 2 separators (SP).
+    fn min_len() -> usize {
+        // Addition is safe because these are small constants.
+        Method::Get.raw().len() + 1 + Version::Http10.raw().len() + 2
+    }
+}
+
+/// Wrapper over an HTTP Request.
+#[derive(Debug)]
+pub struct Request {
+    /// The request line of the request.
+    pub request_line: RequestLine,
+    /// The headers of the request.
+    pub headers: Headers,
+    /// The body of the request.
+    pub body: Option<Body>,
+    /// The optional files associated with the request.
+    pub files: Vec<File>,
+}
+
+impl Request {
+    /// Parses a byte slice into a HTTP Request.
+    ///
+    /// The byte slice is expected to have the following format: </br>
+    ///     * Request Line: "GET SP Request-uri SP HTTP/1.0 CRLF" - Mandatory </br>
+    ///     * Request Headers "<headers> CRLF"- Optional </br>
+    ///     * Empty Line "CRLF" </br>
+    ///     * Entity Body - Optional </br>
+    /// The request headers and the entity body are not parsed and None is returned because
+    /// these are not used by the MMDS server.
+    /// The only supported method is GET and the HTTP protocol is expected to be HTTP/1.0
+    /// or HTTP/1.1.
+    ///
+    /// # Errors
+    /// The function returns InvalidRequest when parsing the byte stream fails.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use micro_http::Request;
+    ///
+    /// let max_request_len = 2000;
+    /// let request_bytes = b"GET http://localhost/home HTTP/1.0\r\n\r\n";
+    /// let http_request = Request::try_from(request_bytes, Some(max_request_len)).unwrap();
+    /// ```
+    pub fn try_from(byte_stream: &[u8], max_len: Option<usize>) -> Result<Self, RequestError> {
+        // If a size limit is provided, verify the request length does not exceed it.
+        if let Some(limit) = max_len {
+            if byte_stream.len() >= limit {
+                return Err(RequestError::InvalidRequest);
+            }
+        }
+
+        // The first line of the request is the Request Line. The line ending is CR LF.
+        let request_line_end = match find(byte_stream, &[CR, LF]) {
+            Some(len) => len,
+            // If no CR LF is found in the stream, the request format is invalid.
+            None => return Err(RequestError::InvalidRequest),
+        };
+
+        // Slice access is safe because `find` validates that `request_line_end` < `byte_stream` size.
+        let request_line_bytes = &byte_stream[..request_line_end];
+        if request_line_bytes.len() < RequestLine::min_len() {
+            return Err(RequestError::InvalidRequest);
+        }
+
+        let request_line = RequestLine::try_from(request_line_bytes)?;
+
+        // Find the next CR LF CR LF sequence in our buffer starting at the end on the Request
+        // Line, including the trailing CR LF previously found.
+        match find(&byte_stream[request_line_end..], &[CR, LF, CR, LF]) {
+            // If we have found a CR LF CR LF at the end of the Request Line, the request
+            // is complete.
+            Some(0) => Ok(Self {
+                request_line,
+                headers: Headers::default(),
+                body: None,
+                files: Vec::new(),
+            }),
+            Some(headers_end) => {
+                // Parse the request headers.
+                // Start by removing the leading CR LF from them.
+                // The addition is safe because `find()` guarantees that `request_line_end`
+                // precedes 2 `CRLF` sequences.
+                let headers_start = request_line_end + CRLF_LEN;
+                // Slice access is safe because starting from `request_line_end` there are at least two CRLF
+                // (enforced by `find` at the start of this method).
+                let headers_and_body = &byte_stream[headers_start..];
+                // Because we advanced the start with CRLF_LEN, we now have to subtract CRLF_LEN
+                // from the end in order to keep the same window.
+                // Underflow is not possible here because `byte_stream[request_line_end..]` starts with CR LF,
+                // so `headers_end` can be either zero (this case is treated separately in the first match arm)
+                // or >= 3 (current case).
+                let headers_end = headers_end - CRLF_LEN;
+                // Slice access is safe because `headers_end` is checked above
+                // (`find` gives a valid position, and  subtracting 2 can't underflow).
+                let headers = Headers::try_from(&headers_and_body[..headers_end])?;
+
+                // Parse the body of the request.
+                // Firstly check if we have a body.
+                let body = match headers.content_length() {
+                    0 => {
+                        // No request body.
+                        None
+                    }
+                    content_length => {
+                        if request_line.method == Method::Get {
+                            return Err(RequestError::InvalidRequest);
+                        }
+                        // Multiplication is safe because `CRLF_LEN` is a small constant.
+                        // Addition is also safe because `headers_end` started out as the result
+                        // of `find(<something>, CRLFCRLF)`, then `CRLF_LEN` was subtracted from it.
+                        let crlf_end = headers_end + 2 * CRLF_LEN;
+                        // This can't underflow because `headers_and_body.len()` >= `crlf_end`.
+                        let body_len = headers_and_body.len() - crlf_end;
+                        // Headers suggest we have a body, but the buffer is shorter than the specified
+                        // content length.
+                        if body_len < content_length as usize {
+                            return Err(RequestError::InvalidRequest);
+                        }
+                        // Slice access is safe because `crlf_end` is the index after two CRLF
+                        // (it is <= `headers_and_body` size).
+                        let body_as_bytes = &headers_and_body[crlf_end..];
+                        // If the actual length of the body is different than the `Content-Length` value
+                        // in the headers, then this request is invalid.
+                        if body_as_bytes.len() == content_length as usize {
+                            Some(Body::new(body_as_bytes))
+                        } else {
+                            return Err(RequestError::InvalidRequest);
+                        }
+                    }
+                };
+
+                Ok(Self {
+                    request_line,
+                    headers,
+                    body,
+                    files: Vec::new(),
+                })
+            }
+            // If we can't find a CR LF CR LF even though the request should have headers
+            // the request format is invalid.
+            None => Err(RequestError::InvalidRequest),
+        }
+    }
+
+    /// Returns the `Uri` from the parsed `Request`.
+    ///
+    /// The return value can be used to get the absolute path of the URI.
+    pub fn uri(&self) -> &Uri {
+        &self.request_line.uri
+    }
+
+    /// Returns the HTTP `Version` of the `Request`.
+    pub fn http_version(&self) -> Version {
+        self.request_line.http_version
+    }
+
+    /// Returns the HTTP `Method` of the `Request`.
+    pub fn method(&self) -> Method {
+        self.request_line.method
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    impl PartialEq for Request {
+        fn eq(&self, other: &Self) -> bool {
+            // Ignore the other fields of Request for now because they are not used.
+            self.request_line == other.request_line
+                && self.headers.content_length() == other.headers.content_length()
+                && self.headers.expect() == other.headers.expect()
+                && self.headers.chunked() == other.headers.chunked()
+        }
+    }
+
+    impl RequestLine {
+        pub fn new(method: Method, uri: &str, http_version: Version) -> Self {
+            Self {
+                method,
+                uri: Uri::new(uri),
+                http_version,
+            }
+        }
+    }
+
+    #[test]
+    fn test_uri() {
+        for tc in &vec![
+            ("http://localhost/home", "/home"),
+            ("http://localhost:8080/home", "/home"),
+            ("http://localhost/home/sub", "/home/sub"),
+            ("/home", "/home"),
+            ("home", ""),
+            ("http://", ""),
+            ("http://192.168.0.0", ""),
+        ] {
+            assert_eq!(Uri::new(tc.0).get_abs_path(), tc.1);
+        }
+    }
+
+    #[test]
+    fn test_find() {
+        let bytes: &[u8; 13] = b"abcacrgbabsjl";
+
+        for tc in &vec![
+            ("ac", Some(3)),
+            ("rgb", Some(5)),
+            ("ab", Some(0)),
+            ("l", Some(12)),
+            ("abcacrgbabsjl", Some(0)),
+            ("jle", None),
+            ("asdkjhasjhdjhgsadg", None),
+        ] {
+            assert_eq!(find(&bytes[..], tc.0.as_bytes()), tc.1);
+        }
+    }
+
+    #[test]
+    fn test_into_request_line() {
+        let expected_request_line = RequestLine {
+            http_version: Version::Http10,
+            method: Method::Get,
+            uri: Uri::new("http://localhost/home"),
+        };
+
+        let request_line = b"GET http://localhost/home HTTP/1.0";
+        assert_eq!(
+            RequestLine::try_from(request_line).unwrap(),
+            expected_request_line
+        );
+
+        let expected_request_line = RequestLine {
+            http_version: Version::Http11,
+            method: Method::Get,
+            uri: Uri::new("http://localhost/home"),
+        };
+
+        // Happy case with request line ending in CRLF.
+        let request_line = b"GET http://localhost/home HTTP/1.1";
+        assert_eq!(
+            RequestLine::try_from(request_line).unwrap(),
+            expected_request_line
+        );
+
+        // Happy case with request line ending in LF instead of CRLF.
+        let request_line = b"GET http://localhost/home HTTP/1.1";
+        assert_eq!(
+            RequestLine::try_from(request_line).unwrap(),
+            expected_request_line
+        );
+
+        // Test for invalid request missing the separator.
+        let request_line = b"GET";
+        assert_eq!(
+            RequestLine::try_from(request_line).unwrap_err(),
+            RequestError::InvalidRequest
+        );
+
+        // Test for invalid method.
+        let request_line = b"POST http://localhost/home HTTP/1.0";
+        assert_eq!(
+            RequestLine::try_from(request_line).unwrap_err(),
+            RequestError::InvalidHttpMethod("Unsupported HTTP method.")
+        );
+
+        // Test for invalid uri.
+        let request_line = b"GET  HTTP/1.0";
+        assert_eq!(
+            RequestLine::try_from(request_line).unwrap_err(),
+            RequestError::InvalidUri("Empty URI not allowed.")
+        );
+
+        // Test for invalid HTTP version.
+        let request_line = b"GET http://localhost/home HTTP/2.0";
+        assert_eq!(
+            RequestLine::try_from(request_line).unwrap_err(),
+            RequestError::InvalidHttpVersion("Unsupported HTTP version.")
+        );
+
+        // Test for invalid format with no method, uri or version.
+        let request_line = b"nothing";
+        assert_eq!(
+            RequestLine::try_from(request_line).unwrap_err(),
+            RequestError::InvalidRequest
+        );
+
+        // Test for invalid format with no version.
+        let request_line = b"GET /";
+        assert_eq!(
+            RequestLine::try_from(request_line).unwrap_err(),
+            RequestError::InvalidRequest
+        );
+    }
+
+    #[test]
+    fn test_into_request() {
+        let expected_request = Request {
+            request_line: RequestLine {
+                http_version: Version::Http10,
+                method: Method::Get,
+                uri: Uri::new("http://localhost/home"),
+            },
+            body: None,
+            files: Vec::new(),
+            headers: Headers::default(),
+        };
+        let request_bytes = b"GET http://localhost/home HTTP/1.0\r\n\
+                                     Last-Modified: Tue, 15 Nov 1994 12:45:26 GMT\r\n\r\n";
+        let request = Request::try_from(request_bytes, None).unwrap();
+        assert_eq!(request, expected_request);
+        assert_eq!(request.uri(), &Uri::new("http://localhost/home"));
+        assert_eq!(request.http_version(), Version::Http10);
+        assert!(request.body.is_none());
+
+        // Test for invalid Request (missing CR LF).
+        let request_bytes = b"GET / HTTP/1.1";
+        assert_eq!(
+            Request::try_from(request_bytes, None).unwrap_err(),
+            RequestError::InvalidRequest
+        );
+
+        // Test for invalid Request (length is less than minimum).
+        let request_bytes = b"GET";
+        assert_eq!(
+            Request::try_from(request_bytes, None).unwrap_err(),
+            RequestError::InvalidRequest
+        );
+
+        // Test for invalid Request (`GET` requests should have no body).
+        let request_bytes = b"GET /machine-config HTTP/1.1\r\n\
+                                        Content-Length: 13\r\n\
+                                        Content-Type: application/json\r\n\r\nwhatever body";
+        assert_eq!(
+            Request::try_from(request_bytes, None).unwrap_err(),
+            RequestError::InvalidRequest
+        );
+
+        // Test for request larger than maximum len provided.
+        let request_bytes = b"GET http://localhost/home HTTP/1.0\r\n\
+                                     Last-Modified: Tue, 15 Nov 1994 12:45:26 GMT\r\n\r\n";
+        assert_eq!(
+            Request::try_from(request_bytes, Some(20)).unwrap_err(),
+            RequestError::InvalidRequest
+        );
+
+        // Test request smaller than maximum len provided is ok.
+        let request_bytes = b"GET http://localhost/home HTTP/1.0\r\n\
+                                     Last-Modified: Tue, 15 Nov 1994 12:45:26 GMT\r\n\r\n";
+        assert!(Request::try_from(request_bytes, Some(500)).is_ok());
+
+        // Test for a request with the headers we are looking for.
+        let request_bytes = b"PATCH http://localhost/home HTTP/1.1\r\n\
+                              Expect: 100-continue\r\n\
+                              Transfer-Encoding: chunked\r\n\
+                              Content-Length: 26\r\n\r\nthis is not\n\r\na json \nbody";
+        let request = Request::try_from(request_bytes, None).unwrap();
+        assert_eq!(request.uri(), &Uri::new("http://localhost/home"));
+        assert_eq!(request.http_version(), Version::Http11);
+        assert_eq!(request.method(), Method::Patch);
+        assert!(request.headers.chunked());
+        assert!(request.headers.expect());
+        assert_eq!(request.headers.content_length(), 26);
+        assert_eq!(
+            request.body.unwrap().body,
+            String::from("this is not\n\r\na json \nbody")
+                .as_bytes()
+                .to_vec()
+        );
+
+        // Test for an invalid request format.
+        Request::try_from(b"PATCH http://localhost/home HTTP/1.1\r\n", None).unwrap_err();
+
+        // Test for an invalid encoding.
+        let request_bytes = b"PATCH http://localhost/home HTTP/1.1\r\n\
+                                Expect: 100-continue\r\n\
+                                Transfer-Encoding: identity; q=0\r\n\
+                                Content-Length: 26\r\n\r\nthis is not\n\r\na json \nbody";
+
+        assert!(Request::try_from(request_bytes, None).is_ok());
+
+        // Test for an invalid content length.
+        let request_bytes = b"PATCH http://localhost/home HTTP/1.1\r\n\
+                                Content-Length: 5000\r\n\r\nthis is a short body";
+        let request = Request::try_from(request_bytes, None).unwrap_err();
+        assert_eq!(request, RequestError::InvalidRequest);
+
+        // Test for a request without a body and an optional header.
+        let request_bytes = b"GET http://localhost/ HTTP/1.0\r\n\
+                                Accept-Encoding: gzip\r\n\r\n";
+        let request = Request::try_from(request_bytes, None).unwrap();
+        assert_eq!(request.uri(), &Uri::new("http://localhost/"));
+        assert_eq!(request.http_version(), Version::Http10);
+        assert_eq!(request.method(), Method::Get);
+        assert!(!request.headers.chunked());
+        assert!(!request.headers.expect());
+        assert_eq!(request.headers.content_length(), 0);
+        assert!(request.body.is_none());
+
+        let request_bytes = b"GET http://localhost/ HTTP/1.0\r\n\
+                                Accept-Encoding: identity;q=0\r\n\r\n";
+        let request = Request::try_from(request_bytes, None);
+        assert_eq!(
+            request.unwrap_err(),
+            RequestError::HeaderError(HttpHeaderError::InvalidValue(
+                "Accept-Encoding".to_string(),
+                "identity;q=0".to_string()
+            ))
+        );
+    }
+}

--- a/crates/db-micro-http/src/response.rs
+++ b/crates/db-micro-http/src/response.rs
@@ -1,0 +1,483 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::io::{Error as WriteError, Write};
+
+use crate::ascii::{COLON, CR, LF, SP};
+use crate::common::{Body, Version};
+use crate::headers::{Header, MediaType};
+use crate::Method;
+
+/// Wrapper over a response status code.
+///
+/// The status code is defined as specified in the
+/// [RFC](https://tools.ietf.org/html/rfc7231#section-6).
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum StatusCode {
+    /// 100, Continue
+    Continue,
+    /// 200, OK
+    OK,
+    /// 204, No Content
+    NoContent,
+    /// 400, Bad Request
+    BadRequest,
+    /// 401, Unauthorized
+    Unauthorized,
+    /// 404, Not Found
+    NotFound,
+    /// 405, Method Not Allowed
+    MethodNotAllowed,
+    /// 413, Payload Too Large
+    PayloadTooLarge,
+    /// 500, Internal Server Error
+    InternalServerError,
+    /// 501, Not Implemented
+    NotImplemented,
+    /// 503, Service Unavailable
+    ServiceUnavailable,
+}
+
+impl StatusCode {
+    /// Returns the status code as bytes.
+    pub fn raw(self) -> &'static [u8; 3] {
+        match self {
+            Self::Continue => b"100",
+            Self::OK => b"200",
+            Self::NoContent => b"204",
+            Self::BadRequest => b"400",
+            Self::Unauthorized => b"401",
+            Self::NotFound => b"404",
+            Self::MethodNotAllowed => b"405",
+            Self::PayloadTooLarge => b"413",
+            Self::InternalServerError => b"500",
+            Self::NotImplemented => b"501",
+            Self::ServiceUnavailable => b"503",
+        }
+    }
+}
+
+#[derive(Debug, PartialEq)]
+struct StatusLine {
+    http_version: Version,
+    status_code: StatusCode,
+}
+
+impl StatusLine {
+    fn new(http_version: Version, status_code: StatusCode) -> Self {
+        Self {
+            http_version,
+            status_code,
+        }
+    }
+
+    fn write_all<T: Write>(&self, mut buf: T) -> Result<(), WriteError> {
+        buf.write_all(self.http_version.raw())?;
+        buf.write_all(&[SP])?;
+        buf.write_all(self.status_code.raw())?;
+        buf.write_all(&[SP, CR, LF])?;
+
+        Ok(())
+    }
+}
+
+/// Wrapper over the list of headers associated with a HTTP Response.
+/// When creating a ResponseHeaders object, the content type is initialized to `text/plain`.
+/// The content type can be updated with a call to `set_content_type`.
+#[derive(Debug, PartialEq)]
+pub struct ResponseHeaders {
+    content_length: i32,
+    content_type: MediaType,
+    deprecation: bool,
+    server: String,
+    allow: Vec<Method>,
+    accept_encoding: bool,
+}
+
+impl Default for ResponseHeaders {
+    fn default() -> Self {
+        Self {
+            content_length: Default::default(),
+            content_type: Default::default(),
+            deprecation: false,
+            server: String::from("Firecracker API"),
+            allow: Vec::new(),
+            accept_encoding: false,
+        }
+    }
+}
+
+impl ResponseHeaders {
+    // The logic pertaining to `Allow` header writing.
+    fn write_allow_header<T: Write>(&self, buf: &mut T) -> Result<(), WriteError> {
+        if self.allow.is_empty() {
+            return Ok(());
+        }
+
+        buf.write_all(b"Allow: ")?;
+
+        let delimitator = b", ";
+        for (idx, method) in self.allow.iter().enumerate() {
+            buf.write_all(method.raw())?;
+            // We check above that `self.allow` is not empty.
+            if idx < self.allow.len() - 1 {
+                buf.write_all(delimitator)?;
+            }
+        }
+
+        buf.write_all(&[CR, LF])
+    }
+
+    // The logic pertaining to `Deprecation` header writing.
+    fn write_deprecation_header<T: Write>(&self, buf: &mut T) -> Result<(), WriteError> {
+        if !self.deprecation {
+            return Ok(());
+        }
+
+        buf.write_all(b"Deprecation: true")?;
+        buf.write_all(&[CR, LF])
+    }
+
+    /// Writes the headers to `buf` using the HTTP specification.
+    pub fn write_all<T: Write>(&self, buf: &mut T) -> Result<(), WriteError> {
+        buf.write_all(Header::Server.raw())?;
+        buf.write_all(&[COLON, SP])?;
+        buf.write_all(self.server.as_bytes())?;
+        buf.write_all(&[CR, LF])?;
+
+        buf.write_all(b"Connection: keep-alive")?;
+        buf.write_all(&[CR, LF])?;
+
+        self.write_allow_header(buf)?;
+        self.write_deprecation_header(buf)?;
+
+        if self.content_length != 0 {
+            buf.write_all(Header::ContentType.raw())?;
+            buf.write_all(&[COLON, SP])?;
+            buf.write_all(self.content_type.as_str().as_bytes())?;
+            buf.write_all(&[CR, LF])?;
+
+            buf.write_all(Header::ContentLength.raw())?;
+            buf.write_all(&[COLON, SP])?;
+            buf.write_all(self.content_length.to_string().as_bytes())?;
+            buf.write_all(&[CR, LF])?;
+
+            if self.accept_encoding {
+                buf.write_all(Header::AcceptEncoding.raw())?;
+                buf.write_all(&[COLON, SP])?;
+                buf.write_all(b"identity")?;
+                buf.write_all(&[CR, LF])?;
+            }
+        }
+
+        buf.write_all(&[CR, LF])
+    }
+
+    // Sets the content length to be written in the HTTP response.
+    fn set_content_length(&mut self, content_length: i32) {
+        self.content_length = content_length;
+    }
+
+    /// Sets the HTTP response header server.
+    pub fn set_server(&mut self, server: &str) {
+        self.server = String::from(server);
+    }
+
+    /// Sets the content type to be written in the HTTP response.
+    pub fn set_content_type(&mut self, content_type: MediaType) {
+        self.content_type = content_type;
+    }
+
+    /// Sets the `Deprecation` header to be written in the HTTP response.
+    /// https://tools.ietf.org/id/draft-dalal-deprecation-header-03.html
+    #[allow(unused)]
+    pub fn set_deprecation(&mut self) {
+        self.deprecation = true;
+    }
+
+    /// Sets the encoding type to be written in the HTTP response.
+    #[allow(unused)]
+    pub fn set_encoding(&mut self) {
+        self.accept_encoding = true;
+    }
+}
+
+/// Wrapper over an HTTP Response.
+///
+/// The Response is created using a `Version` and a `StatusCode`. When creating a Response object,
+/// the body is initialized to `None` and the header is initialized with the `default` value. The body
+/// can be updated with a call to `set_body`. The header can be updated with `set_content_type` and
+/// `set_server`.
+#[derive(Debug, PartialEq)]
+pub struct Response {
+    status_line: StatusLine,
+    headers: ResponseHeaders,
+    body: Option<Body>,
+}
+
+impl Response {
+    /// Creates a new HTTP `Response` with an empty body.
+    pub fn new(http_version: Version, status_code: StatusCode) -> Self {
+        Self {
+            status_line: StatusLine::new(http_version, status_code),
+            headers: ResponseHeaders::default(),
+            body: Default::default(),
+        }
+    }
+
+    /// Updates the body of the `Response`.
+    ///
+    /// This function has side effects because it also updates the headers:
+    /// - `ContentLength`: this is set to the length of the specified body.
+    pub fn set_body(&mut self, body: Body) {
+        self.headers.set_content_length(body.len() as i32);
+        self.body = Some(body);
+    }
+
+    /// Updates the content type of the `Response`.
+    pub fn set_content_type(&mut self, content_type: MediaType) {
+        self.headers.set_content_type(content_type);
+    }
+
+    /// Marks the `Response` as deprecated.
+    pub fn set_deprecation(&mut self) {
+        self.headers.set_deprecation();
+    }
+
+    /// Updates the encoding type of `Response`.
+    pub fn set_encoding(&mut self) {
+        self.headers.set_encoding();
+    }
+
+    /// Sets the HTTP response server.
+    pub fn set_server(&mut self, server: &str) {
+        self.headers.set_server(server);
+    }
+
+    /// Sets the HTTP allowed methods.
+    pub fn set_allow(&mut self, methods: Vec<Method>) {
+        self.headers.allow = methods;
+    }
+
+    /// Allows a specific HTTP method.
+    pub fn allow_method(&mut self, method: Method) {
+        self.headers.allow.push(method);
+    }
+
+    fn write_body<T: Write>(&self, mut buf: T) -> Result<(), WriteError> {
+        if let Some(ref body) = self.body {
+            buf.write_all(body.raw())?;
+        }
+        Ok(())
+    }
+
+    /// Writes the content of the `Response` to the specified `buf`.
+    ///
+    /// # Errors
+    /// Returns an error when the buffer is not large enough.
+    pub fn write_all<T: Write>(&self, mut buf: &mut T) -> Result<(), WriteError> {
+        self.status_line.write_all(&mut buf)?;
+        self.headers.write_all(&mut buf)?;
+        self.write_body(&mut buf)?;
+
+        Ok(())
+    }
+
+    /// Returns the Status Code of the Response.
+    pub fn status(&self) -> StatusCode {
+        self.status_line.status_code
+    }
+
+    /// Returns the Body of the response. If the response does not have a body,
+    /// it returns None.
+    pub fn body(&self) -> Option<Body> {
+        self.body.clone()
+    }
+
+    /// Returns the Content Length of the response.
+    pub fn content_length(&self) -> i32 {
+        self.headers.content_length
+    }
+
+    /// Returns the Content Type of the response.
+    pub fn content_type(&self) -> MediaType {
+        self.headers.content_type
+    }
+
+    /// Returns the deprecation status of the response.
+    pub fn deprecation(&self) -> bool {
+        self.headers.deprecation
+    }
+
+    /// Returns the HTTP Version of the response.
+    pub fn http_version(&self) -> Version {
+        self.status_line.http_version
+    }
+
+    /// Returns the allowed HTTP methods.
+    pub fn allow(&self) -> Vec<Method> {
+        self.headers.allow.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_write_response() {
+        let mut response = Response::new(Version::Http10, StatusCode::OK);
+        let body = "This is a test";
+        response.set_body(Body::new(body));
+        response.set_content_type(MediaType::PlainText);
+        response.set_encoding();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(response.body().unwrap(), Body::new(body));
+        assert_eq!(response.http_version(), Version::Http10);
+        assert_eq!(response.content_length(), 14);
+        assert_eq!(response.content_type(), MediaType::PlainText);
+
+        let expected_response: &'static [u8] = b"HTTP/1.0 200 \r\n\
+            Server: Firecracker API\r\n\
+            Connection: keep-alive\r\n\
+            Content-Type: text/plain\r\n\
+            Content-Length: 14\r\n\
+            Accept-Encoding: identity\r\n\r\n\
+            This is a test";
+
+        let mut response_buf: [u8; 153] = [0; 153];
+        assert!(response.write_all(&mut response_buf.as_mut()).is_ok());
+        assert_eq!(response_buf.as_ref(), expected_response);
+
+        // Test response `Allow` header.
+        let mut response = Response::new(Version::Http10, StatusCode::OK);
+        let allowed_methods = vec![Method::Get, Method::Patch, Method::Put];
+        response.set_allow(allowed_methods.clone());
+        assert_eq!(response.allow(), allowed_methods);
+
+        let expected_response: &'static [u8] = b"HTTP/1.0 200 \r\n\
+            Server: Firecracker API\r\n\
+            Connection: keep-alive\r\n\
+            Allow: GET, PATCH, PUT\r\n\r\n";
+        let mut response_buf: [u8; 90] = [0; 90];
+        assert!(response.write_all(&mut response_buf.as_mut()).is_ok());
+        assert_eq!(response_buf.as_ref(), expected_response);
+
+        // Test write failed.
+        let mut response_buf: [u8; 1] = [0; 1];
+        assert!(response.write_all(&mut response_buf.as_mut()).is_err());
+    }
+
+    #[test]
+    fn test_set_server() {
+        let mut response = Response::new(Version::Http10, StatusCode::OK);
+        let body = "This is a test";
+        let server = "rust-vmm API";
+        response.set_body(Body::new(body));
+        response.set_content_type(MediaType::PlainText);
+        response.set_server(server);
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(response.body().unwrap(), Body::new(body));
+        assert_eq!(response.http_version(), Version::Http10);
+        assert_eq!(response.content_length(), 14);
+        assert_eq!(response.content_type(), MediaType::PlainText);
+
+        let expected_response = format!(
+            "HTTP/1.0 200 \r\n\
+             Server: {}\r\n\
+             Connection: keep-alive\r\n\
+             Content-Type: text/plain\r\n\
+             Content-Length: 14\r\n\r\n\
+             This is a test",
+            server
+        );
+
+        let mut response_buf: [u8; 123] = [0; 123];
+        assert!(response.write_all(&mut response_buf.as_mut()).is_ok());
+        assert!(response_buf.as_ref() == expected_response.as_bytes());
+    }
+
+    #[test]
+    fn test_status_code() {
+        assert_eq!(StatusCode::Continue.raw(), b"100");
+        assert_eq!(StatusCode::OK.raw(), b"200");
+        assert_eq!(StatusCode::NoContent.raw(), b"204");
+        assert_eq!(StatusCode::BadRequest.raw(), b"400");
+        assert_eq!(StatusCode::Unauthorized.raw(), b"401");
+        assert_eq!(StatusCode::NotFound.raw(), b"404");
+        assert_eq!(StatusCode::MethodNotAllowed.raw(), b"405");
+        assert_eq!(StatusCode::PayloadTooLarge.raw(), b"413");
+        assert_eq!(StatusCode::InternalServerError.raw(), b"500");
+        assert_eq!(StatusCode::NotImplemented.raw(), b"501");
+        assert_eq!(StatusCode::ServiceUnavailable.raw(), b"503");
+    }
+
+    #[test]
+    fn test_allow_method() {
+        let mut response = Response::new(Version::Http10, StatusCode::MethodNotAllowed);
+        response.allow_method(Method::Get);
+        response.allow_method(Method::Put);
+        assert_eq!(response.allow(), vec![Method::Get, Method::Put]);
+    }
+
+    #[test]
+    fn test_deprecation() {
+        // Test a deprecated response with body.
+        let mut response = Response::new(Version::Http10, StatusCode::OK);
+        let body = "This is a test";
+        response.set_body(Body::new(body));
+        response.set_content_type(MediaType::PlainText);
+        response.set_encoding();
+        response.set_deprecation();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(response.body().unwrap(), Body::new(body));
+        assert_eq!(response.http_version(), Version::Http10);
+        assert_eq!(response.content_length(), 14);
+        assert_eq!(response.content_type(), MediaType::PlainText);
+        assert!(response.deprecation());
+
+        let expected_response: &'static [u8] = b"HTTP/1.0 200 \r\n\
+            Server: Firecracker API\r\n\
+            Connection: keep-alive\r\n\
+            Deprecation: true\r\n\
+            Content-Type: text/plain\r\n\
+            Content-Length: 14\r\n\
+            Accept-Encoding: identity\r\n\r\n\
+            This is a test";
+
+        let mut response_buf: [u8; 172] = [0; 172];
+        assert!(response.write_all(&mut response_buf.as_mut()).is_ok());
+        assert_eq!(response_buf.as_ref(), expected_response);
+
+        // Test a deprecated response without a body.
+        let mut response = Response::new(Version::Http10, StatusCode::NoContent);
+        response.set_deprecation();
+
+        assert_eq!(response.status(), StatusCode::NoContent);
+        assert_eq!(response.http_version(), Version::Http10);
+        assert!(response.deprecation());
+
+        let expected_response: &'static [u8] = b"HTTP/1.0 204 \r\n\
+            Server: Firecracker API\r\n\
+            Connection: keep-alive\r\n\
+            Deprecation: true\r\n\r\n";
+
+        let mut response_buf: [u8; 85] = [0; 85];
+        assert!(response.write_all(&mut response_buf.as_mut()).is_ok());
+        assert_eq!(response_buf.as_ref(), expected_response);
+    }
+
+    #[test]
+    fn test_equal() {
+        let response = Response::new(Version::Http10, StatusCode::MethodNotAllowed);
+        let another_response = Response::new(Version::Http10, StatusCode::MethodNotAllowed);
+        assert_eq!(response, another_response);
+
+        let response = Response::new(Version::Http10, StatusCode::OK);
+        let another_response = Response::new(Version::Http10, StatusCode::BadRequest);
+        assert_ne!(response, another_response);
+    }
+}

--- a/crates/db-micro-http/src/router.rs
+++ b/crates/db-micro-http/src/router.rs
@@ -1,0 +1,156 @@
+// Copyright (C) 2019 Alibaba Cloud. All rights reserved.
+// Copyright © 2019 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::hash_map::{Entry, HashMap};
+
+use crate::{MediaType, Method, Request, Response, StatusCode, Version};
+
+pub use crate::common::RouteError;
+
+/// An HTTP endpoint handler interface
+pub trait EndpointHandler<T>: Sync + Send {
+    /// Handles an HTTP request.
+    fn handle_request(&self, req: &Request, arg: &T) -> Response;
+}
+
+/// An HTTP routes structure.
+pub struct HttpRoutes<T> {
+    server_id: String,
+    prefix: String,
+    media_type: MediaType,
+    /// routes is a hash table mapping endpoint URIs to their endpoint handlers.
+    routes: HashMap<String, Box<dyn EndpointHandler<T> + Sync + Send>>,
+}
+
+impl<T: Send> HttpRoutes<T> {
+    /// Create a http request router.
+    pub fn new(server_id: String, prefix: String) -> Self {
+        HttpRoutes {
+            server_id,
+            prefix,
+            media_type: MediaType::ApplicationJson,
+            routes: HashMap::new(),
+        }
+    }
+
+    /// Register a request handler for a unique (HTTP_METHOD, HTTP_PATH) tuple.
+    ///
+    /// # Arguments
+    /// * `method`: HTTP method to assoicate with the handler.
+    /// * `path`: HTTP path to associate with the handler.
+    /// * `handler`: HTTP request handler for the (method, path) tuple.
+    pub fn add_route(
+        &mut self,
+        method: Method,
+        path: String,
+        handler: Box<dyn EndpointHandler<T> + Sync + Send>,
+    ) -> Result<(), RouteError> {
+        let full_path = format!("{}:{}{}", method.to_str(), self.prefix, path);
+        match self.routes.entry(full_path.clone()) {
+            Entry::Occupied(_) => Err(RouteError::HandlerExist(full_path)),
+            Entry::Vacant(entry) => {
+                entry.insert(handler);
+                Ok(())
+            }
+        }
+    }
+
+    /// Handle an incoming http request and generate corresponding response.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// extern crate micro_http;
+    /// use micro_http::{
+    ///     EndpointHandler, HttpRoutes, Method, StatusCode, Request, Response, Version
+    /// };
+    ///
+    /// struct HandlerArg(bool);
+    /// struct MockHandler {}
+    /// impl EndpointHandler<HandlerArg> for MockHandler {
+    ///     fn handle_request(&self, _req: &Request, _arg: &HandlerArg) -> Response {
+    ///         Response::new(Version::Http11, StatusCode::OK)
+    ///     }
+    /// }
+    ///
+    /// let mut router = HttpRoutes::new("Mock_Server".to_string(), "/api/v1".to_string());
+    /// let handler = MockHandler {};
+    /// router.add_route(Method::Get, "/func1".to_string(), Box::new(handler)).unwrap();
+    ///
+    /// let request_bytes = b"GET http://localhost/api/v1/func1 HTTP/1.1\r\n\r\n";
+    /// let request = Request::try_from(request_bytes, None).unwrap();
+    /// let arg = HandlerArg(true);
+    /// let reply = router.handle_http_request(&request, &arg);
+    /// assert_eq!(reply.status(), StatusCode::OK);
+    /// ```
+    pub fn handle_http_request(&self, request: &Request, argument: &T) -> Response {
+        let path = format!(
+            "{}:{}",
+            request.method().to_str(),
+            request.uri().get_abs_path()
+        );
+        let mut response = match self.routes.get(&path) {
+            Some(route) => route.handle_request(request, argument),
+            None => Response::new(Version::Http11, StatusCode::NotFound),
+        };
+
+        response.set_server(&self.server_id);
+        response.set_content_type(self.media_type);
+        response
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct HandlerArg(bool);
+
+    struct MockHandler {}
+
+    impl EndpointHandler<HandlerArg> for MockHandler {
+        fn handle_request(&self, _req: &Request, _arg: &HandlerArg) -> Response {
+            Response::new(Version::Http11, StatusCode::OK)
+        }
+    }
+
+    #[test]
+    fn test_create_router() {
+        let mut router = HttpRoutes::new("Mock_Server".to_string(), "/api/v1".to_string());
+        let handler = MockHandler {};
+        let res = router.add_route(Method::Get, "/func1".to_string(), Box::new(handler));
+        assert!(res.is_ok());
+        assert!(router.routes.contains_key("GET:/api/v1/func1"));
+
+        let handler = MockHandler {};
+        match router.add_route(Method::Get, "/func1".to_string(), Box::new(handler)) {
+            Err(RouteError::HandlerExist(_)) => {}
+            _ => panic!("add_route() should return error for path with existing handler"),
+        }
+
+        let handler = MockHandler {};
+        let res = router.add_route(Method::Put, "/func1".to_string(), Box::new(handler));
+        assert!(res.is_ok());
+
+        let handler = MockHandler {};
+        let res = router.add_route(Method::Get, "/func2".to_string(), Box::new(handler));
+        assert!(res.is_ok());
+    }
+
+    #[test]
+    fn test_handle_http_request() {
+        let mut router = HttpRoutes::new("Mock_Server".to_string(), "/api/v1".to_string());
+        let handler = MockHandler {};
+        router
+            .add_route(Method::Get, "/func1".to_string(), Box::new(handler))
+            .unwrap();
+
+        let request =
+            Request::try_from(b"GET http://localhost/api/v1/func2 HTTP/1.1\r\n\r\n", None).unwrap();
+        let arg = HandlerArg(true);
+        let reply = router.handle_http_request(&request, &arg);
+        assert_eq!(reply.status(), StatusCode::NotFound);
+    }
+}

--- a/crates/db-micro-http/src/server.rs
+++ b/crates/db-micro-http/src/server.rs
@@ -1,0 +1,1094 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::HashMap;
+use std::io::{Read, Write};
+use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
+use std::os::unix::net::{UnixListener, UnixStream};
+use std::path::Path;
+
+use crate::common::{Body, Version};
+pub use crate::common::{ConnectionError, RequestError, ServerError};
+use crate::connection::HttpConnection;
+use crate::request::Request;
+use crate::response::{Response, StatusCode};
+use vmm_sys_util::sock_ctrl_msg::ScmSocket;
+
+use vmm_sys_util::epoll;
+
+static SERVER_FULL_ERROR_MESSAGE: &[u8] = b"HTTP/1.1 503\r\n\
+                                            Server: Firecracker API\r\n\
+                                            Connection: close\r\n\
+                                            Content-Length: 40\r\n\r\n{ \"error\": \"Too many open connections\" }";
+const MAX_CONNECTIONS: usize = 10;
+/// Payload max size
+pub(crate) const MAX_PAYLOAD_SIZE: usize = 51200;
+
+type Result<T> = std::result::Result<T, ServerError>;
+
+/// Wrapper over `Request` which adds an identification token.
+pub struct ServerRequest {
+    /// Inner request.
+    pub request: Request,
+    /// Identification token.
+    id: u64,
+}
+
+impl ServerRequest {
+    /// Creates a new `ServerRequest` object from an existing `Request`,
+    /// adding an identification token.
+    pub fn new(request: Request, id: u64) -> Self {
+        Self { request, id }
+    }
+
+    /// Returns a reference to the inner request.
+    pub fn inner(&self) -> &Request {
+        &self.request
+    }
+
+    /// Calls the function provided on the inner request to obtain the response.
+    /// The response is then wrapped in a `ServerResponse`.
+    ///
+    /// Returns a `ServerResponse` ready for yielding to the server
+    pub fn process<F>(&self, mut callable: F) -> ServerResponse
+    where
+        F: FnMut(&Request) -> Response,
+    {
+        let http_response = callable(self.inner());
+        ServerResponse::new(http_response, self.id)
+    }
+}
+
+/// Wrapper over `Response` which adds an identification token.
+pub struct ServerResponse {
+    /// Inner response.
+    response: Response,
+    /// Identification token.
+    id: u64,
+}
+
+impl ServerResponse {
+    fn new(response: Response, id: u64) -> Self {
+        Self { response, id }
+    }
+}
+
+/// Describes the state of the connection as far as data exchange
+/// on the stream is concerned.
+#[derive(PartialOrd, PartialEq)]
+enum ClientConnectionState {
+    AwaitingIncoming,
+    AwaitingOutgoing,
+    Closed,
+}
+
+/// Wrapper over `HttpConnection` which keeps track of yielded
+/// requests and absorbed responses.
+struct ClientConnection<T> {
+    /// The `HttpConnection` object which handles data exchange.
+    connection: HttpConnection<T>,
+    /// The state of the connection in the `epoll` structure.
+    state: ClientConnectionState,
+    /// Represents the difference between yielded requests and
+    /// absorbed responses.
+    /// This has to be `0` if we want to drop the connection.
+    in_flight_response_count: u32,
+}
+
+impl<T: Read + Write + ScmSocket> ClientConnection<T> {
+    fn new(connection: HttpConnection<T>) -> Self {
+        Self {
+            connection,
+            state: ClientConnectionState::AwaitingIncoming,
+            in_flight_response_count: 0,
+        }
+    }
+
+    fn read(&mut self) -> Result<Vec<Request>> {
+        // Data came into the connection.
+        let mut parsed_requests = vec![];
+        match self.connection.try_read() {
+            Err(ConnectionError::ConnectionClosed) => {
+                // Connection timeout.
+                self.state = ClientConnectionState::Closed;
+                // We don't want to propagate this to the server and we will
+                // return no requests and wait for the connection to become
+                // safe to drop.
+                return Ok(vec![]);
+            }
+            Err(ConnectionError::StreamReadError(inner)) => {
+                // Reading from the connection failed.
+                // We should try to write an error message regardless.
+                let mut internal_error_response =
+                    Response::new(Version::Http11, StatusCode::InternalServerError);
+                internal_error_response.set_body(Body::new(inner.to_string()));
+                self.connection.enqueue_response(internal_error_response);
+            }
+            Err(ConnectionError::ParseError(inner)) => {
+                // An error occurred while parsing the read bytes.
+                // Check if there are any valid parsed requests in the queue.
+                while let Some(_discarded_request) = self.connection.pop_parsed_request() {}
+
+                // Send an error response for the request that gave us the error.
+                let mut error_response = Response::new(Version::Http11, StatusCode::BadRequest);
+                error_response.set_body(Body::new(format!(
+                    "{{ \"error\": \"{}\nAll previous unanswered requests will be dropped.\" }}",
+                    inner
+                )));
+                self.connection.enqueue_response(error_response);
+            }
+            Err(ConnectionError::InvalidWrite) | Err(ConnectionError::StreamWriteError(_)) => {
+                // This is unreachable because `HttpConnection::try_read()` cannot return this error variant.
+                unreachable!();
+            }
+            Ok(()) => {
+                while let Some(request) = self.connection.pop_parsed_request() {
+                    // Add all valid requests to `parsed_requests`.
+                    parsed_requests.push(request);
+                }
+            }
+        }
+        self.in_flight_response_count = self
+            .in_flight_response_count
+            .checked_add(parsed_requests.len() as u32)
+            .ok_or(ServerError::Overflow)?;
+        // If the state of the connection has changed, we need to update
+        // the event set in the `epoll` structure.
+        if self.connection.pending_write() {
+            self.state = ClientConnectionState::AwaitingOutgoing;
+        }
+
+        Ok(parsed_requests)
+    }
+
+    fn write(&mut self) -> Result<()> {
+        // The stream is available for writing.
+        match self.connection.try_write() {
+            Err(ConnectionError::ConnectionClosed) | Err(ConnectionError::StreamWriteError(_)) => {
+                // Writing to the stream failed so it will be removed.
+                self.state = ClientConnectionState::Closed;
+            }
+            Err(ConnectionError::InvalidWrite) => {
+                // A `try_write` call was performed on a connection that has nothing
+                // to write.
+                return Err(ServerError::ConnectionError(ConnectionError::InvalidWrite));
+            }
+            _ => {
+                // Check if we still have bytes to write for this connection.
+                if !self.connection.pending_write() {
+                    self.state = ClientConnectionState::AwaitingIncoming;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn enqueue_response(&mut self, response: Response) -> Result<()> {
+        if self.state != ClientConnectionState::Closed {
+            self.connection.enqueue_response(response);
+        }
+        self.in_flight_response_count = self
+            .in_flight_response_count
+            .checked_sub(1)
+            .ok_or(ServerError::Underflow)?;
+        Ok(())
+    }
+
+    /// Discards all pending writes from the inner connection.
+    fn clear_write_buffer(&mut self) {
+        self.connection.clear_write_buffer();
+    }
+
+    // Returns `true` if the connection is closed and safe to drop.
+    fn is_done(&self) -> bool {
+        self.state == ClientConnectionState::Closed
+            && !self.connection.pending_write()
+            && self.in_flight_response_count == 0
+    }
+}
+
+/// HTTP Server implementation using Unix Domain Sockets and `EPOLL` to
+/// handle multiple connections on the same thread.
+///
+/// The function that handles incoming connections, parses incoming
+/// requests and sends responses for awaiting requests is `requests`.
+/// It can be called in a loop, which will render the thread that the
+/// server runs on incapable of performing other operations, or it can
+/// be used in another `EPOLL` structure, as it provides its `epoll`,
+/// which is a wrapper over the file descriptor of the epoll structure
+/// used within the server, and it can be added to another one using
+/// the `EPOLLIN` flag. Whenever there is a notification on that fd,
+/// `requests` should be called once.
+///
+/// # Example
+///
+/// ## Starting and running the server
+///
+/// ```
+/// use micro_http::{HttpServer, Response, StatusCode};
+///
+/// let path_to_socket = "/tmp/example.sock";
+/// std::fs::remove_file(path_to_socket).unwrap_or_default();
+///
+/// // Start the server.
+/// let mut server = HttpServer::new(path_to_socket).unwrap();
+/// server.start_server().unwrap();
+///
+/// // Connect a client to the server so it doesn't block in our example.
+/// let mut socket = std::os::unix::net::UnixStream::connect(path_to_socket).unwrap();
+///
+/// // Server loop processing requests.
+/// loop {
+///     for request in server.requests().unwrap() {
+///         let response = request.process(|request| {
+///             // Your code here.
+///             Response::new(request.http_version(), StatusCode::NoContent)
+///         });
+///         server.respond(response);
+///     }
+///     // Break this example loop.
+///     break;
+/// }
+/// ```
+pub struct HttpServer {
+    /// Socket on which we listen for new connections.
+    socket: UnixListener,
+    /// Server's epoll instance.
+    epoll: epoll::Epoll,
+    /// Holds the token-connection pairs of the server.
+    /// Each connection has an associated identification token, which is
+    /// the file descriptor of the underlying stream.
+    /// We use the file descriptor of the stream as the key for mapping
+    /// connections because the 1-to-1 relation is guaranteed by the OS.
+    connections: HashMap<RawFd, ClientConnection<UnixStream>>,
+    /// Payload max size
+    payload_max_size: usize,
+}
+
+impl HttpServer {
+    /// Constructor for `HttpServer`.
+    ///
+    /// Returns the newly formed `HttpServer`.
+    ///
+    /// # Errors
+    /// Returns an `IOError` when binding or `epoll::create` fails.
+    pub fn new<P: AsRef<Path>>(path_to_socket: P) -> Result<Self> {
+        let socket = UnixListener::bind(path_to_socket).map_err(ServerError::IOError)?;
+        let epoll = epoll::Epoll::new().map_err(ServerError::IOError)?;
+        Ok(Self {
+            socket,
+            epoll,
+            connections: HashMap::new(),
+            payload_max_size: MAX_PAYLOAD_SIZE,
+        })
+    }
+
+    /// Constructor for `HttpServer`.
+    ///
+    /// Note that this function requires the socket_fd to be solely owned
+    /// and not be associated with another File in the caller as it uses
+    /// the unsafe `UnixListener::from_raw_fd method`.
+    ///
+    /// Returns the newly formed `HttpServer`.
+    ///
+    /// # Errors
+    /// Returns an `IOError` when `epoll::create` fails.
+    pub fn new_from_fd(socket_fd: RawFd) -> Result<Self> {
+        let socket = unsafe { UnixListener::from_raw_fd(socket_fd) };
+        let epoll = epoll::Epoll::new().map_err(ServerError::IOError)?;
+        Ok(HttpServer {
+            socket,
+            epoll,
+            connections: HashMap::new(),
+            payload_max_size: MAX_PAYLOAD_SIZE,
+        })
+    }
+
+    /// This function sets the limit for PUT/PATCH requests. It overwrites the
+    /// default limit of 0.05MiB with the one allowed by server.
+    pub fn set_payload_max_size(&mut self, request_payload_max_size: usize) {
+        self.payload_max_size = request_payload_max_size;
+    }
+
+    /// Starts the HTTP Server.
+    pub fn start_server(&mut self) -> Result<()> {
+        // Add the socket on which we listen for new connections to the
+        // `epoll` structure.
+        Self::epoll_add(&self.epoll, self.socket.as_raw_fd())
+    }
+
+    /// This function is responsible for the data exchange with the clients and should
+    /// be called when we are either notified through `epoll` that we need to exchange
+    /// data with at least a client or when we don't need to perform any other operations
+    /// on this thread and we can afford to call it in a loop.
+    ///
+    /// Note that this function will block the current thread if there are no notifications
+    /// to be handled by the server.
+    ///
+    /// Returns a collection of complete and valid requests to be processed by the user
+    /// of the server. Once processed, responses should be sent using `enqueue_responses()`.
+    ///
+    /// # Errors
+    /// `IOError` is returned when `read`, `write` or `epoll::ctl` operations fail.
+    /// `ServerFull` is returned when a client is trying to connect to the server, but
+    /// full capacity has already been reached.
+    /// `InvalidWrite` is returned when the server attempted to perform a write operation
+    /// on a connection on which it is not possible.
+    pub fn requests(&mut self) -> Result<Vec<ServerRequest>> {
+        let mut parsed_requests: Vec<ServerRequest> = vec![];
+        let mut events = vec![epoll::EpollEvent::default(); MAX_CONNECTIONS];
+        // This is a wrapper over the syscall `epoll_wait` and it will block the
+        // current thread until at least one event is received.
+        // The received notifications will then populate the `events` array with
+        // `event_count` elements, where 1 <= event_count <= MAX_CONNECTIONS.
+        let event_count = match self.epoll.wait(-1, &mut events[..]) {
+            Ok(event_count) => event_count,
+            Err(e) if e.raw_os_error() == Some(libc::EINTR) => 0,
+            Err(e) => return Err(ServerError::IOError(e)),
+        };
+        // We use `take()` on the iterator over `events` as, even though only
+        // `events_count` events have been inserted into `events`, the size of
+        // the array is still `MAX_CONNECTIONS`, so we discard empty elements
+        // at the end of the array.
+        for e in events.iter().take(event_count) {
+            // Check the file descriptor which produced the notification `e`.
+            // It could be that we have a new connection, or one of our open
+            // connections is ready to exchange data with a client.
+            if e.fd() == self.socket.as_raw_fd() {
+                // We have received a notification on the listener socket, which
+                // means we have a new connection to accept.
+                match self.handle_new_connection() {
+                    // If the server is full, we send a message to the client
+                    // notifying them that we will close the connection, then
+                    // we discard it.
+                    Err(ServerError::ServerFull) => {
+                        self.socket
+                            .accept()
+                            .map_err(ServerError::IOError)
+                            .and_then(move |(mut stream, _)| {
+                                stream
+                                    .write(SERVER_FULL_ERROR_MESSAGE)
+                                    .map_err(ServerError::IOError)
+                            })?;
+                    }
+                    // An internal error will compromise any in-flight requests.
+                    Err(error) => return Err(error),
+                    Ok(()) => {}
+                };
+            } else {
+                // We have a notification on one of our open connections.
+                let fd = e.fd();
+                let client_connection = self.connections.get_mut(&fd).unwrap();
+
+                // If we receive a hang up on a connection, we clear the write buffer and set
+                // the connection state to closed to mark it ready for removal from the
+                // connections map, which will gracefully close the socket.
+                // The connection is also marked for removal when encountering `EPOLLERR`,
+                // since this is an "error condition happened on the associated file
+                // descriptor", according to the `epoll_ctl` man page.
+                if e.event_set().contains(epoll::EventSet::ERROR)
+                    || e.event_set().contains(epoll::EventSet::HANG_UP)
+                    || e.event_set().contains(epoll::EventSet::READ_HANG_UP)
+                {
+                    client_connection.clear_write_buffer();
+                    client_connection.state = ClientConnectionState::Closed;
+                    continue;
+                }
+
+                if e.event_set().contains(epoll::EventSet::IN) {
+                    // We have bytes to read from this connection.
+                    // If our `read` yields `Request` objects, we wrap them with an ID before
+                    // handing them to the user.
+                    parsed_requests.append(
+                        &mut client_connection
+                            .read()?
+                            .into_iter()
+                            .map(|request| ServerRequest::new(request, e.data()))
+                            .collect(),
+                    );
+                    // If the connection was incoming before we read and we now have to write
+                    // either an error message or an `expect` response, we change its `epoll`
+                    // event set to notify us when the stream is ready for writing.
+                    if client_connection.state == ClientConnectionState::AwaitingOutgoing {
+                        Self::epoll_mod(
+                            &self.epoll,
+                            fd,
+                            epoll::EventSet::OUT | epoll::EventSet::READ_HANG_UP,
+                        )?;
+                    }
+                } else if e.event_set().contains(epoll::EventSet::OUT) {
+                    // We have bytes to write on this connection.
+                    client_connection.write()?;
+                    // If the connection was outgoing before we tried to write the responses
+                    // and we don't have any more responses to write, we change the `epoll`
+                    // event set to notify us when we have bytes to read from the stream.
+                    if client_connection.state == ClientConnectionState::AwaitingIncoming {
+                        Self::epoll_mod(
+                            &self.epoll,
+                            fd,
+                            epoll::EventSet::IN | epoll::EventSet::READ_HANG_UP,
+                        )?;
+                    }
+                }
+            }
+        }
+
+        // Remove dead connections.
+        let epoll = &self.epoll;
+        self.connections.retain(|rawfd, client_connection| {
+            if client_connection.is_done() {
+                // The rawfd should have been registered to the epoll fd.
+                Self::epoll_del(epoll, *rawfd).unwrap();
+                false
+            } else {
+                true
+            }
+        });
+
+        Ok(parsed_requests)
+    }
+
+    /// This function is responsible with flushing any remaining outgoing
+    /// requests on the server.
+    ///
+    /// Note that this function can block the thread on write, since the
+    /// operation is blocking.
+    pub fn flush_outgoing_writes(&mut self) {
+        for (_, connection) in self.connections.iter_mut() {
+            while connection.state == ClientConnectionState::AwaitingOutgoing {
+                if let Err(e) = connection.write() {
+                    if let ServerError::ConnectionError(ConnectionError::InvalidWrite) = e {
+                        // Nothing is logged since an InvalidWrite means we have successfully
+                        // flushed the connection
+                    }
+                    break;
+                }
+            }
+        }
+    }
+
+    /// The file descriptor of the `epoll` structure can enable the server to become
+    /// a non-blocking structure in an application.
+    ///
+    /// Returns a reference to the instance of the server's internal `epoll` structure.
+    ///
+    /// # Example
+    ///
+    /// ## Non-blocking server
+    /// ```
+    /// use std::os::unix::io::AsRawFd;
+    ///
+    /// use micro_http::{HttpServer, Response, StatusCode};
+    /// use vmm_sys_util::epoll;
+    ///
+    /// // Create our epoll manager.
+    /// let epoll = epoll::Epoll::new().unwrap();
+    ///
+    /// let path_to_socket = "/tmp/epoll_example.sock";
+    /// std::fs::remove_file(path_to_socket).unwrap_or_default();
+    ///
+    /// // Start the server.
+    /// let mut server = HttpServer::new(path_to_socket).unwrap();
+    /// server.start_server().unwrap();
+    ///
+    /// // Add our server to the `epoll` manager.
+    /// epoll.ctl(
+    ///     epoll::ControlOperation::Add,
+    ///     server.epoll().as_raw_fd(),
+    ///     epoll::EpollEvent::new(epoll::EventSet::IN, 1234u64),
+    /// )
+    /// .unwrap();
+    ///
+    /// // Connect a client to the server so it doesn't block in our example.
+    /// let mut socket = std::os::unix::net::UnixStream::connect(path_to_socket).unwrap();
+    ///
+    /// // Control loop of the application.
+    /// let mut events = Vec::with_capacity(10);
+    /// loop {
+    ///     let num_ev = epoll.wait(-1, events.as_mut_slice());
+    ///     for event in events {
+    ///         match event.data() {
+    ///             // The server notification.
+    ///             1234 => {
+    ///                 let request = server.requests();
+    ///                 // Process...
+    ///             }
+    ///             // Other `epoll` notifications.
+    ///             _ => {
+    ///                 // Do other computation.
+    ///             }
+    ///         }
+    ///     }
+    ///     // Break this example loop.
+    ///     break;
+    /// }
+    /// ```
+    pub fn epoll(&self) -> &epoll::Epoll {
+        &self.epoll
+    }
+
+    /// Enqueues the provided responses in the outgoing connection.
+    ///
+    /// # Errors
+    /// `IOError` is returned when an `epoll::ctl` operation fails.
+    pub fn enqueue_responses(&mut self, responses: Vec<ServerResponse>) -> Result<()> {
+        for response in responses {
+            self.respond(response)?;
+        }
+
+        Ok(())
+    }
+
+    /// Adds the provided response to the outgoing buffer in the corresponding connection.
+    ///
+    /// # Errors
+    /// `IOError` is returned when an `epoll::ctl` operation fails.
+    /// `Underflow` is returned when `enqueue_response` fails.
+    pub fn respond(&mut self, response: ServerResponse) -> Result<()> {
+        if let Some(client_connection) = self.connections.get_mut(&(response.id as i32)) {
+            // If the connection was incoming before we enqueue the response, we change its
+            // `epoll` event set to notify us when the stream is ready for writing.
+            if let ClientConnectionState::AwaitingIncoming = client_connection.state {
+                client_connection.state = ClientConnectionState::AwaitingOutgoing;
+                Self::epoll_mod(
+                    &self.epoll,
+                    response.id as RawFd,
+                    epoll::EventSet::OUT | epoll::EventSet::READ_HANG_UP,
+                )?;
+            }
+            client_connection.enqueue_response(response.response)?;
+        }
+        Ok(())
+    }
+
+    /// Accepts a new incoming connection and adds it to the `epoll` notification structure.
+    ///
+    /// # Errors
+    /// `IOError` is returned when socket or epoll operations fail.
+    /// `ServerFull` is returned if server full capacity has been reached.
+    fn handle_new_connection(&mut self) -> Result<()> {
+        if self.connections.len() == MAX_CONNECTIONS {
+            // If we want a replacement policy for connections
+            // this is where we will have it.
+            return Err(ServerError::ServerFull);
+        }
+
+        self.socket
+            .accept()
+            .map_err(ServerError::IOError)
+            .and_then(|(stream, _)| {
+                // `HttpConnection` is supposed to work with non-blocking streams.
+                stream
+                    .set_nonblocking(true)
+                    .map(|_| stream)
+                    .map_err(ServerError::IOError)
+            })
+            .and_then(|stream| {
+                // Add the stream to the `epoll` structure and listen for bytes to be read.
+                let raw_fd = stream.as_raw_fd();
+                Self::epoll_add(&self.epoll, raw_fd)?;
+                let mut conn = HttpConnection::new(stream);
+                conn.set_payload_max_size(self.payload_max_size);
+                // Then add it to our open connections.
+                self.connections.insert(raw_fd, ClientConnection::new(conn));
+                Ok(())
+            })
+    }
+
+    /// Changes the event type for a connection to either listen for incoming bytes
+    /// or for when the stream is ready for writing.
+    ///
+    /// # Errors
+    /// `IOError` is returned when an `EPOLL_CTL_MOD` control operation fails.
+    fn epoll_mod(epoll: &epoll::Epoll, stream_fd: RawFd, evset: epoll::EventSet) -> Result<()> {
+        let event = epoll::EpollEvent::new(evset, stream_fd as u64);
+        epoll
+            .ctl(epoll::ControlOperation::Modify, stream_fd, event)
+            .map_err(ServerError::IOError)
+    }
+
+    /// Adds a stream to the `epoll` notification structure with the `EPOLLIN` event set.
+    ///
+    /// # Errors
+    /// `IOError` is returned when an `EPOLL_CTL_ADD` control operation fails.
+    fn epoll_add(epoll: &epoll::Epoll, stream_fd: RawFd) -> Result<()> {
+        epoll
+            .ctl(
+                epoll::ControlOperation::Add,
+                stream_fd,
+                epoll::EpollEvent::new(
+                    epoll::EventSet::IN | epoll::EventSet::READ_HANG_UP,
+                    stream_fd as u64,
+                ),
+            )
+            .map_err(ServerError::IOError)
+    }
+
+    /// Removes a stream to the `epoll` notification structure.
+    fn epoll_del(epoll: &epoll::Epoll, stream_fd: RawFd) -> Result<()> {
+        epoll
+            .ctl(
+                epoll::ControlOperation::Delete,
+                stream_fd,
+                epoll::EpollEvent::new(epoll::EventSet::IN, stream_fd as u64),
+            )
+            .map_err(ServerError::IOError)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{Read, Write};
+    use std::net::Shutdown;
+    use std::os::unix::net::UnixStream;
+
+    use crate::common::Body;
+    use vmm_sys_util::tempfile::TempFile;
+
+    fn get_temp_socket_file() -> TempFile {
+        let mut path_to_socket = TempFile::new().unwrap();
+        path_to_socket.remove().unwrap();
+        path_to_socket
+    }
+
+    #[test]
+    fn test_wait_one_connection() {
+        let path_to_socket = get_temp_socket_file();
+
+        let mut server = HttpServer::new(path_to_socket.as_path()).unwrap();
+        server.start_server().unwrap();
+
+        // Test one incoming connection.
+        let mut socket = UnixStream::connect(path_to_socket.as_path()).unwrap();
+        assert!(server.requests().unwrap().is_empty());
+
+        socket
+            .write_all(
+                b"PATCH /machine-config HTTP/1.1\r\n\
+                         Content-Length: 13\r\n\
+                         Content-Type: application/json\r\n\r\nwhatever body",
+            )
+            .unwrap();
+
+        let mut req_vec = server.requests().unwrap();
+        let server_request = req_vec.remove(0);
+
+        server
+            .respond(server_request.process(|_request| {
+                let mut response = Response::new(Version::Http11, StatusCode::OK);
+                let response_body = b"response body";
+                response.set_body(Body::new(response_body.to_vec()));
+                response
+            }))
+            .unwrap();
+        assert!(server.requests().unwrap().is_empty());
+
+        let mut buf: [u8; 1024] = [0; 1024];
+        assert!(socket.read(&mut buf[..]).unwrap() > 0);
+    }
+
+    #[test]
+    fn test_connection_size_limit_exceeded() {
+        let path_to_socket = get_temp_socket_file();
+
+        let mut server = HttpServer::new(path_to_socket.as_path()).unwrap();
+        server.start_server().unwrap();
+
+        // Test one incoming connection.
+        let mut socket = UnixStream::connect(path_to_socket.as_path()).unwrap();
+        assert!(server.requests().unwrap().is_empty());
+
+        socket
+            .write_all(
+                b"PATCH /machine-config HTTP/1.1\r\n\
+                         Content-Length: 51201\r\n\
+                         Content-Type: application/json\r\n\r\naaaaa",
+            )
+            .unwrap();
+        assert!(server.requests().unwrap().is_empty());
+        assert!(server.requests().unwrap().is_empty());
+        let mut buf: [u8; 265] = [0; 265];
+        assert!(socket.read(&mut buf[..]).unwrap() > 0);
+        let error_message = b"HTTP/1.1 400 \r\n\
+                              Server: Firecracker API\r\n\
+                              Connection: keep-alive\r\n\
+                              Content-Type: application/json\r\n\
+                              Content-Length: 149\r\n\r\n{ \"error\": \"\
+                              Request payload with size 51201 is larger than \
+                              the limit of 51200 allowed by server.\nAll \
+                              previous unanswered requests will be dropped.";
+        assert_eq!(&buf[..], &error_message[..]);
+    }
+
+    #[test]
+    fn test_set_payload_size() {
+        let path_to_socket = get_temp_socket_file();
+
+        let mut server = HttpServer::new(path_to_socket.as_path()).unwrap();
+        server.start_server().unwrap();
+        server.set_payload_max_size(4);
+
+        // Test one incoming connection.
+        let mut socket = UnixStream::connect(path_to_socket.as_path()).unwrap();
+        assert!(server.requests().unwrap().is_empty());
+
+        socket
+            .write_all(
+                b"PATCH /machine-config HTTP/1.1\r\n\
+                         Content-Length: 5\r\n\
+                         Content-Type: application/json\r\n\r\naaaaa",
+            )
+            .unwrap();
+        assert!(server.requests().unwrap().is_empty());
+        assert!(server.requests().unwrap().is_empty());
+        let mut buf: [u8; 260] = [0; 260];
+        assert!(socket.read(&mut buf[..]).unwrap() > 0);
+        let error_message = b"HTTP/1.1 400 \r\n\
+                              Server: Firecracker API\r\n\
+                              Connection: keep-alive\r\n\
+                              Content-Type: application/json\r\n\
+                              Content-Length: 141\r\n\r\n{ \"error\": \"\
+                              Request payload with size 5 is larger than the \
+                              limit of 4 allowed by server.\nAll previous \
+                              unanswered requests will be dropped.\" }";
+        assert_eq!(&buf[..], &error_message[..]);
+    }
+
+    #[test]
+    fn test_wait_one_fd_connection() {
+        use std::os::unix::io::IntoRawFd;
+        let path_to_socket = get_temp_socket_file();
+
+        let socket_listener = UnixListener::bind(path_to_socket.as_path()).unwrap();
+        let socket_fd = socket_listener.into_raw_fd();
+
+        let mut server = HttpServer::new_from_fd(socket_fd).unwrap();
+        server.start_server().unwrap();
+
+        // Test one incoming connection.
+        let mut socket = UnixStream::connect(path_to_socket.as_path()).unwrap();
+        assert!(server.requests().unwrap().is_empty());
+
+        socket
+            .write_all(
+                b"PATCH /machine-config HTTP/1.1\r\n\
+                         Content-Length: 13\r\n\
+                         Content-Type: application/json\r\n\r\nwhatever body",
+            )
+            .unwrap();
+
+        let mut req_vec = server.requests().unwrap();
+        let server_request = req_vec.remove(0);
+
+        server
+            .respond(server_request.process(|request| {
+                assert_eq!(
+                    std::str::from_utf8(&request.body.as_ref().unwrap().body).unwrap(),
+                    "whatever body"
+                );
+                let mut response = Response::new(Version::Http11, StatusCode::OK);
+                let response_body = b"response body";
+                response.set_body(Body::new(response_body.to_vec()));
+                response
+            }))
+            .unwrap();
+        assert!(server.requests().unwrap().is_empty());
+
+        let mut buf: [u8; 1024] = [0; 1024];
+        assert!(socket.read(&mut buf[..]).unwrap() > 0);
+        assert!(String::from_utf8_lossy(&buf).contains("response body"));
+    }
+
+    #[test]
+    fn test_wait_concurrent_connections() {
+        let path_to_socket = get_temp_socket_file();
+
+        let mut server = HttpServer::new(path_to_socket.as_path()).unwrap();
+        server.start_server().unwrap();
+
+        // Test two concurrent connections.
+        let mut first_socket = UnixStream::connect(path_to_socket.as_path()).unwrap();
+        assert!(server.requests().unwrap().is_empty());
+
+        first_socket
+            .write_all(
+                b"PATCH /machine-config HTTP/1.1\r\n\
+                               Content-Length: 13\r\n\
+                               Content-Type: application/json\r\n\r\nwhatever body",
+            )
+            .unwrap();
+        let mut second_socket = UnixStream::connect(path_to_socket.as_path()).unwrap();
+
+        let mut req_vec = server.requests().unwrap();
+        let server_request = req_vec.remove(0);
+
+        server
+            .respond(server_request.process(|_request| {
+                let mut response = Response::new(Version::Http11, StatusCode::OK);
+                let response_body = b"response body";
+                response.set_body(Body::new(response_body.to_vec()));
+                response
+            }))
+            .unwrap();
+        second_socket
+            .write_all(
+                b"GET /machine-config HTTP/1.1\r\n\
+                                Content-Type: application/json\r\n\r\n",
+            )
+            .unwrap();
+
+        let mut req_vec = server.requests().unwrap();
+        let second_server_request = req_vec.remove(0);
+
+        assert_eq!(
+            second_server_request.request,
+            Request::try_from(
+                b"GET /machine-config HTTP/1.1\r\n\
+            Content-Type: application/json\r\n\r\n",
+                None
+            )
+            .unwrap()
+        );
+
+        let mut buf: [u8; 1024] = [0; 1024];
+        assert!(first_socket.read(&mut buf[..]).unwrap() > 0);
+        first_socket.shutdown(std::net::Shutdown::Both).unwrap();
+
+        server
+            .respond(second_server_request.process(|_request| {
+                let mut response = Response::new(Version::Http11, StatusCode::OK);
+                let response_body = b"response second body";
+                response.set_body(Body::new(response_body.to_vec()));
+                response
+            }))
+            .unwrap();
+
+        assert!(server.requests().unwrap().is_empty());
+        let mut buf: [u8; 1024] = [0; 1024];
+        assert!(second_socket.read(&mut buf[..]).unwrap() > 0);
+        second_socket.shutdown(std::net::Shutdown::Both).unwrap();
+        assert!(server.requests().unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_wait_expect_connection() {
+        let path_to_socket = get_temp_socket_file();
+
+        let mut server = HttpServer::new(path_to_socket.as_path()).unwrap();
+        server.start_server().unwrap();
+
+        // Test one incoming connection with `Expect: 100-continue`.
+        let mut socket = UnixStream::connect(path_to_socket.as_path()).unwrap();
+        assert!(server.requests().unwrap().is_empty());
+
+        socket
+            .write_all(
+                b"PATCH /machine-config HTTP/1.1\r\n\
+                         Content-Length: 13\r\n\
+                         Expect: 100-continue\r\n\r\n",
+            )
+            .unwrap();
+        // `wait` on server to receive what the client set on the socket.
+        // This will set the stream direction to `Outgoing`, as we need to send a `100 CONTINUE` response.
+        let req_vec = server.requests().unwrap();
+        assert!(req_vec.is_empty());
+        // Another `wait`, this time to send the response.
+        // Will be called because of an `EPOLLOUT` notification.
+        let req_vec = server.requests().unwrap();
+        assert!(req_vec.is_empty());
+        let mut buf: [u8; 1024] = [0; 1024];
+        assert!(socket.read(&mut buf[..]).unwrap() > 0);
+
+        socket.write_all(b"whatever body").unwrap();
+        let mut req_vec = server.requests().unwrap();
+        let server_request = req_vec.remove(0);
+
+        server
+            .respond(server_request.process(|_request| {
+                let mut response = Response::new(Version::Http11, StatusCode::OK);
+                let response_body = b"response body";
+                response.set_body(Body::new(response_body.to_vec()));
+                response
+            }))
+            .unwrap();
+
+        let req_vec = server.requests().unwrap();
+        assert!(req_vec.is_empty());
+
+        let mut buf: [u8; 1024] = [0; 1024];
+        assert!(socket.read(&mut buf[..]).unwrap() > 0);
+    }
+
+    #[test]
+    fn test_wait_many_connections() {
+        let path_to_socket = get_temp_socket_file();
+
+        let mut server = HttpServer::new(path_to_socket.as_path()).unwrap();
+        server.start_server().unwrap();
+
+        let mut sockets: Vec<UnixStream> = Vec::with_capacity(MAX_CONNECTIONS + 1);
+        for _ in 0..MAX_CONNECTIONS {
+            sockets.push(UnixStream::connect(path_to_socket.as_path()).unwrap());
+            assert!(server.requests().unwrap().is_empty());
+        }
+
+        sockets.push(UnixStream::connect(path_to_socket.as_path()).unwrap());
+        assert!(server.requests().unwrap().is_empty());
+        let mut buf: [u8; 120] = [0; 120];
+        sockets[MAX_CONNECTIONS].read_exact(&mut buf).unwrap();
+        assert_eq!(&buf[..], SERVER_FULL_ERROR_MESSAGE);
+        assert_eq!(server.connections.len(), 10);
+        {
+            // Drop this stream.
+            let _refused_stream = sockets.pop().unwrap();
+        }
+        assert_eq!(server.connections.len(), 10);
+
+        // Check that the server detects a connection shutdown.
+        let sock: &UnixStream = sockets.get(0).unwrap();
+        sock.shutdown(Shutdown::Both).unwrap();
+        assert!(server.requests().unwrap().is_empty());
+        // Server should drop a closed connection.
+        assert_eq!(server.connections.len(), 9);
+
+        // Close the backing FD of this connection by dropping
+        // it out of scope.
+        {
+            // Enforce the drop call on the stream
+            let _sock = sockets.pop().unwrap();
+        }
+        assert!(server.requests().unwrap().is_empty());
+        // Server should drop a closed connection.
+        assert_eq!(server.connections.len(), 8);
+
+        let sock: &UnixStream = sockets.get(1).unwrap();
+        // Close both the read and write sides of the socket
+        // separately and check that the server detects it.
+        sock.shutdown(Shutdown::Read).unwrap();
+        sock.shutdown(Shutdown::Write).unwrap();
+        assert!(server.requests().unwrap().is_empty());
+        // Server should drop a closed connection.
+        assert_eq!(server.connections.len(), 7);
+    }
+
+    #[test]
+    fn test_wait_parse_error() {
+        let path_to_socket = get_temp_socket_file();
+
+        let mut server = HttpServer::new(path_to_socket.as_path()).unwrap();
+        server.start_server().unwrap();
+
+        // Test one incoming connection.
+        let mut socket = UnixStream::connect(path_to_socket.as_path()).unwrap();
+        socket.set_nonblocking(true).unwrap();
+        assert!(server.requests().unwrap().is_empty());
+
+        socket
+            .write_all(
+                b"PATCH /machine-config HTTP/1.1\r\n\
+                         Content-Length: alpha\r\n\
+                         Content-Type: application/json\r\n\r\nwhatever body",
+            )
+            .unwrap();
+
+        assert!(server.requests().unwrap().is_empty());
+        assert!(server.requests().unwrap().is_empty());
+        let mut buf: [u8; 255] = [0; 255];
+        assert!(socket.read(&mut buf[..]).unwrap() > 0);
+        let error_message = b"HTTP/1.1 400 \r\n\
+                              Server: Firecracker API\r\n\
+                              Connection: keep-alive\r\n\
+                              Content-Type: application/json\r\n\
+                              Content-Length: 136\r\n\r\n{ \"error\": \"Invalid header. \
+                              Reason: Invalid value. Key:Content-Length; Value: alpha\nAll previous unanswered requests will be dropped.\" }";
+        assert_eq!(&buf[..], &error_message[..]);
+
+        socket
+            .write_all(
+                b"PATCH /machine-config HTTP/1.1\r\n\
+                         Content-Length: alpha\r\n\
+                         Content-Type: application/json\r\n\r\nwhatever body",
+            )
+            .unwrap();
+    }
+
+    #[test]
+    fn test_wait_in_flight_responses() {
+        let path_to_socket = get_temp_socket_file();
+
+        let mut server = HttpServer::new(path_to_socket.as_path()).unwrap();
+        server.start_server().unwrap();
+
+        // Test a connection dropped and then a new one appearing
+        // before the user had a chance to send the response to the
+        // first one.
+        let mut first_socket = UnixStream::connect(path_to_socket.as_path()).unwrap();
+        assert!(server.requests().unwrap().is_empty());
+
+        first_socket
+            .write_all(
+                b"PATCH /machine-config HTTP/1.1\r\n\
+                               Content-Length: 13\r\n\
+                               Content-Type: application/json\r\n\r\nwhatever body",
+            )
+            .unwrap();
+
+        let mut req_vec = server.requests().unwrap();
+        let server_request = req_vec.remove(0);
+
+        first_socket.shutdown(std::net::Shutdown::Both).unwrap();
+        assert!(server.requests().unwrap().is_empty());
+        let mut second_socket = UnixStream::connect(path_to_socket.as_path()).unwrap();
+        second_socket.set_nonblocking(true).unwrap();
+        assert!(server.requests().unwrap().is_empty());
+
+        server
+            .enqueue_responses(vec![server_request.process(|_request| {
+                let mut response = Response::new(Version::Http11, StatusCode::OK);
+                let response_body = b"response body";
+                response.set_body(Body::new(response_body.to_vec()));
+                response
+            })])
+            .unwrap();
+        assert!(server.requests().unwrap().is_empty());
+        assert_eq!(server.connections.len(), 1);
+        let mut buf: [u8; 1024] = [0; 1024];
+        assert!(second_socket.read(&mut buf[..]).is_err());
+
+        second_socket
+            .write_all(
+                b"GET /machine-config HTTP/1.1\r\n\
+                                Content-Type: application/json\r\n\r\n",
+            )
+            .unwrap();
+
+        let mut req_vec = server.requests().unwrap();
+        let second_server_request = req_vec.remove(0);
+
+        assert_eq!(
+            second_server_request.request,
+            Request::try_from(
+                b"GET /machine-config HTTP/1.1\r\n\
+            Content-Type: application/json\r\n\r\n",
+                None
+            )
+            .unwrap()
+        );
+
+        server
+            .respond(second_server_request.process(|_request| {
+                let mut response = Response::new(Version::Http11, StatusCode::OK);
+                let response_body = b"response second body";
+                response.set_body(Body::new(response_body.to_vec()));
+                response
+            }))
+            .unwrap();
+
+        assert!(server.requests().unwrap().is_empty());
+        let mut buf: [u8; 1024] = [0; 1024];
+        assert!(second_socket.read(&mut buf[..]).unwrap() > 0);
+        second_socket.shutdown(std::net::Shutdown::Both).unwrap();
+        assert!(server.requests().is_ok());
+    }
+}

--- a/crates/db-micro-http/src/vmm/src/vmm_config/mmds.rs
+++ b/crates/db-micro-http/src/vmm/src/vmm_config/mmds.rs
@@ -1,0 +1,22 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use serde::{export::Formatter, Deserialize};
+use std::fmt::{Display, Result};
+use std::net::Ipv4Addr;
+
+/// Keeps the MMDS configuration.
+#[derive(Debug, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct MmdsConfig {
+    /// MMDS IPv4 configured address.
+    ipv4_address: Option<Ipv4Addr>,
+}
+
+impl MmdsConfig {
+    /// Returns the MMDS IPv4 address if one was configured.
+    /// Otherwise returns None.
+    pub fn ipv4_addr(&self) -> Option<Ipv4Addr> {
+        self.ipv4_address
+    }
+}


### PR DESCRIPTION
This commit introduce db-micro-http for handling HTTP 1.0 and 1.1
protocols.
More change and optimization will be introduced in later commits.

Signed-off-by: Chao Wu <chaowu@linux.alibaba.com>