### PR TITLE
dbs-interrupt: introduce interrupt manager for devices

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "crates/dbs-device",
     "crates/dbs-legacy-devices",
     "crates/dbs-utils",
+    "crates/dbs-interrupt",
 ]
 
 [patch.crates-io]

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This repository contains the following crates:
 | [db-arch](crates/db-arch) | collections of CPU architecture related modules | TBD |
 | [db-boot](crates/db-boot) | collections of constants, structs and utilities used during VM boot stage | TBD |
 | [dbs-device](crates/dbs-device) | virtual machine's device model | TBD |
+| [dbs-interrupt](crates/dbs-interrupt) | virtual machine's interrupt model | TBD |
 
 (Dragonball is a virtual machine monitor developed by Alibaba and db is the abbreviation for Dragonball.)
 

--- a/crates/dbs-interrupt/Cargo.toml
+++ b/crates/dbs-interrupt/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "dbs-interrupt"
+version = "0.1.0"
+authors = ["Alibaba Dragonball Team"]
+license = "Apache-2.0"
+edition = "2018"
+homepage = "https://github.com/openanolis/dragonball-sandbox"
+repository = "https://github.com/openanolis/dragonball-sandbox"
+keywords = ["dragonball", "secure-sandbox", "device", "interrupt"]
+readme = "README.md"
+
+[dependencies]
+thiserror = "1"
+vmm-sys-util = ">=0.8.0"
+libc = "0.2"
+kvm-bindings = { version = "0.5.0", optional = true }
+kvm-ioctls = { version = "0.11.0", optional = true }
+dbs-device = { path = "../dbs-device", version = "0.1.0" }
+
+[features]
+default = ["legacy-irq", "msi-irq"]
+
+legacy-irq = []
+msi-irq = []
+
+kvm-irq = ["kvm-ioctls", "kvm-bindings"]
+kvm-msi-generic = ["msi-irq", "kvm-irq"]
+kvm-legacy-irq = ["legacy-irq", "kvm-irq"]
+kvm-msi-irq = ["kvm-msi-generic"]

--- a/crates/dbs-interrupt/LICENSE
+++ b/crates/dbs-interrupt/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/crates/dbs-interrupt/README.md
+++ b/crates/dbs-interrupt/README.md
@@ -1,0 +1,70 @@
+# dbs-interrupt
+
+Software indicating an event that needs immediate attention. An interrupt alerts the processor to a
+high-priority condition requiring the interruption of the current code the processor is executing.
+The processor responds by suspending its current activities, saving its state, and executing a
+function called an interrupt handler (or an interrupt service routine, ISR) to deal with the event.
+This interruption is temporary, and, after the interrupt handler finishes, unless handling the
+interrupt has emitted a fatal error, the processor resumes normal activities.
+
+Hardware interrupts are used by devices to communicate that they require attention from the
+operating system, or a bare-metal program running on the CPU if there are no OSes. The act of
+initiating a hardware interrupt is referred to as an interrupt request (IRQ). Different devices are
+usually associated with different interrupts using a unique value associated with each interrupt.
+This makes it possible to know which hardware device caused which interrupts. These interrupt values
+are often called IRQ lines, or just interrupt lines.
+
+Nowadays, IRQ lines is not the only mechanism to deliver device interrupts to processors. MSI
+(Message Signaled Interrupt) is another commonly used alternative in-band method of signaling an
+interrupt, using special in-band messages to replace traditional out-of-band assertion of dedicated
+interrupt lines. While more complex to implement in a device, message signaled interrupts have some
+significant advantages over pin-based out-of-band interrupt signaling. Message signaled interrupts
+are supported in PCI bus since its version 2.2, and in later available PCI Express bus. Some non-PCI
+architectures also use message signaled interrupts.
+
+While IRQ is a term commonly used by Operating Systems when dealing with hardware interrupts, the
+IRQ numbers managed by OSes are independent of the ones managed by VMM. For simplicity sake, the
+term Interrupt Source is used instead of IRQ to represent both pin-based interrupts and MSI
+interrupts.
+
+A device may support multiple types of interrupts, and each type of interrupt may support one or
+multiple interrupt sources. For example, a PCI device may support:
+
+- Legacy Irq: exactly one interrupt source.
+- PCI MSI Irq: 1,2,4,8,16,32 interrupt sources.
+- PCI MSIx Irq: 2^n(n=0-11) interrupt sources.
+
+A distinct Interrupt Source Identifier (ISID) will be assigned to each interrupt source. An ID
+allocator will be used to allocate and free Interrupt Source Identifiers for devices. To decouple
+this crate from the ID allocator, here we doesn’t take the responsibility to allocate/free Interrupt
+Source IDs but only makes use of assigned IDs.
+
+The overall flow to deal with interrupts is:
+
+- the VMM creates an interrupt manager
+- the VMM creates a device manager, passing on an reference to the interrupt manager
+- the device manager passes on an reference to the interrupt manager to all registered devices
+- guest kernel loads drivers for virtual devices
+- guest device driver determines the type and number of interrupts needed, and update the device
+  configuration
+- the virtual device backend requests the interrupt manager to create an interrupt group according to guest configuration information
+
+The dbs-device crate provides:
+
+- [InterruptManager] trait: manage interrupt sources for virtual device backends
+- [DeviceInterruptManager] struct: An implementation of [InterruptManager],  manage interrupts and interrupt modes for a device
+- [InterruptSourceGroup] trait: manage a group of interrupt sources for a device, provide methods to control the interrupts
+- [InterruptSourceType] enum: Type of interrupt source
+- [InterruptSourceConfig] enum, [LegacyIrqSourceConfig] struct and [MsiIrqSourceConfig] struct: Configuration data for an interrupt source
+
+## License
+
+This project is licensed under [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0).
+
+[InterruptManager]: src/lib.rs
+[DeviceInterruptManager]: src/manager.rs
+[InterruptSourceGroup]: src/lib.rs
+[InterruptSourceType]: src/lib.rs
+[InterruptSourceConfig]: src/lib.rs
+[LegacyIrqSourceConfig]: src/lib.rs
+[MsiIrqSourceConfig]: src/lib.rs

