### PR TITLE
db-arch: avoid dependency on the db-boot crate

### DIFF
--- a/crates/db-arch/Cargo.toml
+++ b/crates/db-arch/Cargo.toml
@@ -6,15 +6,17 @@ license = "Apache-2.0"
 edition = "2018"
 homepage = "https://github.com/openanolis/dragonball-sandbox"
 repository = "https://github.com/openanolis/dragonball-sandbox"
-keywords = ["dragonball", "arch", "ARM64", "x86", "VMM"]
+keywords = ["dragonball", "secure-sandbox", "arch", "ARM64", "x86", "VMM"]
 readme = "README.md"
 
 [dependencies]
 kvm-bindings = { version = ">=0.5.0", features = ["fam-wrappers"] }
 kvm-ioctls = ">=0.9.0"
-vm-memory = { version = "0.7", features = ["backend-mmap"] }
+vm-memory = { version = "0.7" }
 vmm-sys-util = ">=0.8.0"
-db-boot = "0.1.0"
+
+[dev-dependencies]
+vm-memory = { version = "0.7", features = ["backend-mmap"] }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/db-arch/src/aarch64/mod.rs
+++ b/crates/db-arch/src/aarch64/mod.rs
@@ -1,4 +1,4 @@
 // Copyright 2021 Alibaba Cloud. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//! CPU architecture specific constants and utilities for the `aarch64` architecture.
+//! CPU architecture specific constants, structures and utilities for the `aarch64` architecture.

--- a/crates/db-arch/src/lib.rs
+++ b/crates/db-arch/src/lib.rs
@@ -3,10 +3,10 @@
 
 #![deny(missing_docs)]
 
-//! CPU architecture specific constants and utilities.
+//! CPU architecture specific constants, structures and utilities.
 //!
-//! This crate provides CPU architecture specific constants and utilities to abstract away CPU
-//! architecture specific details from the Dragonball Sandbox or other VMMs.
+//! This crate provides CPU architecture specific constants, structures and utilities to abstract
+//! away CPU architecture specific details from the Dragonball Secure Sandbox or other VMMs.
 //!
 //! # Supported CPU Architectures
 //! - **x86_64**: x86_64 (also known as x64, x86-64, AMD64, and Intel 64) is a 64-bit


### PR DESCRIPTION
The db-arch is designed to maintain CPU architecture specific
information, so it should not dependent on the db-boot crate.
Otherwise it may cause circular dependency issue later.

Signed-off-by: Chao Wu <chaowu@linux.alibaba.com>