### PR TITLE
dbs-interrupt: add notifier support

### DIFF
--- a/crates/dbs-interrupt/Cargo.toml
+++ b/crates/dbs-interrupt/Cargo.toml
@@ -11,6 +11,7 @@ readme = "README.md"
 
 [dependencies]
 thiserror = "1"
+downcast-rs = "1.2.0"
 vmm-sys-util = ">=0.8.0"
 libc = "0.2"
 kvm-bindings = { version = "0.5.0", optional = true }

--- a/crates/dbs-interrupt/src/kvm/mod.rs
+++ b/crates/dbs-interrupt/src/kvm/mod.rs
@@ -267,7 +267,7 @@ pub fn from_sys_util_errno(e: vmm_sys_util::errno::Error) -> std::io::Error {
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use super::*;
     use crate::manager::tests::create_vm_fd;
 
@@ -299,12 +299,16 @@ mod tests {
     const SLAVE_PIC: usize = 8;
     const IOAPIC: usize = 23;
 
-    #[test]
-    fn test_create_kvm_irq_manager() {
+    pub fn create_kvm_irq_manager() -> (Arc<VmFd>, KvmIrqManager) {
         let vmfd = Arc::new(create_vm_fd());
         let manager = KvmIrqManager::new(vmfd.clone());
         vmfd.create_irq_chip().unwrap();
         manager.initialize().unwrap();
+        (vmfd, manager)
+    }
+    #[test]
+    fn test_create_kvm_irq_manager() {
+        let _ = create_kvm_irq_manager();
     }
 
     #[test]

--- a/crates/dbs-interrupt/src/lib.rs
+++ b/crates/dbs-interrupt/src/lib.rs
@@ -59,6 +59,9 @@ mod manager;
 pub use manager::MSI_DEVICE_ID_SHIFT;
 pub use manager::{DeviceInterruptManager, DeviceInterruptMode, InterruptStatusRegister32};
 
+mod notifier;
+pub use self::notifier::*;
+
 #[cfg(feature = "kvm-irq")]
 pub mod kvm;
 #[cfg(feature = "kvm-irq")]

--- a/crates/dbs-interrupt/src/notifier.rs
+++ b/crates/dbs-interrupt/src/notifier.rs
@@ -1,0 +1,216 @@
+// Copyright 2019 Alibaba Cloud. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
+
+//! Device event notifier to inject interrupt to guest.
+
+use std::io::Error;
+use std::sync::Arc;
+
+use downcast_rs::{impl_downcast, Downcast};
+use vmm_sys_util::eventfd::EventFd;
+
+use crate::{InterruptIndex, InterruptSourceGroup, InterruptStatusRegister32};
+
+#[cfg(feature = "legacy-irq")]
+pub use self::legacy::*;
+#[cfg(feature = "msi-irq")]
+pub use self::msi::*;
+
+/// Trait to inject interrupt for device.
+pub trait InterruptNotifier: Send + Sync + Downcast {
+    /// Inject an interrupt to guest.
+    fn notify(&self) -> Result<(), Error>;
+
+    /// Get the optional eventfd to inject interrupt to guest.
+    fn notifier(&self) -> Option<&EventFd>;
+}
+impl_downcast!(InterruptNotifier);
+
+#[cfg(feature = "legacy-irq")]
+mod legacy {
+    use super::*;
+    /// Struct to inject legacy interrupt to guest.
+    #[derive(Clone)]
+    pub struct LegacyNotifier {
+        pub(crate) intr_group: Arc<Box<dyn InterruptSourceGroup>>,
+        pub(crate) intr_status: Arc<InterruptStatusRegister32>,
+        pub(crate) status_bits: u32,
+    }
+
+    impl LegacyNotifier {
+        /// Create a legacy notifier.
+        pub fn new(
+            intr_group: Arc<Box<dyn InterruptSourceGroup>>,
+            intr_status: Arc<InterruptStatusRegister32>,
+            status_bits: u32,
+        ) -> Self {
+            Self {
+                intr_group,
+                intr_status,
+                status_bits,
+            }
+        }
+    }
+
+    impl InterruptNotifier for LegacyNotifier {
+        fn notify(&self) -> Result<(), Error> {
+            self.intr_status.set_bits(self.status_bits);
+            self.intr_group.trigger(0)
+        }
+
+        fn notifier(&self) -> Option<&EventFd> {
+            self.intr_group.notifier(0)
+        }
+    }
+}
+
+#[cfg(feature = "msi-irq")]
+mod msi {
+    use super::*;
+
+    /// Struct to inject message signalled interrupt to guest.
+    #[derive(Clone)]
+    pub struct MsiNotifier {
+        pub(crate) intr_group: Arc<Box<dyn InterruptSourceGroup>>,
+        pub(crate) intr_index: InterruptIndex,
+    }
+
+    impl MsiNotifier {
+        /// Create a notifier to inject message signalled interrupt to guest.
+        pub fn new(
+            intr_group: Arc<Box<dyn InterruptSourceGroup>>,
+            intr_index: InterruptIndex,
+        ) -> Self {
+            MsiNotifier {
+                intr_group,
+                intr_index,
+            }
+        }
+    }
+
+    impl InterruptNotifier for MsiNotifier {
+        fn notify(&self) -> Result<(), Error> {
+            self.intr_group.trigger(self.intr_index)
+        }
+
+        fn notifier(&self) -> Option<&EventFd> {
+            self.intr_group.notifier(self.intr_index)
+        }
+    }
+}
+
+/// Struct to discard interrupts.
+#[derive(Copy, Clone, Debug, Default)]
+pub struct NoopNotifier {}
+
+impl NoopNotifier {
+    /// Create a noop notifier to discard interrupts.
+    pub fn new() -> Self {
+        NoopNotifier {}
+    }
+}
+
+impl InterruptNotifier for NoopNotifier {
+    fn notify(&self) -> Result<(), Error> {
+        Ok(())
+    }
+
+    fn notifier(&self) -> Option<&EventFd> {
+        None
+    }
+}
+
+/// Clone a boxed interrupt notifier object.
+pub fn clone_notifier(notifier: &dyn InterruptNotifier) -> Box<dyn InterruptNotifier> {
+    #[cfg(feature = "legacy-irq")]
+    if let Some(v) = notifier.as_any().downcast_ref::<LegacyNotifier>() {
+        return Box::new(LegacyNotifier::new(
+            v.intr_group.clone(),
+            v.intr_status.clone(),
+            v.status_bits,
+        ));
+    }
+    #[cfg(feature = "msi-irq")]
+    if let Some(v) = notifier.as_any().downcast_ref::<MsiNotifier>() {
+        return Box::new(MsiNotifier::new(v.intr_group.clone(), v.intr_index));
+    }
+    if let Some(_v) = notifier.as_any().downcast_ref::<NoopNotifier>() {
+        Box::new(NoopNotifier {})
+    } else {
+        panic!("failed to clone interrupt notifier.")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(unused_imports)]
+    #![allow(dead_code)]
+    use super::*;
+
+    use crate::{InterruptManager, InterruptSourceType};
+
+    const VIRTIO_INTR_VRING: u32 = 0x01;
+    const VIRTIO_INTR_CONFIG: u32 = 0x02;
+
+    #[test]
+    fn create_virtio_null_notifier() {
+        let notifier = NoopNotifier::new();
+
+        notifier.notify().unwrap();
+        assert!(notifier.notifier().is_none());
+    }
+
+    #[cfg(feature = "kvm-legacy-irq")]
+    #[test]
+    fn test_create_legacy_notifier() {
+        let (_vmfd, irq_manager) = crate::kvm::tests::create_kvm_irq_manager();
+        let group = irq_manager
+            .create_group(InterruptSourceType::LegacyIrq, 0, 1)
+            .unwrap();
+        let status = Arc::new(InterruptStatusRegister32::new());
+        assert_eq!(status.read(), 0);
+
+        let notifer = LegacyNotifier::new(group.clone(), status.clone(), VIRTIO_INTR_CONFIG);
+        notifer.notify().unwrap();
+        assert!(notifer.notifier().is_some());
+        assert_eq!(notifer.status_bits, VIRTIO_INTR_CONFIG);
+        assert_eq!(status.read_and_clear(), VIRTIO_INTR_CONFIG);
+        assert_eq!(status.read(), 0);
+
+        let notifier = LegacyNotifier::new(group.clone(), status.clone(), VIRTIO_INTR_VRING);
+        notifier.notify().unwrap();
+        assert!(notifier.notifier().is_some());
+        assert_eq!(status.read(), VIRTIO_INTR_VRING);
+        status.clear_bits(VIRTIO_INTR_VRING);
+        assert_eq!(status.read(), 0);
+        let eventfd = notifier.notifier().unwrap();
+        assert_eq!(eventfd.read().unwrap(), 2);
+
+        let clone = clone_notifier(&notifier);
+        assert_eq!(clone.type_id(), notifier.as_any().type_id());
+    }
+
+    #[cfg(feature = "kvm-msi-irq")]
+    #[test]
+    fn test_virtio_msi_notifier() {
+        let (_vmfd, irq_manager) = crate::kvm::tests::create_kvm_irq_manager();
+        let group = irq_manager
+            .create_group(InterruptSourceType::MsiIrq, 0, 3)
+            .unwrap();
+        let notifier1 = MsiNotifier::new(group.clone(), 1);
+        let notifier2 = MsiNotifier::new(group.clone(), 2);
+        let notifier3 = MsiNotifier::new(group.clone(), 3);
+        assert!(notifier1.notifier().is_some());
+        assert!(notifier2.notifier().is_some());
+        assert!(notifier3.notifier().is_none());
+
+        notifier1.notify().unwrap();
+        notifier1.notify().unwrap();
+        notifier2.notify().unwrap();
+        assert_eq!(notifier1.notifier().unwrap().read().unwrap(), 2);
+        assert_eq!(notifier2.notifier().unwrap().read().unwrap(), 1);
+
+        let clone = clone_notifier(&notifier1);
+        assert_eq!(clone.type_id(), notifier1.as_any().type_id());
+    }
+}


### PR DESCRIPTION
It is used for device event notifier to inject interrupt to the guest.

Signed-off-by: wllenyj <wllenyj@linux.alibaba.com>