--- a/crates/dbs-interrupt/src/kvm/legacy_irq.rs
+++ b/crates/dbs-interrupt/src/kvm/legacy_irq.rs
@@ -1,0 +1,258 @@
+// Copyright (C) 2019 Alibaba Cloud. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Manage virtual device's legacy interrupts based on Linux KVM framework.
+//!
+//! On x86 platforms, legacy interrupts are those managed by the Master PIC, the slave PIC and
+//! IOAPICs.
+
+#[cfg(target_arch = "aarch64")]
+use kvm_bindings::KVM_IRQ_ROUTING_IRQCHIP;
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+use kvm_bindings::{
+    KVM_IRQCHIP_IOAPIC, KVM_IRQCHIP_PIC_MASTER, KVM_IRQCHIP_PIC_SLAVE, KVM_IRQ_ROUTING_IRQCHIP,
+};
+use vmm_sys_util::eventfd::EFD_NONBLOCK;
+
+use super::*;
+
+/// Maximum number of legacy interrupts supported.
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+pub const MAX_LEGACY_IRQS: u32 = 24;
+#[cfg(target_arch = "aarch64")]
+pub const MAX_LEGACY_IRQS: u32 = 128;
+
+pub(super) struct LegacyIrq {
+    base: u32,
+    vmfd: Arc<VmFd>,
+    irqfd: EventFd,
+}
+
+impl LegacyIrq {
+    pub(super) fn new(
+        base: InterruptIndex,
+        count: InterruptIndex,
+        vmfd: Arc<VmFd>,
+        _routes: Arc<KvmIrqRouting>,
+    ) -> Result<Self> {
+        if count != 1 {
+            return Err(std::io::Error::from_raw_os_error(libc::EINVAL));
+        }
+
+        if base >= MAX_LEGACY_IRQS {
+            return Err(std::io::Error::from_raw_os_error(libc::EINVAL));
+        }
+
+        Ok(LegacyIrq {
+            base,
+            vmfd,
+            irqfd: EventFd::new(EFD_NONBLOCK)?,
+        })
+    }
+
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    fn add_legacy_entry(
+        gsi: u32,
+        chip: u32,
+        pin: u32,
+        routes: &mut HashMap<u64, kvm_irq_routing_entry>,
+    ) -> Result<()> {
+        let mut entry = kvm_irq_routing_entry {
+            gsi,
+            type_: KVM_IRQ_ROUTING_IRQCHIP,
+            ..Default::default()
+        };
+        // Safe because we are initializing all fields of the `irqchip` struct.
+        entry.u.irqchip.irqchip = chip;
+        entry.u.irqchip.pin = pin;
+        routes.insert(hash_key(&entry), entry);
+
+        Ok(())
+    }
+
+    /// Build routings for IRQs connected to the master PIC, the slave PIC or the first IOAPIC.
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    pub(super) fn initialize_legacy(
+        routes: &mut HashMap<u64, kvm_irq_routing_entry>,
+    ) -> Result<()> {
+        // Build routings for the master PIC
+        for i in 0..8 {
+            if i != 2 {
+                Self::add_legacy_entry(i, KVM_IRQCHIP_PIC_MASTER, i, routes)?;
+            }
+        }
+
+        // Build routings for the slave PIC
+        for i in 8..16 {
+            Self::add_legacy_entry(i, KVM_IRQCHIP_PIC_SLAVE, i - 8, routes)?;
+        }
+
+        // Build routings for the first IOAPIC
+        for i in 0..MAX_LEGACY_IRQS {
+            if i == 0 {
+                Self::add_legacy_entry(i, KVM_IRQCHIP_IOAPIC, 2, routes)?;
+            } else if i != 2 {
+                Self::add_legacy_entry(i, KVM_IRQCHIP_IOAPIC, i, routes)?;
+            };
+        }
+
+        Ok(())
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    pub(super) fn initialize_legacy(
+        routes: &mut HashMap<u64, kvm_irq_routing_entry>,
+    ) -> Result<()> {
+        for i in 0..MAX_LEGACY_IRQS {
+            let mut entry = kvm_irq_routing_entry {
+                gsi: i,
+                type_: KVM_IRQ_ROUTING_IRQCHIP,
+                ..Default::default()
+            };
+            entry.u.irqchip.irqchip = 0;
+            entry.u.irqchip.pin = i;
+            routes.insert(hash_key(&entry), entry);
+        }
+        Ok(())
+    }
+}
+
+impl InterruptSourceGroup for LegacyIrq {
+    fn interrupt_type(&self) -> InterruptSourceType {
+        InterruptSourceType::LegacyIrq
+    }
+
+    fn len(&self) -> u32 {
+        1
+    }
+
+    fn base(&self) -> u32 {
+        self.base
+    }
+
+    fn enable(&self, configs: &[InterruptSourceConfig]) -> Result<()> {
+        if configs.len() != 1 {
+            return Err(std::io::Error::from_raw_os_error(libc::EINVAL));
+        }
+        // The IRQ routings for legacy IRQs have been configured during KvmIrqManager::initialize(),
+        // so only need to register irqfd to the KVM driver.
+        self.vmfd
+            .register_irqfd(&self.irqfd, self.base)
+            .map_err(from_sys_util_errno)
+    }
+
+    fn disable(&self) -> Result<()> {
+        self.vmfd
+            .unregister_irqfd(&self.irqfd, self.base)
+            .map_err(from_sys_util_errno)
+    }
+
+    fn update(&self, index: InterruptIndex, _config: &InterruptSourceConfig) -> Result<()> {
+        // For legacy interrupts, the routing configuration is managed by the PIC/IOAPIC interrupt
+        // controller drivers, so nothing to do here.
+        if index != 0 {
+            return Err(std::io::Error::from_raw_os_error(libc::EINVAL));
+        }
+        Ok(())
+    }
+
+    fn notifier(&self, index: InterruptIndex) -> Option<&EventFd> {
+        if index != 0 {
+            None
+        } else {
+            Some(&self.irqfd)
+        }
+    }
+
+    fn trigger(&self, index: InterruptIndex) -> Result<()> {
+        if index != 0 {
+            return Err(std::io::Error::from_raw_os_error(libc::EINVAL));
+        }
+        self.irqfd.write(1)
+    }
+
+    fn mask(&self, index: InterruptIndex) -> Result<()> {
+        if index > 1 {
+            return Err(std::io::Error::from_raw_os_error(libc::EINVAL));
+        }
+
+        self.vmfd
+            .unregister_irqfd(&self.irqfd, self.base + index)
+            .map_err(from_sys_util_errno)?;
+
+        Ok(())
+    }
+
+    fn unmask(&self, index: InterruptIndex) -> Result<()> {
+        if index > 1 {
+            return Err(std::io::Error::from_raw_os_error(libc::EINVAL));
+        }
+
+        self.vmfd
+            .register_irqfd(&self.irqfd, self.base + index)
+            .map_err(from_sys_util_errno)?;
+
+        Ok(())
+    }
+
+    fn get_pending_state(&self, index: InterruptIndex) -> bool {
+        if index > 1 {
+            return false;
+        }
+
+        // Peak the EventFd.count by reading and writing back.
+        // The irqfd must be in NON-BLOCKING mode.
+        match self.irqfd.read() {
+            Err(_) => false,
+            Ok(count) => {
+                if count != 0 && self.irqfd.write(count).is_err() {
+                    // Hope the caller will handle the pending state corrrectly,
+                    // then no interrupt will be lost.
+                }
+                count != 0
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+mod test {
+    use super::*;
+    use crate::manager::tests::create_vm_fd;
+
+    #[test]
+    #[allow(unreachable_patterns)]
+    fn test_legacy_interrupt_group() {
+        let vmfd = Arc::new(create_vm_fd());
+        let rounting = Arc::new(KvmIrqRouting::new(vmfd.clone()));
+        let base = 0;
+        let count = 1;
+        let group = LegacyIrq::new(base, count, vmfd.clone(), rounting.clone()).unwrap();
+
+        let legacy_fds = vec![InterruptSourceConfig::LegacyIrq(LegacyIrqSourceConfig {})];
+
+        match group.interrupt_type() {
+            InterruptSourceType::LegacyIrq => {}
+            _ => {
+                panic!();
+            }
+        }
+        assert_eq!(group.len(), 1);
+        assert_eq!(group.base(), base);
+        assert!(group.enable(&legacy_fds).is_ok());
+        assert!(group.notifier(0).unwrap().write(1).is_ok());
+        assert!(group.trigger(0).is_ok());
+        assert!(group.trigger(1).is_err());
+        assert!(group
+            .update(
+                0,
+                &InterruptSourceConfig::LegacyIrq(LegacyIrqSourceConfig {})
+            )
+            .is_ok());
+        assert!(group.disable().is_ok());
+
+        assert!(LegacyIrq::new(base, 2, vmfd.clone(), rounting.clone()).is_err());
+        assert!(LegacyIrq::new(110, 1, vmfd, rounting).is_err());
+    }
+}

--- a/crates/dbs-interrupt/src/kvm/mod.rs
+++ b/crates/dbs-interrupt/src/kvm/mod.rs
@@ -1,0 +1,426 @@
+// Copyright (C) 2019 Alibaba Cloud. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Manage virtual device's interrupts based on the Linux KVM framework.
+//!
+//! When updaing KVM IRQ routing by ioctl(KVM_SET_GSI_ROUTING), all interrupts of the virtual
+//! machine must be updated all together. The [KvmIrqRouting](struct.KvmIrqRouting.html) structure
+//! is to maintain the global interrupt routing table.
+//!
+//! It deserves a good documentation about the way that KVM based vmms manages interrupts. From the
+//! KVM hypervisor side, it provides three mechanism to support injecting interrupts into guests:
+//! 1) Irqfd. When data is written to an irqfd, it triggers KVM to inject an interrupt into guest.
+//! 2) Irq routing. Irq routing determines the way to inject an irq into guest.
+//! 3) Signal MSI. Vmm can inject an MSI interrupt into guest by issuing KVM_SIGNAL_MSI ioctl.
+//!
+//! Most VMMs use irqfd + irq routing to support interrupt injecting, so we will focus on this mode.
+//! The flow to enable interrupt injecting is:
+//! 1) VMM creates an irqfd
+//! 2) VMM invokes KVM_IRQFD to bind the irqfd to an interrupt source
+//! 3) VMM invokes KVM_SET_GSI_ROUTING to configure the way to inject the interrupt into guest
+//! 4) device backend driver writes to the irqfd
+//! 5) an interurpt is injected into the guest
+
+#[cfg(feature = "kvm-legacy-irq")]
+mod legacy_irq;
+#[cfg(feature = "kvm-msi-generic")]
+mod msi_generic;
+#[cfg(feature = "kvm-msi-irq")]
+mod msi_irq;
+
+use std::collections::HashMap;
+use std::io::{Error, ErrorKind};
+use std::sync::{Arc, Mutex};
+
+use kvm_bindings::{kvm_irq_routing, kvm_irq_routing_entry};
+use kvm_ioctls::VmFd;
+#[cfg(feature = "kvm-legacy-irq")]
+use legacy_irq::LegacyIrq;
+#[cfg(feature = "kvm-msi-irq")]
+use msi_irq::MsiIrq;
+
+use super::*;
+
+/// Maximum number of global interrupt sources.
+pub const MAX_IRQS: InterruptIndex = 1024;
+
+/// Default maximum number of Message Signaled Interrupts per device.
+pub const DEFAULT_MAX_MSI_IRQS_PER_DEVICE: InterruptIndex = 256;
+
+/// Structure to manage interrupt sources for a virtual machine based on the Linux KVM framework.
+///
+/// The KVM framework provides methods to inject interrupts into the target virtual machines, which
+/// uses irqfd to notity the KVM kernel module for injecting interrupts. When the interrupt source,
+/// usually a virtual device backend in userspace, writes to the irqfd file descriptor, the KVM
+/// kernel module will inject a corresponding interrupt into the target VM according to the IRQ
+/// routing configuration.
+pub struct KvmIrqManager {
+    mgr: Mutex<KvmIrqManagerObj>,
+}
+
+impl KvmIrqManager {
+    /// Create a new interrupt manager based on the Linux KVM framework.
+    ///
+    /// # Arguments
+    /// * `vmfd`: The KVM VM file descriptor, which will be used to access the KVM subsystem.
+    pub fn new(vmfd: Arc<VmFd>) -> Self {
+        KvmIrqManager {
+            mgr: Mutex::new(KvmIrqManagerObj {
+                vmfd: vmfd.clone(),
+                groups: HashMap::new(),
+                routes: Arc::new(KvmIrqRouting::new(vmfd)),
+                max_msi_irqs: DEFAULT_MAX_MSI_IRQS_PER_DEVICE,
+            }),
+        }
+    }
+
+    /// Prepare the interrupt manager for generating interrupts into the target VM.
+    pub fn initialize(&self) -> Result<()> {
+        // Safe to unwrap because there's no legal way to break the mutex.
+        let mgr = self.mgr.lock().unwrap();
+        mgr.initialize()
+    }
+
+    /// Set maximum supported MSI interrupts per device.
+    pub fn set_max_msi_irqs(&self, max_msi_irqs: InterruptIndex) {
+        let mut mgr = self.mgr.lock().unwrap();
+        mgr.max_msi_irqs = max_msi_irqs;
+    }
+}
+
+impl InterruptManager for KvmIrqManager {
+    fn create_group(
+        &self,
+        ty: InterruptSourceType,
+        base: InterruptIndex,
+        count: u32,
+    ) -> Result<Arc<Box<dyn InterruptSourceGroup>>> {
+        // Safe to unwrap because there's no legal way to break the mutex.
+        let mut mgr = self.mgr.lock().unwrap();
+        mgr.create_group(ty, base, count)
+    }
+
+    fn destroy_group(&self, group: Arc<Box<dyn InterruptSourceGroup>>) -> Result<()> {
+        // Safe to unwrap because there's no legal way to break the mutex.
+        let mut mgr = self.mgr.lock().unwrap();
+        mgr.destroy_group(group)
+    }
+}
+
+struct KvmIrqManagerObj {
+    vmfd: Arc<VmFd>,
+    routes: Arc<KvmIrqRouting>,
+    groups: HashMap<InterruptIndex, Arc<Box<dyn InterruptSourceGroup>>>,
+    max_msi_irqs: InterruptIndex,
+}
+
+impl KvmIrqManagerObj {
+    fn initialize(&self) -> Result<()> {
+        self.routes.initialize()?;
+        Ok(())
+    }
+
+    fn create_group(
+        &mut self,
+        ty: InterruptSourceType,
+        base: InterruptIndex,
+        count: u32,
+    ) -> Result<Arc<Box<dyn InterruptSourceGroup>>> {
+        #[allow(unreachable_patterns)]
+        let group: Arc<Box<dyn InterruptSourceGroup>> = match ty {
+            #[cfg(feature = "kvm-legacy-irq")]
+            InterruptSourceType::LegacyIrq => Arc::new(Box::new(LegacyIrq::new(
+                base,
+                count,
+                self.vmfd.clone(),
+                self.routes.clone(),
+            )?)),
+            #[cfg(feature = "kvm-msi-irq")]
+            InterruptSourceType::MsiIrq => Arc::new(Box::new(MsiIrq::new(
+                base,
+                count,
+                self.max_msi_irqs,
+                self.vmfd.clone(),
+                self.routes.clone(),
+            )?)),
+            _ => return Err(Error::from(ErrorKind::InvalidInput)),
+        };
+
+        self.groups.insert(base, group.clone());
+
+        Ok(group)
+    }
+
+    fn destroy_group(&mut self, group: Arc<Box<dyn InterruptSourceGroup>>) -> Result<()> {
+        self.groups.remove(&group.base());
+        Ok(())
+    }
+}
+
+// Use (entry.type, entry.gsi) as the hash key because entry.gsi can't uniquely identify an
+// interrupt source on x86 platforms. The PIC and IOAPIC may share the same GSI on x86 platforms.
+fn hash_key(entry: &kvm_irq_routing_entry) -> u64 {
+    let type1 = match entry.type_ {
+        #[cfg(feature = "kvm-legacy-irq")]
+        kvm_bindings::KVM_IRQ_ROUTING_IRQCHIP => unsafe { entry.u.irqchip.irqchip },
+        _ => 0u32,
+    };
+    (u64::from(type1) << 48 | u64::from(entry.type_) << 32) | u64::from(entry.gsi)
+}
+
+pub(super) struct KvmIrqRouting {
+    vm_fd: Arc<VmFd>,
+    routes: Mutex<HashMap<u64, kvm_irq_routing_entry>>,
+}
+
+impl KvmIrqRouting {
+    pub(super) fn new(vm_fd: Arc<VmFd>) -> Self {
+        KvmIrqRouting {
+            vm_fd,
+            routes: Mutex::new(HashMap::new()),
+        }
+    }
+
+    pub(super) fn initialize(&self) -> Result<()> {
+        // Safe to unwrap because there's no legal way to break the mutex.
+        #[allow(unused_mut)]
+        let mut routes = self.routes.lock().unwrap();
+
+        #[cfg(feature = "kvm-legacy-irq")]
+        LegacyIrq::initialize_legacy(&mut *routes)?;
+
+        self.set_routing(&*routes)?;
+
+        Ok(())
+    }
+
+    fn set_routing(&self, routes: &HashMap<u64, kvm_irq_routing_entry>) -> Result<()> {
+        // Allocate enough buffer memory.
+        let elem_sz = std::mem::size_of::<kvm_irq_routing>();
+        let total_sz = std::mem::size_of::<kvm_irq_routing_entry>() * routes.len() + elem_sz;
+        let elem_cnt = (total_sz + elem_sz - 1) / elem_sz;
+        let mut irq_routings = Vec::<kvm_irq_routing>::with_capacity(elem_cnt);
+        irq_routings.resize_with(elem_cnt, Default::default);
+
+        // Prepare the irq_routing header.
+        let mut irq_routing = &mut irq_routings[0];
+        irq_routing.nr = routes.len() as u32;
+        irq_routing.flags = 0;
+
+        // Safe because we have just allocated enough memory above.
+        let irq_routing_entries = unsafe { irq_routing.entries.as_mut_slice(routes.len()) };
+        for (idx, entry) in routes.values().enumerate() {
+            irq_routing_entries[idx] = *entry;
+        }
+
+        self.vm_fd
+            .set_gsi_routing(irq_routing)
+            .map_err(from_sys_util_errno)?;
+
+        Ok(())
+    }
+}
+
+#[cfg(feature = "kvm-msi-generic")]
+impl KvmIrqRouting {
+    pub(super) fn add(&self, entries: &[kvm_irq_routing_entry]) -> Result<()> {
+        // Safe to unwrap because there's no legal way to break the mutex.
+        let mut routes = self.routes.lock().unwrap();
+        for entry in entries {
+            if entry.gsi >= MAX_IRQS {
+                return Err(std::io::Error::from_raw_os_error(libc::EINVAL));
+            } else if routes.contains_key(&hash_key(entry)) {
+                return Err(std::io::Error::from_raw_os_error(libc::EEXIST));
+            }
+        }
+
+        for entry in entries {
+            let _ = routes.insert(hash_key(entry), *entry);
+        }
+        self.set_routing(&routes)
+    }
+
+    pub(super) fn remove(&self, entries: &[kvm_irq_routing_entry]) -> Result<()> {
+        // Safe to unwrap because there's no legal way to break the mutex.
+        let mut routes = self.routes.lock().unwrap();
+        for entry in entries {
+            let _ = routes.remove(&hash_key(entry));
+        }
+        self.set_routing(&routes)
+    }
+
+    pub(super) fn modify(&self, entry: &kvm_irq_routing_entry) -> Result<()> {
+        // Safe to unwrap because there's no legal way to break the mutex.
+        let mut routes = self.routes.lock().unwrap();
+        if !routes.contains_key(&hash_key(entry)) {
+            return Err(std::io::Error::from_raw_os_error(libc::ENOENT));
+        }
+
+        let _ = routes.insert(hash_key(entry), *entry);
+        self.set_routing(&routes)
+    }
+}
+
+/// Helper function convert from vmm_sys_util::errno::Error to std::io::Error.
+pub fn from_sys_util_errno(e: vmm_sys_util::errno::Error) -> std::io::Error {
+    std::io::Error::from_raw_os_error(e.errno())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::manager::tests::create_vm_fd;
+
+    fn create_irq_group(
+        manager: Arc<KvmIrqManager>,
+        _vmfd: Arc<VmFd>,
+    ) -> Arc<Box<dyn InterruptSourceGroup>> {
+        let base = 0;
+        let count = 1;
+
+        manager
+            .create_group(InterruptSourceType::LegacyIrq, base, count)
+            .unwrap()
+    }
+
+    fn create_msi_group(
+        manager: Arc<KvmIrqManager>,
+        _vmfd: Arc<VmFd>,
+    ) -> Arc<Box<dyn InterruptSourceGroup>> {
+        let base = 168;
+        let count = 32;
+
+        manager
+            .create_group(InterruptSourceType::MsiIrq, base, count)
+            .unwrap()
+    }
+
+    const MASTER_PIC: usize = 7;
+    const SLAVE_PIC: usize = 8;
+    const IOAPIC: usize = 23;
+
+    #[test]
+    fn test_create_kvm_irq_manager() {
+        let vmfd = Arc::new(create_vm_fd());
+        let manager = KvmIrqManager::new(vmfd.clone());
+        assert!(vmfd.create_irq_chip().is_ok());
+        assert!(manager.initialize().is_ok());
+    }
+
+    #[test]
+    fn test_kvm_irq_manager_opt() {
+        let vmfd = Arc::new(create_vm_fd());
+        assert!(vmfd.create_irq_chip().is_ok());
+        let manager = Arc::new(KvmIrqManager::new(vmfd.clone()));
+        assert!(manager.initialize().is_ok());
+
+        // set max irqs
+        manager.set_max_msi_irqs(0x128);
+        assert_eq!(manager.mgr.lock().unwrap().max_msi_irqs, 0x128);
+
+        // irq
+        let group = create_irq_group(manager.clone(), vmfd.clone());
+        let _ = group.clone();
+        assert!(manager.destroy_group(group).is_ok());
+
+        // msi
+        let group = create_msi_group(manager.clone(), vmfd);
+        let _ = group.clone();
+        assert!(manager.destroy_group(group).is_ok());
+    }
+
+    #[test]
+    fn test_irq_routing_initialize_legacy() {
+        let vmfd = Arc::new(create_vm_fd());
+        let routing = KvmIrqRouting::new(vmfd.clone());
+
+        // this would ok on 4.9 kernel
+        assert!(routing.initialize().is_err());
+
+        assert!(vmfd.create_irq_chip().is_ok());
+        assert!(routing.initialize().is_ok());
+
+        let routes = &routing.routes.lock().unwrap();
+        assert_eq!(routes.len(), MASTER_PIC + SLAVE_PIC + IOAPIC);
+    }
+
+    #[test]
+    fn test_routing_opt() {
+        let vmfd = Arc::new(create_vm_fd());
+        let routing = KvmIrqRouting::new(vmfd.clone());
+
+        // this would ok on 4.9 kernel
+        assert!(routing.initialize().is_err());
+
+        assert!(vmfd.create_irq_chip().is_ok());
+        assert!(routing.initialize().is_ok());
+
+        let mut entry = kvm_irq_routing_entry {
+            gsi: 8,
+            type_: kvm_bindings::KVM_IRQ_ROUTING_IRQCHIP,
+            ..Default::default()
+        };
+
+        // Safe because we are initializing all fields of the `irqchip` struct.
+        entry.u.irqchip.irqchip = 0;
+        entry.u.irqchip.pin = 3;
+
+        let entrys = vec![entry];
+
+        assert!(routing.modify(&entry).is_err());
+        assert!(routing.add(&entrys).is_ok());
+        entry.u.irqchip.pin = 4;
+        assert!(routing.modify(&entry).is_ok());
+        assert!(routing.remove(&entrys).is_ok());
+        assert!(routing.modify(&entry).is_err());
+    }
+
+    #[test]
+    fn test_routing_set_routing() {
+        let vmfd = Arc::new(create_vm_fd());
+        let routing = KvmIrqRouting::new(vmfd.clone());
+
+        // this would ok on 4.9 kernel
+        assert!(routing.initialize().is_err());
+
+        assert!(vmfd.create_irq_chip().is_ok());
+        assert!(routing.initialize().is_ok());
+
+        let mut entry = kvm_irq_routing_entry {
+            gsi: 8,
+            type_: kvm_bindings::KVM_IRQ_ROUTING_IRQCHIP,
+            ..Default::default()
+        };
+        entry.u.irqchip.irqchip = 0;
+        entry.u.irqchip.pin = 3;
+
+        routing
+            .routes
+            .lock()
+            .unwrap()
+            .insert(hash_key(&entry), entry);
+        let routes = routing.routes.lock().unwrap();
+        assert!(routing.set_routing(&routes).is_ok());
+    }
+
+    #[test]
+    fn test_has_key() {
+        let gsi = 4;
+        let mut entry = kvm_irq_routing_entry {
+            gsi,
+            type_: kvm_bindings::KVM_IRQ_ROUTING_IRQCHIP,
+            ..Default::default()
+        };
+        // Safe because we are initializing all fields of the `irqchip` struct.
+        entry.u.irqchip.irqchip = kvm_bindings::KVM_IRQCHIP_PIC_MASTER;
+        entry.u.irqchip.pin = gsi;
+        assert_eq!(hash_key(&entry), 0x0001_0000_0004);
+    }
+
+    #[test]
+    fn test_from_sys_util_errno() {
+        let error = vmm_sys_util::errno::Error::new(1);
+        let io_error = from_sys_util_errno(error);
+        assert_eq!(io_error.kind(), std::io::ErrorKind::PermissionDenied);
+    }
+}

--- a/crates/dbs-interrupt/src/kvm/msi_generic.rs
+++ b/crates/dbs-interrupt/src/kvm/msi_generic.rs
@@ -1,0 +1,138 @@
+// Copyright (C) 2019 Alibaba Cloud. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Helper utilities for handling MSI interrupts.
+
+use kvm_bindings::{kvm_irq_routing_entry, KVM_IRQ_ROUTING_MSI};
+use vmm_sys_util::eventfd::EFD_NONBLOCK;
+
+use super::*;
+
+#[cfg(target_arch = "aarch64")]
+use kvm_bindings::KVM_MSI_VALID_DEVID;
+
+pub(crate) struct MsiConfig {
+    pub(super) irqfd: EventFd,
+    pub(crate) config: Mutex<MsiIrqSourceConfig>,
+}
+
+impl MsiConfig {
+    pub(crate) fn new() -> Self {
+        MsiConfig {
+            irqfd: EventFd::new(EFD_NONBLOCK).unwrap(),
+            config: Mutex::new(Default::default()),
+        }
+    }
+}
+
+pub(super) fn new_msi_routing_entry(
+    gsi: InterruptIndex,
+    msicfg: &MsiIrqSourceConfig,
+) -> kvm_irq_routing_entry {
+    let mut entry = kvm_irq_routing_entry {
+        gsi,
+        type_: KVM_IRQ_ROUTING_MSI,
+        #[cfg(target_arch = "x86_64")]
+        flags: 0,
+        #[cfg(any(target_arch = "aarch64"))]
+        flags: KVM_MSI_VALID_DEVID,
+        ..Default::default()
+    };
+    entry.u.msi.address_hi = msicfg.high_addr;
+    entry.u.msi.address_lo = msicfg.low_addr;
+    entry.u.msi.data = msicfg.data;
+    #[cfg(target_arch = "aarch64")]
+    if let Some(dev_id) = msicfg.device_id {
+        entry.u.msi.__bindgen_anon_1.devid = dev_id;
+    }
+    entry
+}
+
+#[allow(irrefutable_let_patterns)]
+pub(super) fn create_msi_routing_entries(
+    base: InterruptIndex,
+    configs: &[InterruptSourceConfig],
+) -> Result<Vec<kvm_irq_routing_entry>> {
+    let _ = base
+        .checked_add(configs.len() as u32)
+        .ok_or_else(|| std::io::Error::from_raw_os_error(libc::EINVAL))?;
+    let mut entries = Vec::with_capacity(configs.len());
+    for (i, ref val) in configs.iter().enumerate() {
+        if let InterruptSourceConfig::MsiIrq(msicfg) = val {
+            let entry = new_msi_routing_entry(base + i as u32, msicfg);
+            entries.push(entry);
+        } else {
+            return Err(std::io::Error::from_raw_os_error(libc::EINVAL));
+        }
+    }
+    Ok(entries)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_create_msiconfig() {
+        let config = MsiConfig::new();
+        config.irqfd.write(1).unwrap();
+    }
+
+    #[test]
+    fn test_new_msi_routing_single() {
+        let test_gsi = 4;
+        let msi_source_config = MsiIrqSourceConfig {
+            high_addr: 0x1234,
+            low_addr: 0x5678,
+            data: 0x9876,
+            msg_ctl: 0,
+        };
+        let entry = new_msi_routing_entry(test_gsi, &msi_source_config);
+        assert_eq!(entry.gsi, test_gsi);
+        assert_eq!(entry.type_, KVM_IRQ_ROUTING_MSI);
+        unsafe {
+            assert_eq!(entry.u.msi.address_hi, msi_source_config.high_addr);
+            assert_eq!(entry.u.msi.address_lo, msi_source_config.low_addr);
+            assert_eq!(entry.u.msi.data, msi_source_config.data);
+        }
+    }
+
+    #[cfg(all(
+        feature = "legacy_irq",
+        any(target_arch = "x86", target_arch = "x86_64")
+    ))]
+    #[test]
+    fn test_new_msi_routing_multi() {
+        let mut msi_fds = Vec::with_capacity(16);
+        for _ in 0..16 {
+            msi_fds.push(InterruptSourceConfig::MsiIrq(MsiIrqSourceConfig {
+                high_addr: 0x1234,
+                low_addr: 0x5678,
+                data: 0x9876,
+                msg_ctl: 0,
+            }));
+        }
+        let mut legacy_fds = Vec::with_capacity(16);
+        for _ in 0..16 {
+            legacy_fds.push(InterruptSourceConfig::LegacyIrq(LegacyIrqSourceConfig {}));
+        }
+
+        let base = 0;
+        let entrys = create_msi_routing_entries(0, &msi_fds).unwrap();
+
+        for (i, entry) in entrys.iter().enumerate() {
+            assert_eq!(entry.gsi, (base + i) as u32);
+            assert_eq!(entry.type_, KVM_IRQ_ROUTING_MSI);
+            if let InterruptSourceConfig::MsiIrq(config) = &msi_fds[i] {
+                unsafe {
+                    assert_eq!(entry.u.msi.address_hi, config.high_addr);
+                    assert_eq!(entry.u.msi.address_lo, config.low_addr);
+                    assert_eq!(entry.u.msi.data, config.data);
+                }
+            }
+        }
+
+        assert!(create_msi_routing_entries(0, &legacy_fds).is_err());
+        assert!(create_msi_routing_entries(!0, &msi_fds).is_err());
+    }
+}

--- a/crates/dbs-interrupt/src/kvm/msi_irq.rs
+++ b/crates/dbs-interrupt/src/kvm/msi_irq.rs
@@ -1,0 +1,277 @@
+// Copyright (C) 2019 Alibaba Cloud. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Manage virtual device's PCI MSI/PCI MSIx interrupts based on Linux KVM framework.
+//!
+//! To optimize for performance by avoiding unnecessary locking and state checking, we assume that
+//! the caller will take the responsibility to maintain the interrupt states and only issue valid
+//! requests to this driver. If the caller doesn't obey the contract, only the current virtual
+//! machine will be affected, it shouldn't break the host or other virtual machines.
+
+use super::msi_generic::{create_msi_routing_entries, new_msi_routing_entry, MsiConfig};
+use super::*;
+
+pub(super) struct MsiIrq {
+    base: InterruptIndex,
+    count: InterruptIndex,
+    vmfd: Arc<VmFd>,
+    irq_routing: Arc<KvmIrqRouting>,
+    msi_configs: Vec<MsiConfig>,
+}
+
+impl MsiIrq {
+    pub(super) fn new(
+        base: InterruptIndex,
+        count: InterruptIndex,
+        max_msi_irqs: InterruptIndex,
+        vmfd: Arc<VmFd>,
+        irq_routing: Arc<KvmIrqRouting>,
+    ) -> Result<Self> {
+        if count > max_msi_irqs || base >= MAX_IRQS || base + count > MAX_IRQS {
+            return Err(std::io::Error::from_raw_os_error(libc::EINVAL));
+        }
+
+        let mut msi_configs = Vec::with_capacity(count as usize);
+        for _ in 0..count {
+            msi_configs.push(MsiConfig::new());
+        }
+
+        Ok(MsiIrq {
+            base,
+            count,
+            vmfd,
+            irq_routing,
+            msi_configs,
+        })
+    }
+}
+
+impl InterruptSourceGroup for MsiIrq {
+    fn interrupt_type(&self) -> InterruptSourceType {
+        InterruptSourceType::MsiIrq
+    }
+
+    fn len(&self) -> u32 {
+        self.count
+    }
+
+    fn base(&self) -> u32 {
+        self.base
+    }
+
+    fn enable(&self, configs: &[InterruptSourceConfig]) -> Result<()> {
+        if configs.len() != self.count as usize {
+            return Err(std::io::Error::from_raw_os_error(libc::EINVAL));
+        }
+
+        // First add IRQ routings for all the MSI interrupts.
+        let entries = create_msi_routing_entries(self.base, configs)?;
+
+        self.irq_routing
+            .add(&entries)
+            .or_else(|err| match err.kind() {
+                // The irq_routing was already restored when the snapshot was restored, so the AlreadyExists error is ignored here.
+                std::io::ErrorKind::AlreadyExists => Ok(()),
+                _ => Err(err),
+            })?;
+
+        // Then register irqfds to the KVM module.
+        for i in 0..self.count {
+            let irqfd = &self.msi_configs[i as usize].irqfd;
+            self.vmfd
+                .register_irqfd(irqfd, self.base + i)
+                .map_err(from_sys_util_errno)?;
+        }
+
+        Ok(())
+    }
+
+    fn disable(&self) -> Result<()> {
+        // First unregister all irqfds, so it won't trigger anymore.
+        for i in 0..self.count {
+            let irqfd = &self.msi_configs[i as usize].irqfd;
+            self.vmfd
+                .unregister_irqfd(irqfd, self.base + i)
+                .map_err(from_sys_util_errno)?;
+        }
+
+        // Then tear down the IRQ routings for all the MSI interrupts.
+        let mut entries = Vec::with_capacity(self.count as usize);
+        for i in 0..self.count {
+            // Safe to unwrap because there's no legal way to break the mutex.
+            let msicfg = self.msi_configs[i as usize].config.lock().unwrap();
+            let entry = new_msi_routing_entry(self.base + i, &*msicfg);
+            entries.push(entry);
+        }
+        self.irq_routing.remove(&entries)?;
+
+        Ok(())
+    }
+
+    #[allow(irrefutable_let_patterns)]
+    fn update(&self, index: InterruptIndex, config: &InterruptSourceConfig) -> Result<()> {
+        if index >= self.count {
+            return Err(std::io::Error::from_raw_os_error(libc::EINVAL));
+        }
+
+        if let InterruptSourceConfig::MsiIrq(ref cfg) = config {
+            // Safe to unwrap because there's no legal way to break the mutex.
+            let entry = {
+                let mut msicfg = self.msi_configs[index as usize].config.lock().unwrap();
+                msicfg.high_addr = cfg.high_addr;
+                msicfg.low_addr = cfg.low_addr;
+                msicfg.data = cfg.data;
+                #[cfg(target_arch = "aarch64")]
+                {
+                    msicfg.device_id = cfg.device_id;
+                }
+                new_msi_routing_entry(self.base + index, &*msicfg)
+            };
+            self.irq_routing.modify(&entry)
+        } else {
+            Err(std::io::Error::from_raw_os_error(libc::EINVAL))
+        }
+    }
+
+    fn notifier(&self, index: InterruptIndex) -> Option<&EventFd> {
+        if index >= self.count {
+            None
+        } else {
+            let msi_config = &self.msi_configs[index as usize];
+            Some(&msi_config.irqfd)
+        }
+    }
+
+    fn trigger(&self, index: InterruptIndex) -> Result<()> {
+        // Assume that the caller will maintain the interrupt states and only call this function
+        // when suitable.
+        if index >= self.count {
+            return Err(std::io::Error::from_raw_os_error(libc::EINVAL));
+        }
+        let msi_config = &self.msi_configs[index as usize];
+        msi_config.irqfd.write(1)
+    }
+
+    fn mask(&self, index: InterruptIndex) -> Result<()> {
+        if index >= self.count {
+            return Err(std::io::Error::from_raw_os_error(libc::EINVAL));
+        }
+
+        let irqfd = &self.msi_configs[index as usize].irqfd;
+        self.vmfd
+            .unregister_irqfd(irqfd, self.base + index)
+            .map_err(from_sys_util_errno)?;
+
+        Ok(())
+    }
+
+    fn unmask(&self, index: InterruptIndex) -> Result<()> {
+        if index >= self.count {
+            return Err(std::io::Error::from_raw_os_error(libc::EINVAL));
+        }
+
+        let irqfd = &self.msi_configs[index as usize].irqfd;
+        self.vmfd
+            .register_irqfd(irqfd, self.base + index)
+            .map_err(from_sys_util_errno)?;
+
+        Ok(())
+    }
+
+    fn get_pending_state(&self, index: InterruptIndex) -> bool {
+        if index >= self.count {
+            return false;
+        }
+
+        // Peak the EventFd.count by reading and writing back.
+        // The irqfd must be in NON-BLOCKING mode.
+        let irqfd = &self.msi_configs[index as usize].irqfd;
+        match irqfd.read() {
+            Err(_) => false,
+            Ok(count) => {
+                if count != 0 && irqfd.write(count).is_err() {
+                    // Hope the caller will handle the pending state corrrectly,
+                    // then no interrupt will be lost.
+                    // Really no way to recover here!
+                }
+                count != 0
+            }
+        }
+    }
+}
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::manager::tests::create_vm_fd;
+
+    #[test]
+    #[allow(unreachable_patterns)]
+    fn test_msi_interrupt_group() {
+        let vmfd = Arc::new(create_vm_fd());
+        assert!(vmfd.create_irq_chip().is_ok());
+
+        let rounting = Arc::new(KvmIrqRouting::new(vmfd.clone()));
+        assert!(rounting.initialize().is_ok());
+
+        let base = 168;
+        let count = 32;
+        let group = MsiIrq::new(
+            base,
+            count,
+            DEFAULT_MAX_MSI_IRQS_PER_DEVICE,
+            vmfd.clone(),
+            rounting.clone(),
+        )
+        .unwrap();
+        let mut msi_fds = Vec::with_capacity(count as usize);
+
+        match group.interrupt_type() {
+            InterruptSourceType::MsiIrq => {}
+            _ => {
+                panic!();
+            }
+        }
+
+        for _ in 0..count {
+            let msi_source_config = MsiIrqSourceConfig {
+                high_addr: 0x1234,
+                low_addr: 0x5678,
+                data: 0x9876,
+                msg_ctl: 0x6789,
+            };
+            msi_fds.push(InterruptSourceConfig::MsiIrq(msi_source_config));
+        }
+
+        assert!(group.enable(&msi_fds).is_ok());
+        assert_eq!(group.len(), count);
+        assert_eq!(group.base(), base);
+
+        for i in 0..count {
+            let msi_source_config = MsiIrqSourceConfig {
+                high_addr: i + 0x1234,
+                low_addr: i + 0x5678,
+                data: i + 0x9876,
+                msg_ctl: i + 0x6789,
+            };
+            assert!(group.notifier(i).unwrap().write(1).is_ok());
+            assert!(group.trigger(i).is_ok());
+            assert!(group
+                .update(0, &InterruptSourceConfig::MsiIrq(msi_source_config))
+                .is_ok());
+        }
+        assert!(group.trigger(33).is_err());
+        assert!(group.disable().is_ok());
+
+        assert!(MsiIrq::new(
+            base,
+            DEFAULT_MAX_MSI_IRQS_PER_DEVICE + 1,
+            DEFAULT_MAX_MSI_IRQS_PER_DEVICE,
+            vmfd.clone(),
+            rounting.clone()
+        )
+        .is_err());
+        assert!(MsiIrq::new(1100, 1, DEFAULT_MAX_MSI_IRQS_PER_DEVICE, vmfd, rounting).is_err());
+    }
+}

--- a/crates/dbs-interrupt/src/lib.rs
+++ b/crates/dbs-interrupt/src/lib.rs
@@ -1,0 +1,244 @@
+// Copyright (C) 2019-2020 Alibaba Cloud. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Traits and Structs to manage interrupt sources for devices.
+//!
+//! Software indicating an event that needs immediate attention. An interrupt alerts the processor
+//! to a high-priority condition requiring the interruption of the current code the processor is
+//! executing. The processor responds by suspending its current activities, saving its state, and
+//! executing a function called an interrupt handler (or an interrupt service routine, ISR) to deal
+//! with the event. This interruption is temporary, and, after the interrupt handler finishes,
+//! unless handling the interrupt has emitted a fatal error, the processor resumes normal
+//! activities.
+//!
+//! Hardware interrupts are used by devices to communicate that they require attention from the
+//! operating system, or a bare-metal program running on the CPU if there are no OSes. The act of
+//! initiating a hardware interrupt is referred to as an interrupt request (IRQ). Different devices
+//! are usually associated with different interrupts using a unique value associated with each
+//! interrupt. This makes it possible to know which hardware device caused which interrupts. These
+//! interrupt values are often called IRQ lines, or just interrupt lines.
+//!
+//! Nowadays, IRQ lines is not the only mechanism to deliver device interrupts to processors. MSI
+//! [(Message Signaled Interrupt)](https://en.wikipedia.org/wiki/Message_Signaled_Interrupts) is
+//! another commonly used alternative in-band method of signaling an interrupt, using special
+//! in-band messages to replace traditional out-of-band assertion of dedicated interrupt lines.
+//! While more complex to implement in a device, message signaled interrupts have some significant
+//! advantages over pin-based out-of-band interrupt signaling. Message signaled interrupts are
+//! supported in PCI bus since its version 2.2, and in later available PCI Express bus. Some non-PCI
+//! architectures also use message signaled interrupts.
+//!
+//! While IRQ is a term commonly used by Operating Systems when dealing with hardware interrupts,
+//! the IRQ numbers managed by OSes are independent of the ones managed by VMM. For simplicity sake,
+//! the term `Interrupt Source` is used instead of IRQ to represent both pin-based interrupts and
+//! MSI interrupts.
+//!
+//! A device may support multiple types of interrupts, and each type of interrupt may support one or
+//! multiple interrupt sources. For example, a PCI device may support:
+//! * Legacy Irq: exactly one interrupt source.
+//! * PCI MSI Irq: 1,2,4,8,16,32 interrupt sources.
+//! * PCI MSIx Irq: 2^n(n=0-11) interrupt sources.
+//!
+//! A distinct Interrupt Source Identifier (ISID) will be assigned to each interrupt source. An ID
+//! allocator will be used to allocate and free Interrupt Source Identifiers for devices. To
+//! decouple this crate from the ID allocator, here we doesn't take the responsibility to
+//! allocate/free Interrupt Source IDs but only makes use of assigned IDs.
+//!
+//! The overall flow to deal with interrupts is:
+//! * the VMM creates an interrupt manager
+//! * the VMM creates a device manager, passing on an reference to the interrupt manager
+//! * the device manager passes on an reference to the interrupt manager to all registered devices
+//! * guest kernel loads drivers for virtual devices
+//! * guest device driver determines the type and number of interrupts needed, and update the device
+//!   configuration
+//! * the virtual device backend requests the interrupt manager to create an interrupt group
+//!   according to guest configuration information
+
+mod manager;
+/// Defines the offset when device_id is recorded to msi.
+#[cfg(target_arch = "aarch64")]
+pub use manager::MSI_DEVICE_ID_SHIFT;
+pub use manager::{DeviceInterruptManager, DeviceInterruptMode, InterruptStatusRegister32};
+
+#[cfg(feature = "kvm-irq")]
+pub mod kvm;
+#[cfg(feature = "kvm-irq")]
+pub use self::kvm::KvmIrqManager;
+
+use std::io::Error;
+use std::ops::Deref;
+use std::sync::Arc;
+
+use vmm_sys_util::eventfd::EventFd;
+
+/// Reuse std::io::Result to simplify interoperability among crates.
+pub type Result<T> = std::io::Result<T>;
+
+/// Data type to store an interrupt source identifier.
+pub type InterruptIndex = u32;
+
+/// Type of interrupt source.
+#[derive(Clone, PartialEq, Debug)]
+pub enum InterruptSourceType {
+    #[cfg(feature = "legacy-irq")]
+    /// Legacy Pin-based Interrupt.
+    /// On x86 platforms, legacy interrupts are routed through 8259 PICs and/or IOAPICs.
+    LegacyIrq,
+    #[cfg(feature = "msi-irq")]
+    /// Message Signaled Interrupt (PCI MSI/PCI MSIx etc).
+    /// Some non-PCI devices (like HPET on x86) make use of generic MSI in platform specific ways.
+    MsiIrq,
+}
+
+/// Configuration data for an interrupt source.
+#[derive(Clone, Debug, PartialEq)]
+pub enum InterruptSourceConfig {
+    #[cfg(feature = "legacy-irq")]
+    /// Configuration data for Legacy interrupts.
+    LegacyIrq(LegacyIrqSourceConfig),
+    #[cfg(feature = "msi-irq")]
+    /// Configuration data for PciMsi, PciMsix and generic MSI interrupts.
+    MsiIrq(MsiIrqSourceConfig),
+}
+
+/// Configuration data for legacy interrupts.
+///
+/// On x86 platforms, legacy interrupts means those interrupts routed through PICs or IOAPICs.
+#[cfg(feature = "legacy-irq")]
+#[derive(Clone, Debug, PartialEq)]
+pub struct LegacyIrqSourceConfig {}
+
+/// Configuration data for GenericMsi, PciMsi, PciMsix interrupts.
+#[cfg(feature = "msi-irq")]
+#[derive(Default, Clone, Debug, PartialEq)]
+pub struct MsiIrqSourceConfig {
+    /// High address to deliver message signaled interrupt.
+    pub high_addr: u32,
+    /// Low address to deliver message signaled interrupt.
+    pub low_addr: u32,
+    /// Data to write to deliver message signaled interrupt.
+    pub data: u32,
+    /// Interrupt control state.
+    pub msg_ctl: u32,
+    /// Device id indicate the device who triggers this msi irq.
+    #[cfg(target_arch = "aarch64")]
+    pub device_id: Option<u32>,
+}
+
+/// Trait to manage interrupt sources for virtual device backends.
+///
+/// The InterruptManager implementations should protect itself from concurrent accesses internally,
+/// so it could be invoked from multi-threaded context.
+pub trait InterruptManager {
+    /// Create an [InterruptSourceGroup](trait.InterruptSourceGroup.html) object to manage interrupt
+    /// sources for a virtual device.
+    ///
+    /// An [InterruptSourceGroup](trait.InterruptSourceGroup.html) object manages all interrupt
+    /// sources of the same type for a virtual device.
+    ///
+    /// # Arguments
+    /// * type_: type of interrupt source.
+    /// * base: base Interrupt Source ID to be managed by the group object.
+    /// * count: number of Interrupt Sources to be managed by the group object.
+    fn create_group(
+        &self,
+        type_: InterruptSourceType,
+        base: InterruptIndex,
+        count: InterruptIndex,
+    ) -> Result<Arc<Box<dyn InterruptSourceGroup>>>;
+
+    /// Destroy an [InterruptSourceGroup](trait.InterruptSourceGroup.html) object created by
+    /// [create_group()](trait.InterruptManager.html#tymethod.create_group).
+    ///
+    /// Assume the caller takes the responsibility to disable all interrupt sources of the group
+    /// before calling destroy_group(). This assumption helps to simplify InterruptSourceGroup
+    /// implementations.
+    fn destroy_group(&self, group: Arc<Box<dyn InterruptSourceGroup>>) -> Result<()>;
+}
+
+impl<T: InterruptManager> InterruptManager for Arc<T> {
+    fn create_group(
+        &self,
+        type_: InterruptSourceType,
+        base: u32,
+        count: u32,
+    ) -> std::result::Result<Arc<Box<dyn InterruptSourceGroup>>, Error> {
+        self.deref().create_group(type_, base, count)
+    }
+
+    fn destroy_group(
+        &self,
+        group: Arc<Box<dyn InterruptSourceGroup>>,
+    ) -> std::result::Result<(), Error> {
+        self.deref().destroy_group(group)
+    }
+}
+
+/// Trait to manage a group of interrupt sources for a device.
+///
+/// A device may support several types of interrupts, and each type of interrupt may contain one or
+/// multiple continuous interrupt sources. For example, a PCI device may concurrently support:
+/// * Legacy Irq: exactly one interrupt source.
+/// * PCI MSI Irq: 1,2,4,8,16,32 interrupt sources.
+/// * PCI MSIx Irq: 2^n(n=0-11) interrupt sources.
+///
+/// PCI MSI interrupts of a device may not be configured individually, and must configured as a
+/// whole block. So all interrupts of the same type of a device are abstracted as an
+/// [InterruptSourceGroup](trait.InterruptSourceGroup.html) object, instead of abstracting each
+/// interrupt source as a distinct InterruptSource.
+#[allow(clippy::len_without_is_empty)]
+pub trait InterruptSourceGroup: Send + Sync {
+    /// Get type of interrupt sources managed by the group.
+    fn interrupt_type(&self) -> InterruptSourceType;
+
+    /// Get number of interrupt sources managed by the group.
+    fn len(&self) -> InterruptIndex;
+
+    /// Get base of the assigned Interrupt Source Identifiers.
+    fn base(&self) -> InterruptIndex;
+
+    /// Enable the interrupt sources in the group to generate interrupts.
+    fn enable(&self, configs: &[InterruptSourceConfig]) -> Result<()>;
+
+    /// Disable the interrupt sources in the group to generate interrupts.
+    fn disable(&self) -> Result<()>;
+
+    /// Update the interrupt source group configuration.
+    ///
+    /// # Arguments
+    /// * index: sub-index into the group.
+    /// * config: configuration data for the interrupt source.
+    fn update(&self, index: InterruptIndex, config: &InterruptSourceConfig) -> Result<()>;
+
+    /// Returns an interrupt notifier from this interrupt.
+    ///
+    /// An interrupt notifier allows for external components and processes to inject interrupts into
+    /// guest, by writing to the file returned by this method.
+    fn notifier(&self, _index: InterruptIndex) -> Option<&EventFd> {
+        None
+    }
+
+    /// Inject an interrupt from this interrupt source into the guest.
+    ///
+    /// If the interrupt has an associated `interrupt_status` register, all bits set in `flag` will
+    /// be atomically ORed into the `interrupt_status` register.
+    fn trigger(&self, index: InterruptIndex) -> Result<()>;
+
+    /// Mask an interrupt from this interrupt source.
+    fn mask(&self, _index: InterruptIndex) -> Result<()> {
+        // Not all interrupt sources can be disabled.
+        // To accommodate this, we can have a no-op here.
+        Ok(())
+    }
+
+    /// Unmask an interrupt from this interrupt source.
+    fn unmask(&self, _index: InterruptIndex) -> Result<()> {
+        // Not all interrupt sources can be disabled.
+        // To accommodate this, we can have a no-op here.
+        Ok(())
+    }
+
+    /// Check whether there's pending interrupt.
+    fn get_pending_state(&self, _index: InterruptIndex) -> bool {
+        false
+    }
+}

--- a/crates/dbs-interrupt/src/manager.rs
+++ b/crates/dbs-interrupt/src/manager.rs
@@ -1,0 +1,795 @@
+// Copyright (C) 2019-2020 Alibaba Cloud. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Interrupt manager to manage and switch device interrupt modes.
+//!
+//! A device may support multiple interrupt modes. For example, a PCI device may support legacy, PCI
+//! MSI and PCI MSIx interrupts. This interrupt manager helps a device backend driver to manage its
+//! interrupts and provides interfaces to switch interrupt working modes.
+use std::io::{Error, Result};
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::Arc;
+
+use dbs_device::resources::DeviceResources;
+
+#[cfg(feature = "legacy-irq")]
+use super::LegacyIrqSourceConfig;
+#[cfg(feature = "msi-irq")]
+use super::MsiIrqSourceConfig;
+use super::{InterruptManager, InterruptSourceConfig, InterruptSourceGroup, InterruptSourceType};
+
+#[cfg(target_arch = "aarch64")]
+/// Defines the offset when device_id is recorded to msi. For the origin of this value, please refer
+/// to the comment of set_msi_device_id function.
+pub const MSI_DEVICE_ID_SHIFT: u8 = 3;
+
+#[cfg(feature = "legacy-irq")]
+const LEGACY_CONFIGS: [InterruptSourceConfig; 1] =
+    [InterruptSourceConfig::LegacyIrq(LegacyIrqSourceConfig {})];
+
+#[cfg(feature = "msi-irq")]
+const MSI_INT_MASK_BIT: u8 = 0;
+#[cfg(feature = "msi-irq")]
+const MSI_INT_MASK: u32 = (1 << MSI_INT_MASK_BIT) as u32;
+
+/// Device interrupt working modes.
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum DeviceInterruptMode {
+    /// The device interrupt manager has been disabled.
+    Disabled = 0,
+    /// The device interrupt manager works in legacy irq mode.
+    LegacyIrq = 1,
+    /// The device interrupt manager works in generic MSI mode.
+    GenericMsiIrq = 2,
+    /// The device interrupt manager works in PCI MSI mode.
+    PciMsiIrq = 3,
+    /// The device interrupt manager works in PCI MSI-x mode.
+    PciMsixIrq = 4,
+}
+
+/// A struct to manage interrupts and interrupt modes for a device.
+///
+/// The interrupt manager may support multiple working mode. For example, an interrupt manager for a
+/// PCI device may work in legacy mode, PCI MSI mode or PCI MSIx mode. Under certain conditions, the
+/// interrupt manager may switch between interrupt working modes. To simplify implementation,
+/// switching working mode is only supported at configuration stage and will be disabled at runtime
+/// stage. The DeviceInterruptManager::enable() switches the interrupt manager from configuration
+/// stage into runtime stage. And DeviceInterruptManager::reset() switches from runtime stage back
+/// to initial configuration stage.
+pub struct DeviceInterruptManager<T: InterruptManager> {
+    mode: DeviceInterruptMode,
+    activated: bool,
+    current_idx: usize,
+    mode2idx: [usize; 5],
+    intr_mgr: T,
+    intr_groups: Vec<Arc<Box<dyn InterruptSourceGroup>>>,
+    #[cfg(feature = "msi-irq")]
+    msi_config: Vec<InterruptSourceConfig>,
+    /// Device id indicate the device who triggers msi irq.
+    #[cfg(target_arch = "aarch64")]
+    device_id: Option<u32>,
+}
+
+impl<T: InterruptManager> DeviceInterruptManager<T> {
+    /// Create an interrupt manager for a device.
+    ///
+    /// # Arguments
+    /// * `intr_mgr`: underline interrupt manager to allocate/free interrupt groups.
+    /// * `resources`: resources assigned to the device, including assigned interrupt resources.
+    pub fn new(intr_mgr: T, resources: &DeviceResources) -> Result<Self> {
+        let mut mgr = DeviceInterruptManager {
+            mode: DeviceInterruptMode::Disabled,
+            activated: false,
+            current_idx: usize::MAX,
+            mode2idx: [usize::MAX; 5],
+            intr_mgr,
+            intr_groups: Vec::new(),
+            #[cfg(feature = "msi-irq")]
+            msi_config: Vec::new(),
+            #[cfg(target_arch = "aarch64")]
+            device_id: None,
+        };
+
+        #[cfg(feature = "legacy-irq")]
+        {
+            if let Some(irq) = resources.get_legacy_irq() {
+                let group = mgr
+                    .intr_mgr
+                    .create_group(InterruptSourceType::LegacyIrq, irq, 1)?;
+                mgr.mode2idx[DeviceInterruptMode::LegacyIrq as usize] = mgr.intr_groups.len();
+                mgr.intr_groups.push(group);
+            }
+        }
+
+        #[cfg(feature = "msi-irq")]
+        {
+            if let Some(msi) = resources.get_generic_msi_irqs() {
+                let group = mgr
+                    .intr_mgr
+                    .create_group(InterruptSourceType::MsiIrq, msi.0, msi.1)?;
+                mgr.resize_msi_config_space(group.len());
+                mgr.mode2idx[DeviceInterruptMode::GenericMsiIrq as usize] = mgr.intr_groups.len();
+                mgr.intr_groups.push(group);
+            }
+
+            if let Some(msi) = resources.get_pci_msi_irqs() {
+                let group = mgr
+                    .intr_mgr
+                    .create_group(InterruptSourceType::MsiIrq, msi.0, msi.1)?;
+                mgr.resize_msi_config_space(group.len());
+                mgr.mode2idx[DeviceInterruptMode::PciMsiIrq as usize] = mgr.intr_groups.len();
+                mgr.intr_groups.push(group);
+            }
+
+            if let Some(msi) = resources.get_pci_msix_irqs() {
+                let group = mgr
+                    .intr_mgr
+                    .create_group(InterruptSourceType::MsiIrq, msi.0, msi.1)?;
+                mgr.resize_msi_config_space(group.len());
+                mgr.mode2idx[DeviceInterruptMode::PciMsixIrq as usize] = mgr.intr_groups.len();
+                mgr.intr_groups.push(group);
+            }
+        }
+
+        Ok(mgr)
+    }
+
+    /// Set device_id for MSI routing
+    #[cfg(target_arch = "aarch64")]
+    pub fn set_device_id(&mut self, device_id: Option<u32>) {
+        self.device_id = device_id;
+    }
+
+    /// Check whether the interrupt manager has been activated.
+    pub fn is_enabled(&self) -> bool {
+        self.activated
+    }
+
+    /// Switch the interrupt manager from configuration stage into runtime stage.
+    ///
+    /// The working mode could only be changed at configuration stage, and all requests to change
+    /// working mode at runtime stage will be rejected.
+    ///
+    /// If the interrupt manager is still in DISABLED mode when DeviceInterruptManager::enable() is
+    /// called, it will be put into LEGACY mode if LEGACY mode is supported.
+    pub fn enable(&mut self) -> Result<()> {
+        if self.activated {
+            return Ok(());
+        }
+
+        // Enter Legacy mode by default if Legacy mode is supported.
+        if self.mode == DeviceInterruptMode::Disabled
+            && self.mode2idx[DeviceInterruptMode::LegacyIrq as usize] != usize::MAX
+        {
+            self.set_working_mode(DeviceInterruptMode::LegacyIrq)?;
+        }
+        if self.mode == DeviceInterruptMode::Disabled {
+            return Err(Error::from_raw_os_error(libc::EINVAL));
+        }
+
+        self.intr_groups[self.current_idx].enable(self.get_configs(self.mode))?;
+        self.activated = true;
+
+        Ok(())
+    }
+
+    /// Switch the interrupt manager from runtime stage back into initial configuration stage.
+    ///
+    /// Currently we doesn't track the usage of interrupt group object given out by `get_group()`,
+    /// so the the caller needs to take the responsibility to release all interrupt group object
+    /// reference before calling DeviceInterruptManager::reset().
+    pub fn reset(&mut self) -> Result<()> {
+        if self.activated {
+            self.activated = false;
+            self.intr_groups[self.current_idx].disable()?;
+        }
+        self.set_working_mode(DeviceInterruptMode::Disabled)?;
+
+        Ok(())
+    }
+
+    /// Get the current interrupt working mode.
+    pub fn get_working_mode(&mut self) -> DeviceInterruptMode {
+        self.mode
+    }
+
+    /// Switch interrupt working mode.
+    ///
+    /// Currently switching working mode is only supported during device configuration stage and
+    /// will always return failure if called during device runtime stage. The device switches from
+    /// configuration stage to runtime stage by invoking `DeviceInterruptManager::enable()`. With
+    /// this constraint, the device drivers may call `DeviceInterruptManager::get_group()` to get
+    /// the underline active interrupt group object, and directly calls the interrupt group object's
+    /// methods to trigger/acknowledge interrupts.
+    ///
+    /// This is a key design decision for optimizing performance. Though the DeviceInterruptManager
+    /// object itself is not multi-thread safe and must be protected from concurrent access by the
+    /// caller, the interrupt source group object is multi-thread safe and could be called
+    /// concurrently to trigger/acknowledge interrupts. This design may help to improve performance
+    /// for MSI interrupts.
+    ///
+    /// # Arguments
+    /// * `mode`: target working mode.
+    pub fn set_working_mode(&mut self, mode: DeviceInterruptMode) -> Result<()> {
+        // Can't switch mode agian once enabled.
+        if self.activated {
+            return Err(Error::from_raw_os_error(libc::EINVAL));
+        }
+
+        if mode != self.mode {
+            // Supported state transitions:
+            // - other state -> DISABLED
+            // - DISABLED -> other
+            // - non-legacy -> legacy
+            // - legacy -> non-legacy
+            if self.mode != DeviceInterruptMode::Disabled
+                && self.mode != DeviceInterruptMode::LegacyIrq
+                && mode != DeviceInterruptMode::LegacyIrq
+                && mode != DeviceInterruptMode::Disabled
+            {
+                return Err(Error::from_raw_os_error(libc::EINVAL));
+            }
+
+            // Then enter new state
+            if mode != DeviceInterruptMode::Disabled {
+                self.current_idx = self.mode2idx[mode as usize];
+            } else {
+                // We should reset irq configs when disable interrupt
+                self.reset_configs(mode);
+            }
+            self.mode = mode;
+        }
+
+        Ok(())
+    }
+
+    /// Get the underline interrupt source group object, so the device driver could concurrently
+    /// trigger/acknowledge interrupts by using the returned group object.
+    pub fn get_group(&self) -> Option<Arc<Box<dyn InterruptSourceGroup>>> {
+        if !self.activated || self.mode == DeviceInterruptMode::Disabled {
+            None
+        } else {
+            Some(self.intr_groups[self.current_idx].clone())
+        }
+    }
+
+    /// Get the underline interrupt source group object, ignore the mode
+    pub fn get_group_unchecked(&self) -> Arc<Box<dyn InterruptSourceGroup>> {
+        self.intr_groups[self.current_idx].clone()
+    }
+
+    /// Reconfigure a specific interrupt in current working mode at configuration or runtime stage.
+    ///
+    /// It's mainly used to reconfigure Generic MSI/PCI MSI/PCI MSIx interrupts. Actually legacy
+    /// interrupts don't support reconfiguration yet.
+    #[allow(unused_variables)]
+    pub fn update(&mut self, index: u32) -> Result<()> {
+        if !self.activated {
+            return Err(Error::from_raw_os_error(libc::EINVAL));
+        }
+
+        match self.mode {
+            #[cfg(feature = "msi-irq")]
+            DeviceInterruptMode::GenericMsiIrq
+            | DeviceInterruptMode::PciMsiIrq
+            | DeviceInterruptMode::PciMsixIrq => {
+                let group = &self.intr_groups[self.current_idx as usize];
+                if index >= group.len() || index >= self.msi_config.len() as u32 {
+                    return Err(Error::from_raw_os_error(libc::EINVAL));
+                }
+                group.update(index, &self.msi_config[index as usize])?;
+                Ok(())
+            }
+            _ => Err(Error::from_raw_os_error(libc::EINVAL)),
+        }
+    }
+
+    fn get_configs(&self, mode: DeviceInterruptMode) -> &[InterruptSourceConfig] {
+        match mode {
+            #[cfg(feature = "legacy-irq")]
+            DeviceInterruptMode::LegacyIrq => &LEGACY_CONFIGS[..],
+            #[cfg(feature = "msi-irq")]
+            DeviceInterruptMode::GenericMsiIrq
+            | DeviceInterruptMode::PciMsiIrq
+            | DeviceInterruptMode::PciMsixIrq => {
+                let idx = self.mode2idx[mode as usize];
+                let group_len = self.intr_groups[idx].len() as usize;
+                &self.msi_config[0..group_len]
+            }
+            _ => panic!("unhandled interrupt type in get_configs()"),
+        }
+    }
+
+    fn reset_configs(&mut self, mode: DeviceInterruptMode) {
+        match mode {
+            #[cfg(feature = "msi-irq")]
+            DeviceInterruptMode::GenericMsiIrq
+            | DeviceInterruptMode::PciMsiIrq
+            | DeviceInterruptMode::PciMsixIrq => {
+                self.msi_config = vec![
+                    InterruptSourceConfig::MsiIrq(MsiIrqSourceConfig::default());
+                    self.msi_config.len()
+                ];
+            }
+            _ => {}
+        }
+    }
+}
+
+#[cfg(feature = "msi-irq")]
+impl<T: InterruptManager> DeviceInterruptManager<T> {
+    /// Set the high address for a MSI message.
+    #[allow(irrefutable_let_patterns)]
+    pub fn set_msi_high_address(&mut self, index: u32, data: u32) -> Result<()> {
+        if (index as usize) < self.msi_config.len() {
+            if let InterruptSourceConfig::MsiIrq(ref mut msi) = self.msi_config[index as usize] {
+                msi.high_addr = data;
+                return Ok(());
+            }
+        }
+        Err(Error::from_raw_os_error(libc::EINVAL))
+    }
+
+    /// Set the low address for a MSI message.
+    #[allow(irrefutable_let_patterns)]
+    pub fn set_msi_low_address(&mut self, index: u32, data: u32) -> Result<()> {
+        if (index as usize) < self.msi_config.len() {
+            if let InterruptSourceConfig::MsiIrq(ref mut msi) = self.msi_config[index as usize] {
+                msi.low_addr = data;
+                return Ok(());
+            }
+        }
+        Err(Error::from_raw_os_error(libc::EINVAL))
+    }
+
+    /// Set the data for a MSI message.
+    #[allow(irrefutable_let_patterns)]
+    pub fn set_msi_data(&mut self, index: u32, data: u32) -> Result<()> {
+        if (index as usize) < self.msi_config.len() {
+            if let InterruptSourceConfig::MsiIrq(ref mut msi) = self.msi_config[index as usize] {
+                msi.data = data;
+                return Ok(());
+            }
+        }
+        Err(Error::from_raw_os_error(libc::EINVAL))
+    }
+
+    /// Set msi irq MASK bit
+    #[allow(irrefutable_let_patterns)]
+    pub fn set_msi_mask(&mut self, index: u32, mask: bool) -> Result<()> {
+        if (index as usize) < self.msi_config.len() {
+            if let InterruptSourceConfig::MsiIrq(ref mut msi) = self.msi_config[index as usize] {
+                let mut msg_ctl = msi.msg_ctl;
+                msg_ctl &= !MSI_INT_MASK;
+                if mask {
+                    msg_ctl |= MSI_INT_MASK;
+                }
+                msi.msg_ctl = msg_ctl;
+                return Ok(());
+            }
+        }
+        Err(Error::from_raw_os_error(libc::EINVAL))
+    }
+
+    /// Get msi irq MASK state
+    #[allow(irrefutable_let_patterns)]
+    pub fn get_msi_mask(&self, index: u32) -> Result<bool> {
+        if (index as usize) < self.msi_config.len() {
+            if let InterruptSourceConfig::MsiIrq(ref msi) = self.msi_config[index as usize] {
+                return Ok((msi.msg_ctl & MSI_INT_MASK) == MSI_INT_MASK);
+            }
+        }
+        Err(Error::from_raw_os_error(libc::EINVAL))
+    }
+
+    /// Set the device id for a MSI irq
+    #[cfg(target_arch = "aarch64")]
+    pub fn set_msi_device_id(&mut self, index: u32) -> Result<()> {
+        if (index as usize) < self.msi_config.len() {
+            if let InterruptSourceConfig::MsiIrq(ref mut msi) = self.msi_config[index as usize] {
+                msi.device_id = match self.device_id {
+                    // An pci device attach to ITS will have a new device id which is use for msi
+                    // irq routing.  It is caculated according to kernel function PCI_DEVID(),
+                    // new_dev_id = (bus << 8) | devfn. In addition, devfn = device_id << 3, accord
+                    // to pci-host-ecam-generic's spec, and we implement bus = 0.
+                    Some(dev_id) => Some(dev_id << MSI_DEVICE_ID_SHIFT),
+                    None => None,
+                };
+                return Ok(());
+            }
+        }
+        Err(Error::from_raw_os_error(libc::EINVAL))
+    }
+
+    fn resize_msi_config_space(&mut self, size: u32) {
+        if self.msi_config.len() < size as usize {
+            self.msi_config =
+                vec![InterruptSourceConfig::MsiIrq(MsiIrqSourceConfig::default()); size as usize];
+        }
+    }
+}
+
+/// Struct to implement a 32-bit interrupt status register.
+#[derive(Default, Debug)]
+pub struct InterruptStatusRegister32 {
+    status: AtomicU32,
+}
+
+impl InterruptStatusRegister32 {
+    /// Create a status register instance.
+    pub fn new() -> Self {
+        InterruptStatusRegister32 {
+            status: AtomicU32::new(0),
+        }
+    }
+
+    /// Read current value of the status register.
+    pub fn read(&self) -> u32 {
+        self.status.load(Ordering::SeqCst)
+    }
+
+    /// Write value to the status register.
+    pub fn write(&self, value: u32) {
+        self.status.store(value, Ordering::SeqCst);
+    }
+
+    /// Read current value and reset the status register to 0.
+    pub fn read_and_clear(&self) -> u32 {
+        self.status.swap(0, Ordering::SeqCst)
+    }
+
+    /// Set bits into `value`.
+    pub fn set_bits(&self, value: u32) {
+        self.status.fetch_or(value, Ordering::SeqCst);
+    }
+
+    /// Clear bits present in `value`.
+    pub fn clear_bits(&self, value: u32) {
+        self.status.fetch_and(!value, Ordering::SeqCst);
+    }
+}
+
+#[cfg(all(test, feature = "kvm-legacy-irq", feature = "kvm-msi-irq"))]
+pub(crate) mod tests {
+    use std::sync::Arc;
+
+    use dbs_device::resources::{DeviceResources, MsiIrqType, Resource};
+    use kvm_ioctls::{Kvm, VmFd};
+
+    use super::*;
+    use crate::KvmIrqManager;
+
+    pub(crate) fn create_vm_fd() -> VmFd {
+        let kvm = Kvm::new().unwrap();
+        kvm.create_vm().unwrap()
+    }
+
+    fn create_init_resources() -> DeviceResources {
+        let mut resources = DeviceResources::new();
+
+        resources.append(Resource::MmioAddressRange {
+            base: 0xd000_0000,
+            size: 0x10_0000,
+        });
+        resources.append(Resource::LegacyIrq(0));
+        resources.append(Resource::MsiIrq {
+            ty: MsiIrqType::GenericMsi,
+            base: 0x200,
+            size: 0x10,
+        });
+        resources.append(Resource::MsiIrq {
+            ty: MsiIrqType::PciMsi,
+            base: 0x100,
+            size: 0x20,
+        });
+        resources.append(Resource::MsiIrq {
+            ty: MsiIrqType::PciMsix,
+            base: 0x300,
+            size: 0x30,
+        });
+
+        resources
+    }
+
+    fn create_interrupt_manager() -> DeviceInterruptManager<Arc<KvmIrqManager>> {
+        let vmfd = Arc::new(create_vm_fd());
+        assert!(vmfd.create_irq_chip().is_ok());
+        let intr_mgr = Arc::new(KvmIrqManager::new(vmfd));
+
+        let resource = create_init_resources();
+        assert!(intr_mgr.initialize().is_ok());
+        DeviceInterruptManager::new(intr_mgr, &resource).unwrap()
+    }
+
+    #[test]
+    fn test_create_device_interrupt_manager() {
+        let mut mgr = create_interrupt_manager();
+
+        assert_eq!(mgr.mode, DeviceInterruptMode::Disabled);
+        assert!(!mgr.activated);
+        assert_eq!(mgr.current_idx, usize::MAX);
+        assert_eq!(mgr.intr_groups.len(), 4);
+        assert!(!mgr.is_enabled());
+        assert!(mgr.get_group().is_none());
+
+        // Enter legacy mode by default
+        mgr.enable().unwrap();
+        assert!(mgr.is_enabled());
+        assert_eq!(
+            mgr.mode2idx[DeviceInterruptMode::LegacyIrq as usize],
+            mgr.current_idx
+        );
+        assert!(mgr.get_group().is_some());
+        assert_eq!(
+            mgr.get_group_unchecked().interrupt_type(),
+            InterruptSourceType::LegacyIrq
+        );
+
+        // Disable interrupt manager
+        mgr.reset().unwrap();
+        assert!(!mgr.is_enabled());
+        assert_eq!(
+            mgr.mode2idx[DeviceInterruptMode::LegacyIrq as usize],
+            mgr.current_idx
+        );
+        assert_eq!(mgr.get_working_mode(), DeviceInterruptMode::Disabled);
+        assert!(mgr.get_group().is_none());
+    }
+
+    #[test]
+    fn test_device_interrupt_manager_switch_mode() {
+        let mut mgr = create_interrupt_manager();
+
+        // Can't switch working mode in enabled state.
+        mgr.enable().unwrap();
+        mgr.set_working_mode(DeviceInterruptMode::PciMsiIrq)
+            .unwrap_err();
+        mgr.set_working_mode(DeviceInterruptMode::PciMsixIrq)
+            .unwrap_err();
+        mgr.set_working_mode(DeviceInterruptMode::GenericMsiIrq)
+            .unwrap_err();
+        mgr.reset().unwrap();
+
+        // Switch from LEGACY to PciMsi mode
+        mgr.set_working_mode(DeviceInterruptMode::LegacyIrq)
+            .unwrap();
+        mgr.set_working_mode(DeviceInterruptMode::LegacyIrq)
+            .unwrap();
+        mgr.set_working_mode(DeviceInterruptMode::PciMsiIrq)
+            .unwrap();
+        mgr.set_working_mode(DeviceInterruptMode::PciMsiIrq)
+            .unwrap();
+        mgr.set_working_mode(DeviceInterruptMode::PciMsixIrq)
+            .unwrap_err();
+        mgr.set_working_mode(DeviceInterruptMode::GenericMsiIrq)
+            .unwrap_err();
+
+        // Switch from LEGACY to PciMsix mode
+        mgr.set_working_mode(DeviceInterruptMode::LegacyIrq)
+            .unwrap();
+        mgr.set_working_mode(DeviceInterruptMode::PciMsixIrq)
+            .unwrap();
+        mgr.set_working_mode(DeviceInterruptMode::PciMsixIrq)
+            .unwrap();
+        mgr.set_working_mode(DeviceInterruptMode::PciMsiIrq)
+            .unwrap_err();
+        mgr.set_working_mode(DeviceInterruptMode::GenericMsiIrq)
+            .unwrap_err();
+
+        // Switch from LEGACY to GenericMsi mode
+        mgr.set_working_mode(DeviceInterruptMode::LegacyIrq)
+            .unwrap();
+        mgr.set_working_mode(DeviceInterruptMode::GenericMsiIrq)
+            .unwrap();
+        mgr.set_working_mode(DeviceInterruptMode::GenericMsiIrq)
+            .unwrap();
+        mgr.set_working_mode(DeviceInterruptMode::PciMsiIrq)
+            .unwrap_err();
+        mgr.set_working_mode(DeviceInterruptMode::PciMsixIrq)
+            .unwrap_err();
+
+        // Switch from DISABLED to PciMsi mode
+        mgr.set_working_mode(DeviceInterruptMode::Disabled).unwrap();
+        mgr.set_working_mode(DeviceInterruptMode::Disabled).unwrap();
+        mgr.set_working_mode(DeviceInterruptMode::PciMsiIrq)
+            .unwrap();
+        mgr.set_working_mode(DeviceInterruptMode::PciMsixIrq)
+            .unwrap_err();
+        mgr.set_working_mode(DeviceInterruptMode::GenericMsiIrq)
+            .unwrap_err();
+
+        // Switch from DISABLED to PciMsix mode
+        mgr.set_working_mode(DeviceInterruptMode::Disabled).unwrap();
+        mgr.set_working_mode(DeviceInterruptMode::PciMsixIrq)
+            .unwrap();
+        mgr.set_working_mode(DeviceInterruptMode::PciMsiIrq)
+            .unwrap_err();
+        mgr.set_working_mode(DeviceInterruptMode::GenericMsiIrq)
+            .unwrap_err();
+
+        // Switch from DISABLED to GenericMsi mode
+        mgr.set_working_mode(DeviceInterruptMode::Disabled).unwrap();
+        mgr.set_working_mode(DeviceInterruptMode::GenericMsiIrq)
+            .unwrap();
+        mgr.set_working_mode(DeviceInterruptMode::PciMsiIrq)
+            .unwrap_err();
+        mgr.set_working_mode(DeviceInterruptMode::PciMsixIrq)
+            .unwrap_err();
+
+        mgr.set_working_mode(DeviceInterruptMode::Disabled).unwrap();
+        mgr.set_working_mode(DeviceInterruptMode::Disabled).unwrap();
+    }
+
+    #[test]
+    fn test_msi_config() {
+        let mut interrupt_manager = create_interrupt_manager();
+
+        assert!(interrupt_manager.set_msi_data(512, 0).is_err());
+        assert!(interrupt_manager.set_msi_data(0, 0).is_ok());
+        assert!(interrupt_manager.set_msi_high_address(512, 0).is_err());
+        assert!(interrupt_manager.set_msi_high_address(0, 0).is_ok());
+        assert!(interrupt_manager.set_msi_low_address(512, 0).is_err());
+        assert!(interrupt_manager.set_msi_low_address(0, 0).is_ok());
+        assert!(interrupt_manager.get_msi_mask(512).is_err());
+        assert!(!interrupt_manager.get_msi_mask(0).unwrap());
+        assert!(interrupt_manager.set_msi_mask(512, true).is_err());
+        assert!(interrupt_manager.set_msi_mask(0, true).is_ok());
+        assert!(interrupt_manager.get_msi_mask(0).unwrap());
+    }
+
+    #[test]
+    fn test_set_working_mode_after_activated() {
+        let mut interrupt_manager = create_interrupt_manager();
+        interrupt_manager.activated = true;
+        assert!(interrupt_manager
+            .set_working_mode(DeviceInterruptMode::Disabled)
+            .is_err());
+        assert!(interrupt_manager
+            .set_working_mode(DeviceInterruptMode::GenericMsiIrq)
+            .is_err());
+        assert!(interrupt_manager
+            .set_working_mode(DeviceInterruptMode::LegacyIrq)
+            .is_err());
+        assert!(interrupt_manager
+            .set_working_mode(DeviceInterruptMode::PciMsiIrq)
+            .is_err());
+        assert!(interrupt_manager
+            .set_working_mode(DeviceInterruptMode::PciMsixIrq)
+            .is_err());
+    }
+
+    #[test]
+    fn test_disable2legacy() {
+        let mut interrupt_manager = create_interrupt_manager();
+        interrupt_manager.activated = false;
+        interrupt_manager.mode = DeviceInterruptMode::Disabled;
+        assert!(interrupt_manager
+            .set_working_mode(DeviceInterruptMode::LegacyIrq)
+            .is_ok());
+    }
+
+    #[test]
+    fn test_disable2nonlegacy() {
+        let mut interrupt_manager = create_interrupt_manager();
+        interrupt_manager.activated = false;
+        interrupt_manager.mode = DeviceInterruptMode::Disabled;
+        assert!(interrupt_manager
+            .set_working_mode(DeviceInterruptMode::GenericMsiIrq)
+            .is_ok());
+    }
+
+    #[test]
+    fn test_legacy2nonlegacy() {
+        let mut interrupt_manager = create_interrupt_manager();
+        interrupt_manager.activated = false;
+        interrupt_manager.mode = DeviceInterruptMode::Disabled;
+        assert!(interrupt_manager
+            .set_working_mode(DeviceInterruptMode::LegacyIrq)
+            .is_ok());
+        assert!(interrupt_manager
+            .set_working_mode(DeviceInterruptMode::GenericMsiIrq)
+            .is_ok());
+    }
+
+    #[test]
+    fn test_nonlegacy2legacy() {
+        let mut interrupt_manager = create_interrupt_manager();
+        interrupt_manager.activated = false;
+        interrupt_manager.mode = DeviceInterruptMode::Disabled;
+        assert!(interrupt_manager
+            .set_working_mode(DeviceInterruptMode::GenericMsiIrq)
+            .is_ok());
+        assert!(interrupt_manager
+            .set_working_mode(DeviceInterruptMode::LegacyIrq)
+            .is_ok());
+    }
+
+    #[test]
+    fn test_update() {
+        let mut interrupt_manager = create_interrupt_manager();
+        assert!(interrupt_manager
+            .set_working_mode(DeviceInterruptMode::GenericMsiIrq)
+            .is_ok());
+        assert!(interrupt_manager.enable().is_ok());
+        assert!(interrupt_manager.update(0x10).is_err());
+        assert!(interrupt_manager.update(0x01).is_ok());
+        assert!(interrupt_manager.reset().is_ok());
+        assert!(interrupt_manager
+            .set_working_mode(DeviceInterruptMode::LegacyIrq)
+            .is_ok());
+        assert!(interrupt_manager.update(0x10).is_err());
+    }
+
+    #[test]
+    fn test_get_configs() {
+        // legacy irq config
+        {
+            let interrupt_manager = create_interrupt_manager();
+
+            let legacy_config = interrupt_manager.get_configs(DeviceInterruptMode::LegacyIrq);
+            assert_eq!(legacy_config, LEGACY_CONFIGS);
+        }
+
+        // generic irq config
+        {
+            let mut interrupt_manager = create_interrupt_manager();
+            interrupt_manager
+                .set_working_mode(DeviceInterruptMode::GenericMsiIrq)
+                .unwrap();
+            let msi_config = interrupt_manager.get_configs(DeviceInterruptMode::GenericMsiIrq);
+            assert_eq!(msi_config.len(), 0x10);
+        }
+
+        // msi irq config
+        {
+            let mut interrupt_manager = create_interrupt_manager();
+            interrupt_manager
+                .set_working_mode(DeviceInterruptMode::PciMsiIrq)
+                .unwrap();
+            let msi_config = interrupt_manager.get_configs(DeviceInterruptMode::PciMsiIrq);
+            assert_eq!(msi_config.len(), 0x20);
+        }
+
+        // msix irq config
+        {
+            let mut interrupt_manager = create_interrupt_manager();
+            interrupt_manager
+                .set_working_mode(DeviceInterruptMode::PciMsixIrq)
+                .unwrap();
+            let msi_config = interrupt_manager.get_configs(DeviceInterruptMode::PciMsixIrq);
+            assert_eq!(msi_config.len(), 0x30);
+        }
+    }
+
+    #[test]
+    fn test_reset_configs() {
+        let mut interrupt_manager = create_interrupt_manager();
+
+        interrupt_manager.reset_configs(DeviceInterruptMode::LegacyIrq);
+        interrupt_manager.reset_configs(DeviceInterruptMode::LegacyIrq);
+
+        interrupt_manager.set_msi_data(0, 100).unwrap();
+        interrupt_manager.set_msi_high_address(0, 200).unwrap();
+        interrupt_manager.set_msi_low_address(0, 300).unwrap();
+
+        interrupt_manager.reset_configs(DeviceInterruptMode::GenericMsiIrq);
+        assert_eq!(
+            interrupt_manager.msi_config[0],
+            InterruptSourceConfig::MsiIrq(MsiIrqSourceConfig::default())
+        );
+    }
+
+    #[test]
+    fn test_interrupt_status_register() {
+        let status = InterruptStatusRegister32::new();
+
+        assert_eq!(status.read(), 0);
+        status.write(0x13);
+        assert_eq!(status.read(), 0x13);
+        status.clear_bits(0x11);
+        assert_eq!(status.read(), 0x2);
+        status.set_bits(0x100);
+        assert_eq!(status.read_and_clear(), 0x102);
+        assert_eq!(status.read(), 0);
+    }
+}


### PR DESCRIPTION
This patch introduces traits and structs to manage interrupt sources for
devices, including the abstraction of interrupt manager and its implementation
based on kvm framework.

Signed-off-by: Alibaba Dragonball Team
Signed-off-by: Zizheng Bian <zizheng.bian@linux.alibaba.com>