### PR TITLE
db-boot: move code from db-arch

### DIFF
--- a/crates/db-boot/Cargo.toml
+++ b/crates/db-boot/Cargo.toml
@@ -10,6 +10,10 @@ keywords = ["dragonball", "boot", "VMM"]
 readme = "README.md"
 
 [dependencies]
-thiserror = "1"
-vm-memory = { version = "0.7.0", features = ["backend-mmap"] }
+db-arch = { path = "../db-arch", version = "0.1" }
 libc = "0.2.39"
+thiserror = "1"
+vm-memory = "0.7.0"
+
+[dev-dependencies]
+vm-memory = { version = "0.7.0", features = ["backend-mmap"] }

--- a/crates/db-boot/src/x86_64/layout.rs
+++ b/crates/db-boot/src/x86_64/layout.rs
@@ -9,8 +9,26 @@
 
 /// Magic addresses externally used to lay out x86_64 VMs.
 
+/// Address of Global Descriptor Table (GDT)
+pub const BOOT_GDT_ADDRESS: u64 = 0x500;
+/// Number of initial GDT entries.
+pub const BOOT_GDT_MAX: usize = 4;
+
+/// Address of Interrupt Descriptor Table (IDT)
+pub const BOOT_IDT_ADDRESS: u64 = 0x520;
+
+/// The 'zero page', a.k.a linux kernel bootparams.
+pub const ZERO_PAGE_START: u64 = 0x7000;
+
 /// Initial stack for the boot CPU.
 pub const BOOT_STACK_POINTER: u64 = 0x8ff0;
+
+/// Address of page table level 4 page
+pub const PML4_START: u64 = 0x9000;
+/// Address of page table level 3 page
+pub const PDPTE_START: u64 = 0xa000;
+/// Address of page table level 2 page
+pub const PDE_START: u64 = 0xb000;
 
 /// Kernel command line start address.
 pub const CMDLINE_START: u64 = 0x20000;
@@ -33,6 +51,3 @@ pub const IRQ_MAX: u32 = 15;
 
 /// Address for the TSS setup.
 pub const KVM_TSS_ADDRESS: u64 = 0xfffb_d000;
-
-/// The 'zero page', a.k.a linux kernel bootparams.
-pub const ZERO_PAGE_START: u64 = 0x7000;

--- a/crates/db-boot/src/x86_64/mod.rs
+++ b/crates/db-boot/src/x86_64/mod.rs
@@ -3,6 +3,11 @@
 
 //! VM boot related constants and utilities for `x86_64` architecture.
 
+use db_arch::gdt::gdt_entry;
+use vm_memory::{Address, Bytes, GuestAddress, GuestMemory};
+
+use self::layout::{BOOT_GDT_ADDRESS, BOOT_GDT_MAX, BOOT_IDT_ADDRESS};
+
 /// Magic addresses externally used to lay out x86_64 VMs.
 pub mod layout;
 
@@ -11,3 +16,69 @@ pub mod mpspec;
 
 /// MP Table configurations used for defining VM boot status.
 pub mod mptable;
+
+/// Initialize the 1:1 identity mapping table for guest memory range [0..1G).
+pub fn setup_identity_mapping<M: GuestMemory>(mem: &M) -> Result<(), vm_memory::GuestMemoryError> {
+    // Puts PML4 right after zero page but aligned to 4k.
+    let boot_pml4_addr = GuestAddress(layout::PML4_START);
+    let boot_pdpte_addr = GuestAddress(layout::PDPTE_START);
+    let boot_pde_addr = GuestAddress(layout::PDE_START);
+
+    // Entry covering VA [0..512GB)
+    mem.write_obj(boot_pdpte_addr.raw_value() as u64 | 0x03, boot_pml4_addr)?;
+
+    // Entry covering VA [0..1GB)
+    mem.write_obj(boot_pde_addr.raw_value() as u64 | 0x03, boot_pdpte_addr)?;
+
+    // 512 2MB entries together covering VA [0..1GB). Note we are assuming
+    // CPU supports 2MB pages (/proc/cpuinfo has 'pse'). All modern CPUs do.
+    for i in 0..512 {
+        mem.write_obj((i << 21) + 0x83u64, boot_pde_addr.unchecked_add(i * 8))?;
+    }
+
+    Ok(())
+}
+
+/// Get information to configure GDT/IDT.
+pub fn get_descriptor_config_info() -> ([u64; BOOT_GDT_MAX], u64, u64) {
+    let gdt_table: [u64; BOOT_GDT_MAX as usize] = [
+        gdt_entry(0, 0, 0),            // NULL
+        gdt_entry(0xa09b, 0, 0xfffff), // CODE
+        gdt_entry(0xc093, 0, 0xfffff), // DATA
+        gdt_entry(0x808b, 0, 0xfffff), // TSS
+    ];
+
+    (gdt_table, BOOT_GDT_ADDRESS, BOOT_IDT_ADDRESS)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::layout::{PDE_START, PDPTE_START, PML4_START};
+    use vm_memory::GuestMemoryMmap;
+
+    fn read_u64(gm: &GuestMemoryMmap, offset: u64) -> u64 {
+        let read_addr = GuestAddress(offset as u64);
+        gm.read_obj(read_addr).unwrap()
+    }
+
+    #[test]
+    fn test_get_descriptor_config_info() {
+        let (gdt_table, gdt_addr, idt_addr) = get_descriptor_config_info();
+
+        assert_eq!(gdt_table.len(), BOOT_GDT_MAX);
+        assert_eq!(gdt_addr, BOOT_GDT_ADDRESS);
+        assert_eq!(idt_addr, BOOT_IDT_ADDRESS);
+    }
+
+    #[test]
+    fn test_setup_identity_mapping() {
+        let gm = GuestMemoryMmap::from_ranges(&[(GuestAddress(0), 0x10000)]).unwrap();
+        setup_identity_mapping(&gm).unwrap();
+        assert_eq!(0xa003, read_u64(&gm, PML4_START));
+        assert_eq!(0xb003, read_u64(&gm, PDPTE_START));
+        for i in 0..512 {
+            assert_eq!((i << 21) + 0x83u64, read_u64(&gm, PDE_START + (i * 8)));
+        }
+    }
+}


### PR DESCRIPTION
Move some code from db-arch crate into db-boot.

Signed-off-by: Liu Jiang <gerry@linux.alibaba.com>