### PR TITLE
dbs-interrupt: use unwrap instead of is_ok in tests.

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Run test
         working-directory: .github
-        run: vagrant ssh -c 'export CARGO_INCREMENTAL=0; export RUSTFLAGS="-Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests -Cpanic=abort"; export RUSTDOCFLAGS=-Cpanic=abort; cd /vagrant; cargo clean; sudo -E cargo test $CARGO_OPTIONS -- -Z unstable-options --test-threads 1'
+        run: vagrant ssh -c 'export CARGO_INCREMENTAL=0; export RUSTFLAGS="-Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests -Cpanic=abort"; export RUSTDOCFLAGS=-Cpanic=abort; cd /vagrant; cargo clean; sudo -E cargo test --all-features $CARGO_OPTIONS -- -Z unstable-options --test-threads 1'
 
       - name: Coverage
         uses: actions-rs/grcov@v0.1

--- a/crates/dbs-interrupt/src/kvm/legacy_irq.rs
+++ b/crates/dbs-interrupt/src/kvm/legacy_irq.rs
@@ -239,6 +239,7 @@ mod test {
                 panic!();
             }
         }
+        vmfd.create_irq_chip().unwrap();
         assert_eq!(group.len(), 1);
         assert_eq!(group.base(), base);
         group.enable(&legacy_fds).unwrap();

