### PR TITLE
db-address-space: refine the implementation of address-space.rs

### DIFF
--- a/crates/db-address-space/Cargo.toml
+++ b/crates/db-address-space/Cargo.toml
@@ -6,18 +6,19 @@ license = "Apache-2.0"
 edition = "2018"
 homepage = "https://github.com/openanolis/dragonball-sandbox"
 repository = "https://github.com/openanolis/dragonball-sandbox"
-keywords = ["dragonball", "address"]
+keywords = ["dragonball", "address", "vmm", "secure-sandbox"]
 readme = "README.md"
 
 [dependencies]
-arc-swap = ">=0.4.8"
-libc = ">=0.2.39"
-nix = ">=0.15.0"
+libc = "0.2.39"
+nix = "0.15"
 thiserror = "1"
-vmm-sys-util = ">=0.8.0"
-vm-memory = { version = "0.7.0", features = ["backend-mmap"] }
+vmm-sys-util = "0.8"
+vm-memory = { version = "0.7", features = ["backend-mmap"] }
+
+arc-swap = { version = ">=0.4.8", optional = true }
 
 [features]
 default = []
-memory-hotplug = ["atomic-guest-memory"]
-atomic-guest-memory = ["vm-memory/backend-atomic"]
+memory-hotplug = ["region-hotplug"]
+region-hotplug = ["vm-memory/backend-atomic", "arc-swap"]

--- a/crates/db-address-space/src/lib.rs
+++ b/crates/db-address-space/src/lib.rs
@@ -3,13 +3,21 @@
 
 #![deny(missing_docs)]
 
-//! Address Manager traits and implementation.
+//! Traits and Structs to manage guest physical address space for virtual machines.
+//!
+//! The [vm-memory](https://crates.io/crates/vm-memory) implements mechanisms to manage and access
+//! guest memory resident in guest physical address space. In addition to guest memory, there may
+//! be other type of devices resident in the same guest physical address space.
+//!
+//! The `db-address-space` crate provides traits and structs to manage the guest physical address
+//! space for virtual machines, and mechanisms to coordinate all the devices resident in the
+//! guest physical address space.
 
 pub mod numa;
-pub use numa::{NumaIdTable, NumaNode, NumaNodeInfo, MPOL_MF_MOVE, MPOL_PREFERRED};
+pub use self::numa::{NumaIdTable, NumaNode, NumaNodeInfo, MPOL_MF_MOVE, MPOL_PREFERRED};
 
 pub mod address_space;
 pub use self::address_space::{
-    AddressSpace, AddressSpaceBoundary, AddressSpaceError, AddressSpaceInternal,
-    AddressSpaceRegion, AddressSpaceRegionType,
+    AddressSpace, AddressSpaceBase, AddressSpaceError, AddressSpaceLayout, AddressSpaceRegion,
+    AddressSpaceRegionType,
 };


### PR DESCRIPTION
Refine the implementation of address-space.rs by:
1) enforce strict validation
2) rename feature "atomic-guest-memory" to "region-hotplug"
3) rename AddressSpaceBoundary to AddressSpaceLayout

Signed-off-by: Liu Jiang <gerry@linux.alibaba.com>