### PR TITLE
uniform the form of dependent versions in Cargo.toml & reorganize the order of `use` declarations

### DIFF
--- a/crates/db-address-space/Cargo.toml
+++ b/crates/db-address-space/Cargo.toml
@@ -10,11 +10,11 @@ keywords = ["dragonball", "address"]
 readme = "README.md"
 
 [dependencies]
-arc-swap = ">=0.4.8"
-libc = ">=0.2.39"
-nix = ">=0.15.0"
+arc-swap = "1.5.0"
+libc = "0.2.0"
+nix = "0.23.0"
 thiserror = "1"
-vmm-sys-util = ">=0.8.0"
+vmm-sys-util = "0.9.0"
 vm-memory = { version = "0.7.0", features = ["backend-mmap"] }
 
 [features]

--- a/crates/db-allocator/src/lib.rs
+++ b/crates/db-allocator/src/lib.rs
@@ -7,7 +7,9 @@
 
 mod interval_tree;
 pub use interval_tree::{IntervalTree, NodeState, Range};
+
 use std::result;
+
 use thiserror::Error;
 
 /// Error conditions that may appear during `Allocator` related operations.

--- a/crates/db-arch/Cargo.toml
+++ b/crates/db-arch/Cargo.toml
@@ -10,10 +10,10 @@ keywords = ["dragonball", "arch", "ARM64", "x86", "VMM"]
 readme = "README.md"
 
 [dependencies]
-kvm-bindings = { version = ">=0.5.0", features = ["fam-wrappers"] }
-kvm-ioctls = ">=0.9.0"
-vm-memory = { version = "0.7", features = ["backend-mmap"] }
-vmm-sys-util = ">=0.8.0"
+kvm-bindings = { version = "0.5.0", features = ["fam-wrappers"] }
+kvm-ioctls = "0.9.0"
+vm-memory = { version = "0.7.0", features = ["backend-mmap"] }
+vmm-sys-util = "0.9.0"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/db-arch/src/x86_64/cpuid/mod.rs
+++ b/crates/db-arch/src/x86_64/cpuid/mod.rs
@@ -9,12 +9,11 @@
 //! Utilities for configuring the CPUID (CPU identification) for the guest microVM.
 
 pub mod bit_helper;
-pub mod cpu_leaf;
-
 mod brand_string;
 mod common;
-mod transformer;
+pub mod cpu_leaf;
 
+mod transformer;
 pub use transformer::{Error, VmSpec, VpmuFeatureLevel};
 
 type CpuId = kvm_bindings::CpuId;

--- a/crates/db-arch/src/x86_64/regs.rs
+++ b/crates/db-arch/src/x86_64/regs.rs
@@ -11,11 +11,11 @@
 
 use std::mem;
 
-use super::gdt::{gdt_entry, kvm_segment_from_gdt};
-
 use kvm_bindings::{kvm_fpu, kvm_sregs};
 use kvm_ioctls::VcpuFd;
 use vm_memory::{Address, Bytes, GuestAddress, GuestMemory};
+
+use super::gdt::{gdt_entry, kvm_segment_from_gdt};
 
 // Initial pagetables.
 pub const PML4_START: u64 = 0x9000;

--- a/crates/db-boot/Cargo.toml
+++ b/crates/db-boot/Cargo.toml
@@ -12,4 +12,4 @@ readme = "README.md"
 [dependencies]
 thiserror = "1"
 vm-memory = { version = "0.7.0", features = ["backend-mmap"] }
-libc = "0.2.39"
+libc = "0.2"

--- a/crates/db-boot/src/x86_64/mptable.rs
+++ b/crates/db-boot/src/x86_64/mptable.rs
@@ -8,14 +8,15 @@
 
 //! MP Table configurations used for defining VM boot status.
 
-use libc::c_char;
 use std::io;
 use std::mem;
 use std::result;
 use std::slice;
 
-use super::mpspec;
+use libc::c_char;
 use vm_memory::{Address, ByteValued, Bytes, GuestAddress, GuestMemory};
+
+use super::mpspec;
 
 // This is a workaround to the Rust enforcement specifying that any implementation of a foreign
 // trait (in this case `ByteValued`) where:


### PR DESCRIPTION
commit 0ed2d60acd04ffd571a46b35e18162925d1af55d (HEAD -> jason/better-crate-version, origin/jason/better-crate-version)
Author: Zizheng Bian <zizheng.bian@linux.alibaba.com>
Date:   Fri Feb 18 19:24:52 2022 +0800

    refactor: reorganize the order of `use` declarations
    
    uniform the order of `use` declarations by the order of std, other crates, and
    current crate.
    
    Signed-off-by: Zizheng Bian <zizheng.bian@linux.alibaba.com>

commit 399e133b4f95333bc52942d7fd0a057d88d2d8c0
Author: Zizheng Bian <zizheng.bian@linux.alibaba.com>
Date:   Fri Feb 18 19:15:48 2022 +0800

    refactor: uniform the form of dependent versions in Cargo.toml
    
    Use semver without any operator instead of other forms of dependents' version.
    
    Note: semver without any operator is equivalent to the caret form.
    
    Signed-off-by: Zizheng Bian <zizheng.bian@linux.alibaba.com>