--- a/crates/dbs-interrupt/src/kvm/legacy_irq.rs
+++ b/crates/dbs-interrupt/src/kvm/legacy_irq.rs
@@ -134,6 +134,7 @@ impl InterruptSourceGroup for LegacyIrq {
         if configs.len() != 1 {
             return Err(std::io::Error::from_raw_os_error(libc::EINVAL));
         }
+
         // The IRQ routings for legacy IRQs have been configured during KvmIrqManager::initialize(),
         // so only need to register irqfd to the KVM driver.
         self.vmfd
@@ -240,17 +241,17 @@ mod test {
         }
         assert_eq!(group.len(), 1);
         assert_eq!(group.base(), base);
-        assert!(group.enable(&legacy_fds).is_ok());
-        assert!(group.notifier(0).unwrap().write(1).is_ok());
-        assert!(group.trigger(0).is_ok());
+        group.enable(&legacy_fds).unwrap();
+        group.notifier(0).unwrap().write(1).unwrap();
+        group.trigger(0).unwrap();
         assert!(group.trigger(1).is_err());
-        assert!(group
+        group
             .update(
                 0,
-                &InterruptSourceConfig::LegacyIrq(LegacyIrqSourceConfig {})
+                &InterruptSourceConfig::LegacyIrq(LegacyIrqSourceConfig {}),
             )
-            .is_ok());
-        assert!(group.disable().is_ok());
+            .unwrap();
+        group.disable().unwrap();
 
         assert!(LegacyIrq::new(base, 2, vmfd.clone(), rounting.clone()).is_err());
         assert!(LegacyIrq::new(110, 1, vmfd, rounting).is_err());

--- a/crates/dbs-interrupt/src/kvm/mod.rs
+++ b/crates/dbs-interrupt/src/kvm/mod.rs
@@ -303,16 +303,16 @@ mod tests {
     fn test_create_kvm_irq_manager() {
         let vmfd = Arc::new(create_vm_fd());
         let manager = KvmIrqManager::new(vmfd.clone());
-        assert!(vmfd.create_irq_chip().is_ok());
-        assert!(manager.initialize().is_ok());
+        vmfd.create_irq_chip().unwrap();
+        manager.initialize().unwrap();
     }
 
     #[test]
     fn test_kvm_irq_manager_opt() {
         let vmfd = Arc::new(create_vm_fd());
-        assert!(vmfd.create_irq_chip().is_ok());
+        vmfd.create_irq_chip().unwrap();
         let manager = Arc::new(KvmIrqManager::new(vmfd.clone()));
-        assert!(manager.initialize().is_ok());
+        manager.initialize().unwrap();
 
         // set max irqs
         manager.set_max_msi_irqs(0x128);
@@ -321,12 +321,12 @@ mod tests {
         // irq
         let group = create_irq_group(manager.clone(), vmfd.clone());
         let _ = group.clone();
-        assert!(manager.destroy_group(group).is_ok());
+        manager.destroy_group(group).unwrap();
 
         // msi
         let group = create_msi_group(manager.clone(), vmfd);
         let _ = group.clone();
-        assert!(manager.destroy_group(group).is_ok());
+        manager.destroy_group(group).unwrap();
     }
 
     #[test]
@@ -337,8 +337,8 @@ mod tests {
         // this would ok on 4.9 kernel
         assert!(routing.initialize().is_err());
 
-        assert!(vmfd.create_irq_chip().is_ok());
-        assert!(routing.initialize().is_ok());
+        vmfd.create_irq_chip().unwrap();
+        routing.initialize().unwrap();
 
         let routes = &routing.routes.lock().unwrap();
         assert_eq!(routes.len(), MASTER_PIC + SLAVE_PIC + IOAPIC);
@@ -352,8 +352,8 @@ mod tests {
         // this would ok on 4.9 kernel
         assert!(routing.initialize().is_err());
 
-        assert!(vmfd.create_irq_chip().is_ok());
-        assert!(routing.initialize().is_ok());
+        vmfd.create_irq_chip().unwrap();
+        routing.initialize().unwrap();
 
         let mut entry = kvm_irq_routing_entry {
             gsi: 8,
@@ -368,10 +368,10 @@ mod tests {
         let entrys = vec![entry];
 
         assert!(routing.modify(&entry).is_err());
-        assert!(routing.add(&entrys).is_ok());
+        routing.add(&entrys).unwrap();
         entry.u.irqchip.pin = 4;
-        assert!(routing.modify(&entry).is_ok());
-        assert!(routing.remove(&entrys).is_ok());
+        routing.modify(&entry).unwrap();
+        routing.remove(&entrys).unwrap();
         assert!(routing.modify(&entry).is_err());
     }
 
@@ -383,8 +383,8 @@ mod tests {
         // this would ok on 4.9 kernel
         assert!(routing.initialize().is_err());
 
-        assert!(vmfd.create_irq_chip().is_ok());
-        assert!(routing.initialize().is_ok());
+        vmfd.create_irq_chip().unwrap();
+        routing.initialize().unwrap();
 
         let mut entry = kvm_irq_routing_entry {
             gsi: 8,
@@ -400,7 +400,7 @@ mod tests {
             .unwrap()
             .insert(hash_key(&entry), entry);
         let routes = routing.routes.lock().unwrap();
-        assert!(routing.set_routing(&routes).is_ok());
+        routing.set_routing(&routes).unwrap();
     }
 
     #[test]

--- a/crates/dbs-interrupt/src/kvm/msi_irq.rs
+++ b/crates/dbs-interrupt/src/kvm/msi_irq.rs
@@ -210,10 +210,10 @@ mod test {
     #[allow(unreachable_patterns)]
     fn test_msi_interrupt_group() {
         let vmfd = Arc::new(create_vm_fd());
-        assert!(vmfd.create_irq_chip().is_ok());
+        vmfd.create_irq_chip().unwrap();
 
         let rounting = Arc::new(KvmIrqRouting::new(vmfd.clone()));
-        assert!(rounting.initialize().is_ok());
+        rounting.initialize().unwrap();
 
         let base = 168;
         let count = 32;
@@ -244,7 +244,7 @@ mod test {
             msi_fds.push(InterruptSourceConfig::MsiIrq(msi_source_config));
         }
 
-        assert!(group.enable(&msi_fds).is_ok());
+        group.enable(&msi_fds).unwrap();
         assert_eq!(group.len(), count);
         assert_eq!(group.base(), base);
 
@@ -255,14 +255,14 @@ mod test {
                 data: i + 0x9876,
                 msg_ctl: i + 0x6789,
             };
-            assert!(group.notifier(i).unwrap().write(1).is_ok());
-            assert!(group.trigger(i).is_ok());
-            assert!(group
+            group.notifier(i).unwrap().write(1).unwrap();
+            group.trigger(i).unwrap();
+            group
                 .update(0, &InterruptSourceConfig::MsiIrq(msi_source_config))
-                .is_ok());
+                .unwrap();
         }
         assert!(group.trigger(33).is_err());
-        assert!(group.disable().is_ok());
+        group.disable().unwrap();
 
         assert!(MsiIrq::new(
             base,

--- a/crates/dbs-interrupt/src/manager.rs
+++ b/crates/dbs-interrupt/src/manager.rs
@@ -493,11 +493,11 @@ pub(crate) mod tests {
 
     fn create_interrupt_manager() -> DeviceInterruptManager<Arc<KvmIrqManager>> {
         let vmfd = Arc::new(create_vm_fd());
-        assert!(vmfd.create_irq_chip().is_ok());
+        vmfd.create_irq_chip().unwrap();
         let intr_mgr = Arc::new(KvmIrqManager::new(vmfd));
 
         let resource = create_init_resources();
-        assert!(intr_mgr.initialize().is_ok());
+        intr_mgr.initialize().unwrap();
         DeviceInterruptManager::new(intr_mgr, &resource).unwrap()
     }
 
@@ -625,15 +625,15 @@ pub(crate) mod tests {
         let mut interrupt_manager = create_interrupt_manager();
 
         assert!(interrupt_manager.set_msi_data(512, 0).is_err());
-        assert!(interrupt_manager.set_msi_data(0, 0).is_ok());
+        interrupt_manager.set_msi_data(0, 0).unwrap();
         assert!(interrupt_manager.set_msi_high_address(512, 0).is_err());
-        assert!(interrupt_manager.set_msi_high_address(0, 0).is_ok());
+        interrupt_manager.set_msi_high_address(0, 0).unwrap();
         assert!(interrupt_manager.set_msi_low_address(512, 0).is_err());
-        assert!(interrupt_manager.set_msi_low_address(0, 0).is_ok());
+        interrupt_manager.set_msi_low_address(0, 0).unwrap();
         assert!(interrupt_manager.get_msi_mask(512).is_err());
         assert!(!interrupt_manager.get_msi_mask(0).unwrap());
         assert!(interrupt_manager.set_msi_mask(512, true).is_err());
-        assert!(interrupt_manager.set_msi_mask(0, true).is_ok());
+        interrupt_manager.set_msi_mask(0, true).unwrap();
         assert!(interrupt_manager.get_msi_mask(0).unwrap());
     }
 
@@ -663,9 +663,9 @@ pub(crate) mod tests {
         let mut interrupt_manager = create_interrupt_manager();
         interrupt_manager.activated = false;
         interrupt_manager.mode = DeviceInterruptMode::Disabled;
-        assert!(interrupt_manager
+        interrupt_manager
             .set_working_mode(DeviceInterruptMode::LegacyIrq)
-            .is_ok());
+            .unwrap();
     }
 
     #[test]
@@ -673,9 +673,9 @@ pub(crate) mod tests {
         let mut interrupt_manager = create_interrupt_manager();
         interrupt_manager.activated = false;
         interrupt_manager.mode = DeviceInterruptMode::Disabled;
-        assert!(interrupt_manager
+        interrupt_manager
             .set_working_mode(DeviceInterruptMode::GenericMsiIrq)
-            .is_ok());
+            .unwrap();
     }
 
     #[test]
@@ -683,12 +683,12 @@ pub(crate) mod tests {
         let mut interrupt_manager = create_interrupt_manager();
         interrupt_manager.activated = false;
         interrupt_manager.mode = DeviceInterruptMode::Disabled;
-        assert!(interrupt_manager
+        interrupt_manager
             .set_working_mode(DeviceInterruptMode::LegacyIrq)
-            .is_ok());
-        assert!(interrupt_manager
+            .unwrap();
+        interrupt_manager
             .set_working_mode(DeviceInterruptMode::GenericMsiIrq)
-            .is_ok());
+            .unwrap();
     }
 
     #[test]
@@ -696,27 +696,27 @@ pub(crate) mod tests {
         let mut interrupt_manager = create_interrupt_manager();
         interrupt_manager.activated = false;
         interrupt_manager.mode = DeviceInterruptMode::Disabled;
-        assert!(interrupt_manager
+        interrupt_manager
             .set_working_mode(DeviceInterruptMode::GenericMsiIrq)
-            .is_ok());
-        assert!(interrupt_manager
+            .unwrap();
+        interrupt_manager
             .set_working_mode(DeviceInterruptMode::LegacyIrq)
-            .is_ok());
+            .unwrap();
     }
 
     #[test]
     fn test_update() {
         let mut interrupt_manager = create_interrupt_manager();
-        assert!(interrupt_manager
+        interrupt_manager
             .set_working_mode(DeviceInterruptMode::GenericMsiIrq)
-            .is_ok());
-        assert!(interrupt_manager.enable().is_ok());
+            .unwrap();
+        interrupt_manager.enable().unwrap();
         assert!(interrupt_manager.update(0x10).is_err());
-        assert!(interrupt_manager.update(0x01).is_ok());
-        assert!(interrupt_manager.reset().is_ok());
-        assert!(interrupt_manager
+        interrupt_manager.update(0x01).unwrap();
+        interrupt_manager.reset().unwrap();
+        interrupt_manager
             .set_working_mode(DeviceInterruptMode::LegacyIrq)
-            .is_ok());
+            .unwrap();
         assert!(interrupt_manager.update(0x10).is_err());
     }
 


### PR DESCRIPTION
The `unwrap` can display detailed error messages.
