### PR TITLE
dbs-virtio-devices: add mmio support

### DIFF
--- a/crates/dbs-virtio-devices/Cargo.toml
+++ b/crates/dbs-virtio-devices/Cargo.toml
@@ -11,6 +11,7 @@ keywords = ["dragonball", "secure-sandbox", "devices", "virtio"]
 readme = "README.md"
 
 [dependencies]
+byteorder = "1.4.3"
 dbs-device = { version = "0.1.0", path = "../dbs-device" }
 dbs-interrupt = { version = "0.1.0", path = "../dbs-interrupt", features = ["kvm-legacy-irq", "kvm-msi-irq"] }
 dbs-utils = { version = "0.1.0", path = "../dbs-utils" }

--- a/crates/dbs-virtio-devices/Cargo.toml
+++ b/crates/dbs-virtio-devices/Cargo.toml
@@ -14,6 +14,7 @@ readme = "README.md"
 dbs-device = { version = "0.1.0", path = "../dbs-device" }
 dbs-interrupt = { version = "0.1.0", path = "../dbs-interrupt", features = ["kvm-legacy-irq", "kvm-msi-irq"] }
 dbs-utils = { version = "0.1.0", path = "../dbs-utils" }
+kvm-bindings = "0.5.0"
 kvm-ioctls = "0.11.0"
 log = "0.4.14"
 thiserror = "1"

--- a/crates/dbs-virtio-devices/Cargo.toml
+++ b/crates/dbs-virtio-devices/Cargo.toml
@@ -23,3 +23,6 @@ vm-memory = "0.7.0"
 
 [dev-dependencies]
 vm-memory = { version = "0.7.0", features = [ "backend-mmap", "backend-atomic" ] }
+
+[features]
+virtio-mmio = []

--- a/crates/dbs-virtio-devices/src/lib.rs
+++ b/crates/dbs-virtio-devices/src/lib.rs
@@ -39,6 +39,10 @@ pub enum ActivateError {
     InvalidParam,
     #[error("Internal error.")]
     InternalError,
+    #[error("Invalid queue config.")]
+    InvalidQueueConfig,
+    #[error("IO: {0}.")]
+    IOError(#[from] IOError),
 }
 
 /// Specialized std::result::Result for VirtioDevice::activate().
@@ -53,6 +57,12 @@ pub enum Error {
     /// Error from virtio_queue
     #[error("virtio queue error: {0}")]
     VirtioQueueError(#[from] VqError),
+    /// Error from Device activate.
+    #[error("Device activate error: {0}")]
+    ActivateError(#[from] ActivateError),
+    /// Error from Interrupt.
+    #[error("Interrupt error: {0}")]
+    InterruptError(IOError),
 }
 
 /// Specialized std::result::Result for Virtio device operations.

--- a/crates/dbs-virtio-devices/src/lib.rs
+++ b/crates/dbs-virtio-devices/src/lib.rs
@@ -25,6 +25,56 @@ use std::io::Error as IOError;
 
 use virtio_queue::Error as VqError;
 
+/// Version of virtio specifications supported by PCI virtio devices.
+#[allow(non_camel_case_types)]
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum VirtioVersion {
+    /// Unknown/non-virtio VFIO device.
+    VIRTIO_VERSION_UNKNOWN,
+    /// Virtio specification 0.95(Legacy).
+    VIRTIO_VERSION_0_95,
+    /// Virtio specification 1.0/1.1.
+    VIRTIO_VERSION_1_X,
+}
+
+/// Page size for legacy PCI virtio devices. Assume it's 4K.
+pub const VIRTIO_LEGACY_PAGE_SIZE: u32 = 0x1000;
+
+/// Initial state after device initialization/reset.
+pub const DEVICE_INIT: u32 = 0x0;
+/// Indicates that the guest OS has found the device and recognized it as a valid virtio device.
+pub const DEVICE_ACKNOWLEDGE: u32 = 0x01;
+/// Indicates that the guest OS knows how to drive the device.
+pub const DEVICE_DRIVER: u32 = 0x02;
+/// Indicates that the driver is set up and ready to drive the device.
+pub const DEVICE_DRIVER_OK: u32 = 0x04;
+/// Indicates that the driver has acknowledged all the features it understands, and feature
+/// negotiation is complete.
+pub const DEVICE_FEATURES_OK: u32 = 0x08;
+/// Indicates that the device has experienced an error from which it can’t recover.
+pub const DEVICE_NEEDS_RESET: u32 = 0x40;
+/// Indicates that something went wrong in the guest, and it has given up on the device.
+/// This could be an internal error, or the driver didn’t like the device for some reason, or even
+/// a fatal error during device operation.
+pub const DEVICE_FAILED: u32 = 0x80;
+
+/// Virtio network card device.
+pub const TYPE_NET: u32 = 1;
+/// Virtio block device.
+pub const TYPE_BLOCK: u32 = 2;
+/// Virtio-rng device.
+pub const TYPE_RNG: u32 = 4;
+/// Virtio balloon device.
+pub const TYPE_BALLOON: u32 = 5;
+/// Virtio vsock device.
+pub const TYPE_VSOCK: u32 = 19;
+/// Virtio mem device.
+pub const TYPE_MEM: u32 = 24;
+/// Virtio-fs virtual device.
+pub const TYPE_VIRTIO_FS: u32 = 26;
+/// Virtio-pmem device.
+pub const TYPE_PMEM: u32 = 27;
+
 // Interrupt status flags for legacy interrupts. It happens to be the same for both PCI and MMIO
 // virtio devices.
 /// Data available in used queue.

--- a/crates/dbs-virtio-devices/src/lib.rs
+++ b/crates/dbs-virtio-devices/src/lib.rs
@@ -101,6 +101,9 @@ pub type ActivateResult = std::result::Result<(), ActivateError>;
 /// Error for virtio devices to handle requests from guests.
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
+    /// Invalid input parameter or status.
+    #[error("invalid input parameter or status.")]
+    InvalidInput,
     /// Generic IO error
     #[error("IO: {0}.")]
     IOError(#[from] IOError),

--- a/crates/dbs-virtio-devices/src/lib.rs
+++ b/crates/dbs-virtio-devices/src/lib.rs
@@ -18,6 +18,9 @@ pub use self::device::*;
 mod notifier;
 pub use self::notifier::*;
 
+#[cfg(feature = "virtio-mmio")]
+pub mod mmio;
+
 use std::io::Error as IOError;
 
 use virtio_queue::Error as VqError;

--- a/crates/dbs-virtio-devices/src/lib.rs
+++ b/crates/dbs-virtio-devices/src/lib.rs
@@ -121,6 +121,17 @@ pub enum Error {
 /// Specialized std::result::Result for Virtio device operations.
 pub type Result<T> = std::result::Result<T, Error>;
 
+macro_rules! warn_or_panic {
+    ($($arg:tt)*) => {
+        if cfg!(test) {
+            panic!($($arg)*)
+        } else {
+            log::warn!($($arg)*)
+        }
+    }
+}
+pub(crate) use warn_or_panic;
+
 #[cfg(test)]
 pub mod tests {
     use std::sync::Arc;

--- a/crates/dbs-virtio-devices/src/mmio/dragonball.rs
+++ b/crates/dbs-virtio-devices/src/mmio/dragonball.rs
@@ -1,0 +1,78 @@
+// Copyright (C) 2019 Alibaba Cloud. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 or BSD-3-Clause
+
+//! Related to Dragonball MMIO extension.
+
+/// Default size resrved for virtio-mmio doorbell address space.
+///
+/// This represents the size of the mmio device reserved for doorbell which used to per queue notify,
+/// we need to request resource with the `MMIO_DEFAULT_CFG_SIZE + DRAGONBALL_MMIO_DOORBELL_SIZE`
+pub const DRAGONBALL_MMIO_DOORBELL_SIZE: u64 = 0x1000;
+
+/// Default offset of the mmio doorbell
+pub const DRAGONBALL_MMIO_DOORBELL_OFFSET: u64 = 0x1000;
+
+/// Max queue num when the `fast-mmio` enabled, because we only reserved 0x200 memory region for
+/// per queue notify
+pub const DRAGONBALL_MMIO_MAX_QUEUE_NUM: u64 = 255;
+
+/// Scale of the doorbell for per queue notify
+pub const DRAGONBALL_MMIO_DOORBELL_SCALE: u64 = 0x04;
+
+/// This represents the offset at which the device should call DeviceIo::write in order to write
+/// to its configuration space.
+pub const MMIO_CFG_SPACE_OFF: u64 = 0x100;
+
+/// Defines the offset and scale of the mmio doorbell.
+///
+/// Support per-virtque doorbell, so the guest kernel may directly write to the doorbells provided
+/// by hardware virtio devices.
+pub struct DoorBell {
+    offset: u32,
+    scale: u32,
+}
+
+impl DoorBell {
+    /// Creates a Doorbell.
+    pub fn new(offset: u32, scale: u32) -> Self {
+        Self { offset, scale }
+    }
+
+    /// Returns the offset.
+    pub fn offset(&self) -> u32 {
+        self.offset
+    }
+
+    /// Returns the scale.
+    pub fn scale(&self) -> u32 {
+        self.scale
+    }
+
+    /// Returns the offset with the specified index of virtio queue.
+    pub fn queue_offset(&self, queue_index: usize) -> u64 {
+        (self.offset as u64) + (self.scale as u64) * (queue_index as u64)
+    }
+
+    /// Returns the register data.
+    pub fn register_data(&self) -> u32 {
+        self.offset | (self.scale << 16)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_doorbell() {
+        let door = DoorBell::new(
+            DRAGONBALL_MMIO_DOORBELL_OFFSET as u32,
+            DRAGONBALL_MMIO_DOORBELL_SCALE as u32,
+        );
+        assert_eq!(door.offset(), DRAGONBALL_MMIO_DOORBELL_OFFSET as u32);
+        assert_eq!(door.scale(), DRAGONBALL_MMIO_DOORBELL_SCALE as u32);
+        assert_eq!(door.queue_offset(0), DRAGONBALL_MMIO_DOORBELL_OFFSET as u64);
+        assert_eq!(door.queue_offset(4), 0x1010);
+        assert_eq!(door.register_data(), 0x1000 | 0x40000);
+    }
+}

--- a/crates/dbs-virtio-devices/src/mmio/dragonball.rs
+++ b/crates/dbs-virtio-devices/src/mmio/dragonball.rs
@@ -23,10 +23,34 @@ pub const DRAGONBALL_MMIO_DOORBELL_SCALE: u64 = 0x04;
 /// to its configuration space.
 pub const MMIO_CFG_SPACE_OFF: u64 = 0x100;
 
+// Define a 16-byte area to control MMIO MSI
+
+// MSI control/status register offset
+pub const VIRTIO_MMIO_MSI_CSR: u64 = 0x0c0;
+// MSI command register offset
+pub const VIRTIO_MMIO_MSI_COMMAND: u64 = 0x0c2;
+// MSI address_lo register offset
+pub const VIRTIO_MMIO_MSI_ADDRESS_L: u64 = 0x0c4;
+// MSI address_hi register offset
+pub const VIRTIO_MMIO_MSI_ADDRESS_H: u64 = 0x0c8;
+// MSI data register offset
+pub const VIRTIO_MMIO_MSI_DATA: u64 = 0x0cc;
+
+// RW: MSI feature enabled
+pub const VIRTIO_MMIO_MSI_CSR_ENABL: u64 = 0x8000;
+// RO: Maximum queue size available
+pub const VIRTIO_MMIO_MSI_CSR_QMAS: u64 = 0x07ff;
+// Reserved
+pub const VIRTIO_MMIO_MSI_CSR_RESERV: u64 = 0x7800;
+
+pub const VIRTIO_MMIO_MSI_CMD_UPDAT: u64 = 0x1;
+pub const VIRTIO_MMIO_MSI_CMD_CODE_MA: u64 = 0xf000;
+
 /// Defines the offset and scale of the mmio doorbell.
 ///
 /// Support per-virtque doorbell, so the guest kernel may directly write to the doorbells provided
 /// by hardware virtio devices.
+#[derive(Default, Debug, PartialEq, Eq)]
 pub struct DoorBell {
     offset: u32,
     scale: u32,
@@ -59,6 +83,34 @@ impl DoorBell {
     }
 }
 
+/// MSI interrupts.
+#[derive(Default, Debug, PartialEq, Eq)]
+pub struct Msi {
+    pub index_select: u32,
+    pub address_low: u32,
+    pub address_high: u32,
+    pub data: u32,
+}
+
+impl Msi {
+    /// Sets index select.
+    pub fn set_index_select(&mut self, v: u32) {
+        self.index_select = v;
+    }
+    /// Sets address low.
+    pub fn set_address_low(&mut self, v: u32) {
+        self.address_low = v;
+    }
+    /// Sets address high.
+    pub fn set_address_high(&mut self, v: u32) {
+        self.address_high = v;
+    }
+    /// Sets msi data.
+    pub fn set_data(&mut self, v: u32) {
+        self.data = v;
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -74,5 +126,23 @@ mod tests {
         assert_eq!(door.queue_offset(0), DRAGONBALL_MMIO_DOORBELL_OFFSET as u64);
         assert_eq!(door.queue_offset(4), 0x1010);
         assert_eq!(door.register_data(), 0x1000 | 0x40000);
+    }
+
+    #[test]
+    fn test_msi() {
+        let mut msi = Msi::default();
+        msi.set_index_select(1);
+        msi.set_address_low(2);
+        msi.set_address_high(3);
+        msi.set_data(4);
+        assert_eq!(
+            msi,
+            Msi {
+                index_select: 1,
+                address_low: 2,
+                address_high: 3,
+                data: 4
+            }
+        );
     }
 }

--- a/crates/dbs-virtio-devices/src/mmio/dragonball.rs
+++ b/crates/dbs-virtio-devices/src/mmio/dragonball.rs
@@ -79,7 +79,6 @@ pub const MMIO_MSI_CMD_CODE_UPDATE: u16 = 0x1000;
 pub const MMIO_MSI_CMD_CODE_INT_MASK: u16 = 0x2000;
 pub const MMIO_MSI_CMD_CODE_INT_UNMASK: u16 = 0x3000;
 
-
 // Define a 16-byte area to control MMIO MSI
 
 // MSI control/status register offset

--- a/crates/dbs-virtio-devices/src/mmio/mmio_state.rs
+++ b/crates/dbs-virtio-devices/src/mmio/mmio_state.rs
@@ -1,0 +1,320 @@
+// Copyright (C) 2019 Alibaba Cloud Computing. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
+
+///////////////////////////////////////////////////////////////
+// TODO: we really need better support of device reset, error recovery, exceptions handling.
+///////////////////////////////////////////////////////////////
+
+use std::ops::Deref;
+use std::sync::Arc;
+
+use dbs_device::resources::DeviceResources;
+use dbs_interrupt::{DeviceInterruptManager, KvmIrqManager};
+use kvm_bindings::kvm_userspace_memory_region;
+use kvm_ioctls::{IoEventAddress, NoDatamatch, VmFd};
+use log::{debug, error};
+use virtio_queue::QueueStateT;
+use vm_memory::{GuestAddressSpace, GuestMemoryRegion};
+
+use crate::{
+    mmio::*, Error, Result, VirtioDevice, VirtioQueueConfig, VirtioSharedMemory,
+    VirtioSharedMemoryList,
+};
+
+/// The state of Virtio Mmio device.
+pub struct MmioV2DeviceState<AS: GuestAddressSpace + Clone, Q: QueueStateT, R: GuestMemoryRegion> {
+    device: Box<dyn VirtioDevice<AS, Q, R>>,
+    vm_fd: Arc<VmFd>,
+    vm_as: AS,
+    intr_mgr: DeviceInterruptManager<Arc<KvmIrqManager>>,
+    device_resources: DeviceResources,
+    queues: Vec<VirtioQueueConfig<Q>>,
+
+    mmio_base: u64,
+    has_ctrl_queue: bool,
+    device_activated: bool,
+    ioevent_registered: bool,
+
+    features_select: u32,
+    acked_features_select: u32,
+    queue_select: u32,
+
+    msi: Option<Msi>,
+    doorbell: Option<DoorBell>,
+
+    shm_region_id: u32,
+    shm_regions: Option<VirtioSharedMemoryList<R>>,
+}
+
+impl<AS, Q, R> MmioV2DeviceState<AS, Q, R>
+where
+    AS: GuestAddressSpace + Clone,
+    Q: QueueStateT,
+    R: GuestMemoryRegion,
+{
+    /// Returns a reference to the internal device object.
+    pub fn get_inner_device(&self) -> &dyn VirtioDevice<AS, Q, R> {
+        self.device.as_ref()
+    }
+
+    /// Returns a mutable reference to the internal device object.
+    pub fn get_inner_device_mut(&mut self) -> &mut dyn VirtioDevice<AS, Q, R> {
+        self.device.as_mut()
+    }
+
+    pub(crate) fn new(
+        mut device: Box<dyn VirtioDevice<AS, Q, R>>,
+        vm_fd: Arc<VmFd>,
+        vm_as: AS,
+        irq_manager: Arc<KvmIrqManager>,
+        device_resources: DeviceResources,
+        mmio_base: u64,
+        doorbell_enabled: bool,
+    ) -> Result<Self> {
+        let intr_mgr =
+            DeviceInterruptManager::new(irq_manager, &device_resources).map_err(Error::IOError)?;
+
+        let (queues, has_ctrl_queue) = Self::create_queues(device.as_ref())?;
+
+        // Assign requested device resources back to virtio device and let it do necessary setups,
+        // as only virtio device knows how to use such resources. And if there's
+        // VirtioSharedMemoryList returned, assigned it to MmioV2DeviceState
+        let shm_regions = device
+            .set_resource(vm_fd.clone(), device_resources.clone())
+            .map_err(|e| {
+                error!("Failed to assign device resource to virtio device: {}", e);
+                e
+            })?;
+
+        let doorbell = if doorbell_enabled {
+            Some(DoorBell::new(
+                DRAGONBALL_MMIO_DOORBELL_OFFSET as u32,
+                DRAGONBALL_MMIO_DOORBELL_SCALE as u32,
+            ))
+        } else {
+            None
+        };
+
+        Ok(MmioV2DeviceState {
+            device,
+            vm_fd,
+            vm_as,
+            intr_mgr,
+            device_resources,
+            queues,
+            mmio_base,
+            has_ctrl_queue,
+            ioevent_registered: false,
+            device_activated: false,
+            features_select: 0,
+            acked_features_select: 0,
+            queue_select: 0,
+            doorbell,
+            msi: None,
+            shm_region_id: 0,
+            shm_regions,
+        })
+    }
+
+    fn create_queues(
+        device: &dyn VirtioDevice<AS, Q, R>,
+    ) -> Result<(Vec<VirtioQueueConfig<Q>>, bool)> {
+        let mut queues = Vec::new();
+        for (idx, size) in device.queue_max_sizes().iter().enumerate() {
+            queues.push(VirtioQueueConfig::create(*size, idx as u16)?);
+        }
+
+        // The ctrl queue must be append to QueueState Vec, because the guest will
+        // configure it which is same with other queues.
+        let has_ctrl_queue = device.ctrl_queue_max_sizes() > 0;
+        if has_ctrl_queue {
+            queues.push(VirtioQueueConfig::create(
+                device.ctrl_queue_max_sizes(),
+                queues.len() as u16,
+            )?);
+        }
+
+        Ok((queues, has_ctrl_queue))
+    }
+
+    fn register_ioevent(&mut self) -> Result<()> {
+        for (i, queue) in self.queues.iter().enumerate() {
+            if let Some(doorbell) = self.doorbell.as_ref() {
+                let io_addr = IoEventAddress::Mmio(self.mmio_base + doorbell.queue_offset(i));
+                if let Err(e) = self
+                    .vm_fd
+                    .register_ioevent(&queue.eventfd, &io_addr, NoDatamatch)
+                {
+                    self.revert_ioevent(i, &io_addr);
+                    return Err(Error::IOError(std::io::Error::from_raw_os_error(e.errno())));
+                }
+            }
+            // always register ioeventfd in MMIO_NOTIFY_REG_OFFSET to avoid guest kernel which not support doorbell
+            let io_addr = IoEventAddress::Mmio(self.mmio_base + MMIO_NOTIFY_REG_OFFSET as u64);
+            if let Err(e) = self
+                .vm_fd
+                .register_ioevent(&queue.eventfd, &io_addr, i as u32)
+            {
+                self.unregister_ioevent_doorbell();
+                self.revert_ioevent(i, &io_addr);
+                return Err(Error::IOError(std::io::Error::from_raw_os_error(e.errno())));
+            }
+        }
+        self.ioevent_registered = true;
+
+        Ok(())
+    }
+
+    fn deactivate(&mut self) {
+        if self.device_activated {
+            self.device_activated = false;
+        }
+    }
+
+    fn unregister_ioevent(&mut self) {
+        if self.ioevent_registered {
+            let io_addr = IoEventAddress::Mmio(self.mmio_base + MMIO_NOTIFY_REG_OFFSET as u64);
+            for (i, queue) in self.queues.iter().enumerate() {
+                let _ = self
+                    .vm_fd
+                    .unregister_ioevent(&queue.eventfd, &io_addr, i as u32);
+                self.ioevent_registered = false;
+            }
+        }
+    }
+
+    fn revert_ioevent(&mut self, num: usize, io_addr: &IoEventAddress) {
+        assert!(num < self.queues.len());
+        let mut idx = num;
+        while idx > 0 {
+            idx -= 1;
+            let _ = self
+                .vm_fd
+                .unregister_ioevent(&self.queues[idx].eventfd, &io_addr, idx as u32);
+        }
+    }
+
+    fn unregister_ioevent_doorbell(&mut self) {
+        if let Some(doorbell) = self.doorbell.as_ref() {
+            for (i, queue) in self.queues.iter().enumerate() {
+                let io_addr = IoEventAddress::Mmio(self.mmio_base + doorbell.queue_offset(i));
+                let _ = self
+                    .vm_fd
+                    .unregister_ioevent(&queue.eventfd, &io_addr, NoDatamatch);
+            }
+        }
+    }
+
+    fn check_queues_valid(&self) -> bool {
+        let mem = self.vm_as.memory();
+        // All queues must have been enabled, we doesn't allow disabled queues.
+        self.queues.iter().all(|c| c.queue.is_valid(mem.deref()))
+    }
+
+    fn with_queue<U, F>(&self, d: U, f: F) -> U
+    where
+        F: FnOnce(&Q) -> U,
+    {
+        match self.queues.get(self.queue_select as usize) {
+            Some(config) => f(&config.queue),
+            None => d,
+        }
+    }
+
+    fn with_queue_mut<F: FnOnce(&mut Q)>(&mut self, f: F) -> bool {
+        if let Some(config) = self.queues.get_mut(self.queue_select as usize) {
+            f(&mut config.queue);
+            true
+        } else {
+            false
+        }
+    }
+
+    fn get_shm_field<U, F>(&mut self, d: U, f: F) -> U
+    where
+        F: FnOnce(&VirtioSharedMemory) -> U,
+    {
+        if let Some(regions) = self.shm_regions.as_ref() {
+            match regions.region_list.get(self.shm_region_id as usize) {
+                Some(region) => f(region),
+                None => d,
+            }
+        } else {
+            d
+        }
+    }
+
+    fn update_msi_cfg(&mut self) -> Result<()> {
+        if let Some(msi) = self.msi.as_ref() {
+            self.intr_mgr
+                .set_msi_low_address(msi.index_select, msi.address_low)
+                .map_err(Error::InterruptError)?;
+            self.intr_mgr
+                .set_msi_high_address(msi.index_select, msi.address_high)
+                .map_err(Error::InterruptError)?;
+            self.intr_mgr
+                .set_msi_data(msi.index_select, msi.data)
+                .map_err(Error::InterruptError)?;
+            if self.intr_mgr.is_enabled() {
+                self.intr_mgr
+                    .update(msi.index_select)
+                    .map_err(Error::InterruptError)?;
+            }
+        }
+
+        Ok(())
+    }
+
+    fn mask_msi_int(&mut self, index: u32, mask: bool) -> Result<()> {
+        if self.intr_mgr.is_enabled() {
+            if let Some(group) = self.intr_mgr.get_group() {
+                let old_mask = self
+                    .intr_mgr
+                    .get_msi_mask(index)
+                    .map_err(Error::InterruptError)?;
+                debug!("mmio_v2 old mask {}, mask {}", old_mask, mask);
+
+                if !old_mask && mask {
+                    group.mask(index)?;
+                    self.intr_mgr
+                        .set_msi_mask(index, true)
+                        .map_err(Error::InterruptError)?;
+                } else if old_mask && !mask {
+                    group.unmask(index)?;
+                    self.intr_mgr
+                        .set_msi_mask(index, false)
+                        .map_err(Error::InterruptError)?;
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl<AS, Q, R> Drop for MmioV2DeviceState<AS, Q, R>
+where
+    AS: GuestAddressSpace + Clone,
+    Q: QueueStateT,
+    R: GuestMemoryRegion,
+{
+    fn drop(&mut self) {
+        if let Some(memlist) = &self.shm_regions {
+            let mmio_res = self.device_resources.get_mmio_address_ranges();
+            let slots_res = self.device_resources.get_kvm_mem_slots();
+            let shm_regions_num = mmio_res.len();
+            let slots_num = slots_res.len();
+            assert_eq!((shm_regions_num, slots_num), (1, 1));
+            let kvm_mem_region = kvm_userspace_memory_region {
+                slot: slots_res[0],
+                flags: 0,
+                guest_phys_addr: memlist.guest_addr.0,
+                memory_size: 0,
+                userspace_addr: memlist.host_addr,
+            };
+            unsafe {
+                self.vm_fd.set_user_memory_region(kvm_mem_region).unwrap();
+            }
+        }
+    }
+}

--- a/crates/dbs-virtio-devices/src/mmio/mmio_state.rs
+++ b/crates/dbs-virtio-devices/src/mmio/mmio_state.rs
@@ -17,8 +17,8 @@ use virtio_queue::QueueStateT;
 use vm_memory::{GuestAddressSpace, GuestMemoryRegion};
 
 use crate::{
-    mmio::*, ActivateError, Error, Result, VirtioDevice, VirtioDeviceConfig, VirtioQueueConfig,
-    VirtioSharedMemory, VirtioSharedMemoryList, DEVICE_DRIVER_OK, DEVICE_FAILED,
+    mmio::*, warn_or_panic, ActivateError, Error, Result, VirtioDevice, VirtioDeviceConfig,
+    VirtioQueueConfig, VirtioSharedMemory, VirtioSharedMemoryList, DEVICE_DRIVER_OK, DEVICE_FAILED,
 };
 
 /// The state of Virtio Mmio device.
@@ -533,17 +533,17 @@ where
                 if arg > self.device.queue_max_sizes().len() as u16 {
                     info!("mmio_v2: configure interrupt for invalid vector {}", v,);
                 } else if let Err(e) = self.update_msi_cfg(arg) {
-                    warn!("mmio_v2: failed to configure vector {}, {:?}", v, e);
+                    warn_or_panic!("mmio_v2: failed to configure vector {}, {:?}", v, e);
                 }
             }
             MMIO_MSI_CMD_CODE_INT_MASK => {
                 if let Err(e) = self.mask_msi_int(arg as u32, true) {
-                    warn!("mmio_v2: failed to mask {}, {:?}", v, e);
+                    warn_or_panic!("mmio_v2: failed to mask {}, {:?}", v, e);
                 }
             }
             MMIO_MSI_CMD_CODE_INT_UNMASK => {
                 if let Err(e) = self.mask_msi_int(arg as u32, false) {
-                    warn!("mmio_v2: failed to unmask {}, {:?}", v, e);
+                    warn_or_panic!("mmio_v2: failed to unmask {}, {:?}", v, e);
                 }
             }
             _ => {

--- a/crates/dbs-virtio-devices/src/mmio/mmio_v2.rs
+++ b/crates/dbs-virtio-devices/src/mmio/mmio_v2.rs
@@ -1,0 +1,441 @@
+// Copyright (C) 2019 Alibaba Cloud Computing. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
+
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::{Arc, Mutex, MutexGuard};
+
+use byteorder::{ByteOrder, LittleEndian};
+use dbs_device::resources::{DeviceResources, Resource};
+use dbs_device::{DeviceIo, IoAddress};
+use dbs_interrupt::{InterruptStatusRegister32, KvmIrqManager};
+use kvm_ioctls::VmFd;
+use log::{debug, info, warn};
+use virtio_queue::QueueStateT;
+use vm_memory::{GuestAddressSpace, GuestMemoryRegion};
+
+use crate::{
+    mmio::*, Error, Result, VirtioDevice, DEVICE_ACKNOWLEDGE, DEVICE_DRIVER, DEVICE_DRIVER_OK,
+    DEVICE_FAILED, DEVICE_FEATURES_OK, DEVICE_INIT, VIRTIO_INTR_VRING,
+};
+
+const DEVICE_STATUS_INIT: u32 = DEVICE_INIT;
+const DEVICE_STATUS_ACKNOWLEDE: u32 = DEVICE_STATUS_INIT | DEVICE_ACKNOWLEDGE;
+const DEVICE_STATUS_DRIVER: u32 = DEVICE_STATUS_ACKNOWLEDE | DEVICE_DRIVER;
+const DEVICE_STATUS_FEATURE_OK: u32 = DEVICE_STATUS_DRIVER | DEVICE_FEATURES_OK;
+const DEVICE_STATUS_DRIVER_OK: u32 = DEVICE_STATUS_FEATURE_OK | DEVICE_DRIVER_OK;
+
+/// Implements the
+/// [MMIO](http://docs.oasis-open.org/virtio/virtio/v1.0/cs04/virtio-v1.0-cs04.html#x1-1090002)
+/// transport for virtio devices.
+///
+/// This requires 3 points of installation to work with a VM:
+///
+/// 1. Mmio reads and writes must be sent to this device at what is referred to here as MMIO base.
+/// 1. `Mmio::queue_evts` must be installed at `MMIO_NOTIFY_REG_OFFSET` offset from the MMIO
+/// base. Each event in the array must be signaled if the index is written at that offset.
+/// 1. `Mmio::interrupt_evt` must signal an interrupt that the guest driver is listening to when it
+/// is written to.
+///
+/// Typically one page (4096 bytes) of MMIO address space is sufficient to handle this transport
+/// and inner virtio device.
+pub struct MmioV2Device<AS: GuestAddressSpace + Clone, Q: QueueStateT, R: GuestMemoryRegion> {
+    state: Mutex<MmioV2DeviceState<AS, Q, R>>,
+    assigned_resources: DeviceResources,
+    mmio_cfg_res: Resource,
+    device_vendor: u32,
+    driver_status: AtomicU32,
+    config_generation: AtomicU32,
+    interrupt_status: Arc<InterruptStatusRegister32>,
+}
+
+impl<AS, Q, R> MmioV2Device<AS, Q, R>
+where
+    AS: GuestAddressSpace + Clone,
+    Q: QueueStateT + Clone,
+    R: GuestMemoryRegion,
+{
+    /// Constructs a new MMIO transport for the given virtio device.
+    pub fn new(
+        vm_fd: Arc<VmFd>,
+        vm_as: AS,
+        irq_manager: Arc<KvmIrqManager>,
+        device: Box<dyn VirtioDevice<AS, Q, R>>,
+        resources: DeviceResources,
+        mut features: Option<u32>,
+    ) -> Result<Self> {
+        let mut device_resources = DeviceResources::new();
+        let mut mmio_cfg_resource = None;
+        let mut mmio_base = 0;
+        let mut doorbell_enabled = false;
+
+        for res in resources.iter() {
+            if let Resource::MmioAddressRange { base, size } = res {
+                if mmio_cfg_resource.is_none()
+                    && *size == MMIO_DEFAULT_CFG_SIZE + DRAGONBALL_MMIO_DOORBELL_SIZE
+                {
+                    mmio_base = *base;
+                    mmio_cfg_resource = Some(res.clone());
+                    continue;
+                }
+            }
+            device_resources.append(res.clone());
+        }
+        let mmio_cfg_res = match mmio_cfg_resource {
+            Some(v) => v,
+            None => return Err(Error::InvalidInput),
+        };
+
+        let msi_feature = if resources.get_generic_msi_irqs().is_some() {
+            DRAGONBALL_FEATURE_MSI_INTR
+        } else {
+            0
+        };
+
+        if let Some(ref mut ft) = features {
+            if (*ft & DRAGONBALL_FEATURE_PER_QUEUE_NOTIFY != 0)
+                && vm_fd.check_extension(kvm_ioctls::Cap::IoeventfdNoLength)
+            {
+                doorbell_enabled = true;
+            } else {
+                *ft &= !DRAGONBALL_FEATURE_PER_QUEUE_NOTIFY;
+            }
+        }
+
+        debug!("mmiov2: fast-mmio enabled: {}", doorbell_enabled);
+
+        let state = MmioV2DeviceState::new(
+            device,
+            vm_fd,
+            vm_as,
+            irq_manager,
+            device_resources,
+            mmio_base,
+            doorbell_enabled,
+        )?;
+
+        let mut device_vendor = MMIO_VENDOR_ID_DRAGONBALL | msi_feature;
+        if let Some(ft) = features {
+            debug!("mmiov2: feature bit is 0x{:0X}", ft);
+            device_vendor |= ft & DRAGONBALL_FEATURE_MASK;
+        }
+
+        Ok(MmioV2Device {
+            state: Mutex::new(state),
+            assigned_resources: resources,
+            mmio_cfg_res,
+            device_vendor,
+            driver_status: AtomicU32::new(DEVICE_INIT),
+            config_generation: AtomicU32::new(0),
+            interrupt_status: Arc::new(InterruptStatusRegister32::new()),
+        })
+    }
+
+    /// Acquires the state while holding the lock.
+    pub fn state(&self) -> MutexGuard<MmioV2DeviceState<AS, Q, R>> {
+        // Safe to unwrap() because we don't expect poisoned lock here.
+        self.state.lock().unwrap()
+    }
+
+    /// Removes device.
+    pub fn remove(&self) {
+        self.state().get_inner_device_mut().remove();
+    }
+
+    /// Returns the Resource.
+    pub fn get_mmio_cfg_res(&self) -> Resource {
+        self.mmio_cfg_res.clone()
+    }
+
+    /// Returns the type of device.
+    pub fn get_device_type(&self) -> u32 {
+        self.state().get_inner_device().device_type()
+    }
+
+    pub(crate) fn interrupt_status(&self) -> Arc<InterruptStatusRegister32> {
+        self.interrupt_status.clone()
+    }
+
+    #[inline]
+    /// Atomic sets the drive state to fail.
+    pub(crate) fn set_driver_failed(&self) {
+        self.driver_status.fetch_or(DEVICE_FAILED, Ordering::SeqCst);
+    }
+
+    #[inline]
+    pub(crate) fn driver_status(&self) -> u32 {
+        self.driver_status.load(Ordering::SeqCst)
+    }
+
+    #[inline]
+    fn check_driver_status(&self, set: u32, clr: u32) -> bool {
+        self.driver_status() & (set | clr) == set
+    }
+
+    #[inline]
+    fn exchange_driver_status(&self, old: u32, new: u32) -> std::result::Result<u32, u32> {
+        self.driver_status
+            .compare_exchange(old, new, Ordering::SeqCst, Ordering::SeqCst)
+    }
+
+    /// Update driver status according to the state machine defined by VirtIO Spec 1.0.
+    /// Please refer to VirtIO Spec 1.0, section 2.1.1 and 3.1.1.
+    ///
+    /// The driver MUST update device status, setting bits to indicate the completed steps
+    /// of the driver initialization sequence specified in 3.1. The driver MUST NOT clear
+    /// a device status bit. If the driver sets the FAILED bit, the driver MUST later reset
+    /// the device before attempting to re-initialize.
+    fn update_driver_status(&self, v: u32) {
+        // Serialize to update device state.
+        let mut state = self.state();
+        let mut result = Err(DEVICE_FAILED);
+        if v == DEVICE_STATUS_ACKNOWLEDE {
+            result = self.exchange_driver_status(DEVICE_STATUS_INIT, DEVICE_STATUS_ACKNOWLEDE);
+        } else if v == DEVICE_STATUS_DRIVER {
+            result = self.exchange_driver_status(DEVICE_STATUS_ACKNOWLEDE, DEVICE_STATUS_DRIVER);
+        } else if v == DEVICE_STATUS_FEATURE_OK {
+            result = self.exchange_driver_status(DEVICE_STATUS_DRIVER, DEVICE_STATUS_FEATURE_OK);
+        } else if v == DEVICE_STATUS_DRIVER_OK {
+            result = self.exchange_driver_status(DEVICE_STATUS_FEATURE_OK, DEVICE_STATUS_DRIVER_OK);
+            if result.is_ok() {
+                if let Err(e) = state.activate(self) {
+                    // Reset internal status to initial state on failure.
+                    state.reset();
+                    warn!("failed to activate MMIO Virtio device: {:?}", e);
+                    result = Err(DEVICE_FAILED);
+                }
+            }
+        } else if v == 0 {
+            if self.driver_status() == DEVICE_INIT {
+                result = Ok(0);
+            } else if state.device_activated() {
+                let ret = state.get_inner_device_mut().reset();
+                if ret.is_err() {
+                    warn!("failed to reset MMIO Virtio device: {:?}.", ret);
+                } else {
+                    state.deactivate();
+                    state.reset();
+                    // it should reset the device's status to init, otherwise, the guest would
+                    // get the wrong device's status.
+                    result =
+                        self.exchange_driver_status(DEVICE_STATUS_DRIVER_OK, DEVICE_STATUS_INIT);
+                }
+            }
+        } else if v == self.driver_status() {
+            // No real state change, nothing to do.
+            result = Ok(0);
+        } else if v & DEVICE_FAILED != 0 {
+            // Guest driver marks device as failed.
+            self.set_driver_failed();
+            result = Ok(0);
+        }
+
+        if result.is_err() {
+            warn!(
+                "invalid virtio driver status transition: 0x{:x} -> 0x{:x}",
+                self.driver_status(),
+                v
+            );
+            // TODO: notify backend driver to stop the device
+            self.set_driver_failed();
+        }
+    }
+
+    fn update_queue_field<F: FnOnce(&mut Q)>(&self, f: F) {
+        // Use mutex for state to protect device.write_config()
+        let mut state = self.state();
+        if self.check_driver_status(DEVICE_FEATURES_OK, DEVICE_DRIVER_OK | DEVICE_FAILED) {
+            state.with_queue_mut(f);
+        } else {
+            info!(
+                "update virtio queue in invalid state 0x{:x}",
+                self.driver_status()
+            );
+        }
+    }
+
+    fn tweak_intr_flags(&self, flags: u32) -> u32 {
+        // The MMIO virtio transport layer only supports legacy IRQs. And the typical way to
+        // inject interrupt into the guest is:
+        // 1) the vhost-user-net slave sends notifcaticaiton to dragonball by writing to eventfd.
+        // 2) dragonball consumes the notification by read the eventfd.
+        // 3) dragonball updates interrupt status register.
+        // 4) dragonball injects interrupt to the guest by writing to an irqfd.
+        //
+        // We play a trick here to always report "descriptor ready in the used virtque".
+        // This trick doesn't break the virtio spec because it allow virtio devices to inject
+        // supurous interrupts. By applying this trick, the way to inject interrupts gets
+        // simplified as:
+        // 1) the vhost-user-net slave sends interrupt to the guest by writing to the irqfd.
+        if self.device_vendor & DRAGONBALL_FEATURE_INTR_USED != 0 {
+            flags | VIRTIO_INTR_VRING
+        } else {
+            flags
+        }
+    }
+
+    fn device_features(&self) -> u32 {
+        let state = self.state();
+        let features_select = state.features_select();
+        let mut features = state.get_inner_device().get_avail_features(features_select);
+        if features_select == 1 {
+            features |= 0x1; // enable support of VirtIO Version 1
+        }
+        features
+    }
+
+    fn set_acked_features(&self, v: u32) {
+        // Use mutex for state to protect device.ack_features()
+        let mut state = self.state();
+        if self.check_driver_status(DEVICE_DRIVER, DEVICE_FEATURES_OK | DEVICE_FAILED) {
+            state.set_acked_features(v);
+        } else {
+            info!(
+                "ack virtio features in invalid state 0x{:x}",
+                self.driver_status()
+            );
+        }
+    }
+}
+
+impl<AS, Q, R> DeviceIo for MmioV2Device<AS, Q, R>
+where
+    AS: 'static + GuestAddressSpace + Clone + Send + Sync,
+    Q: QueueStateT + Send + Clone,
+    R: GuestMemoryRegion + Send + Sync,
+{
+    fn read(&self, _base: IoAddress, offset: IoAddress, data: &mut [u8]) {
+        let offset = offset.raw_value();
+        let guest_addr: u64 = match self.state().shm_regions() {
+            Some(regions) => regions.guest_addr.0,
+            None => 0,
+        };
+
+        if offset >= MMIO_CFG_SPACE_OFF {
+        } else if data.len() == 4 {
+            let v = match offset {
+                REG_MMIO_MAGIC_VALUE => MMIO_MAGIC_VALUE,
+                REG_MMIO_VERSION => MMIO_VERSION_2,
+                REG_MMIO_DEVICE_ID => self.state().get_inner_device().device_type(),
+                REG_MMIO_VENDOR_ID => self.device_vendor,
+                REG_MMIO_DEVICE_FEATURE => self.device_features(),
+                REG_MMIO_QUEUE_NUM_MA => self.state().with_queue(0, |q| q.max_size() as u32),
+                REG_MMIO_QUEUE_READY => self.state().with_queue(0, |q| q.ready() as u32),
+                REG_MMIO_QUEUE_NOTIF if self.state().doorbell().is_some() => {
+                    // Safe to unwrap() because we have determined the option is a Some value.
+                    self.state()
+                        .doorbell()
+                        .map(|doorbell| doorbell.register_data())
+                        .unwrap()
+                }
+                REG_MMIO_INTERRUPT_STAT => self.tweak_intr_flags(self.interrupt_status.read()),
+                REG_MMIO_STATUS => self.driver_status(),
+                REG_MMIO_SHM_LEN_LOW => self.state().get_shm_field(0xffff_ffff, |s| s.len as u32),
+                REG_MMIO_SHM_LEN_HIGH => self
+                    .state()
+                    .get_shm_field(0xffff_ffff, |s| (s.len >> 32) as u32),
+                REG_MMIO_SHM_BASE_LOW => self
+                    .state()
+                    .get_shm_field(0xffff_ffff, |s| (s.offset + guest_addr) as u32),
+                REG_MMIO_SHM_BASE_HIGH => self
+                    .state()
+                    .get_shm_field(0xffff_ffff, |s| ((s.offset + guest_addr) >> 32) as u32),
+                REG_MMIO_CONFIG_GENERATI => self.config_generation.load(Ordering::SeqCst),
+                _ => {
+                    info!("unknown virtio mmio readl at 0x{:x}", offset);
+                    return;
+                }
+            };
+            LittleEndian::write_u32(data, v);
+        } else if data.len() == 2 {
+            let v = match offset {
+                REG_MMIO_MSI_CSR => {
+                    if (self.device_vendor & DRAGONBALL_FEATURE_MSI_INTR) != 0 {
+                        MMIO_MSI_CSR_SUPPORTED
+                    } else {
+                        0
+                    }
+                }
+                _ => {
+                    info!("unknown virtio mmio readw from 0x{:x}", offset);
+                    return;
+                }
+            };
+            LittleEndian::write_u16(data, v as u16);
+        } else {
+            info!(
+                "unknown virtio mmio register read: 0x{:x}/0x{:x}",
+                offset,
+                data.len()
+            );
+        }
+    }
+
+    fn write(&self, _base: IoAddress, offset: IoAddress, data: &[u8]) {
+        let offset = offset.raw_value();
+        // Write to the device configuration area.
+        if (MMIO_CFG_SPACE_OFF..DRAGONBALL_MMIO_DOORBELL_OFFSET).contains(&offset) {
+        } else if data.len() == 4 {
+            let v = LittleEndian::read_u32(data);
+            match offset {
+                REG_MMIO_DEVICE_FEATURES_S => self.state().set_features_select(v),
+                REG_MMIO_DRIVER_FEATURE => self.set_acked_features(v),
+                REG_MMIO_DRIVER_FEATURES_S => self.state().set_acked_features_select(v),
+                REG_MMIO_QUEUE_SEL => self.state().set_queue_select(v),
+                REG_MMIO_QUEUE_NUM => self.update_queue_field(|q| q.set_size(v as u16)),
+                REG_MMIO_QUEUE_READY => self.update_queue_field(|q| q.set_ready(v == 1)),
+                REG_MMIO_INTERRUPT_AC => self.interrupt_status.clear_bits(v),
+                REG_MMIO_STATUS => self.update_driver_status(v),
+                REG_MMIO_QUEUE_DESC_LOW => {
+                    self.update_queue_field(|q| q.set_desc_table_address(Some(v), None))
+                }
+                REG_MMIO_QUEUE_DESC_HIGH => {
+                    self.update_queue_field(|q| q.set_desc_table_address(None, Some(v)))
+                }
+                REG_MMIO_QUEUE_AVAIL_LOW => {
+                    self.update_queue_field(|q| q.set_avail_ring_address(Some(v), None))
+                }
+                REG_MMIO_QUEUE_AVAIL_HIGH => {
+                    self.update_queue_field(|q| q.set_avail_ring_address(None, Some(v)))
+                }
+                REG_MMIO_QUEUE_USED_LOW => {
+                    self.update_queue_field(|q| q.set_used_ring_address(Some(v), None))
+                }
+                REG_MMIO_QUEUE_USED_HIGH => {
+                    self.update_queue_field(|q| q.set_used_ring_address(None, Some(v)))
+                }
+                REG_MMIO_SHM_SEL => self.state().set_shm_region_id(v),
+                REG_MMIO_MSI_ADDRESS_L => self.state().set_msi_address_low(v),
+                REG_MMIO_MSI_ADDRESS_H => self.state().set_msi_address_high(v),
+                REG_MMIO_MSI_DATA => self.state().set_msi_data(v),
+                _ => info!("unknown virtio mmio writel to 0x{:x}", offset),
+            }
+        } else if data.len() == 2 {
+            let v = LittleEndian::read_u16(data);
+            match offset {
+                REG_MMIO_MSI_CSR => self.state().update_msi_enable(v, self),
+                REG_MMIO_MSI_COMMAND => self.state().handle_msi_cmd(v, self),
+                _ => {
+                    info!("unknown virtio mmio writew to 0x{:x}", offset);
+                }
+            }
+        } else {
+            info!(
+                "unknown virtio mmio register write: 0x{:x}/0x{:x}",
+                offset,
+                data.len()
+            );
+        }
+    }
+
+    fn get_assigned_resources(&self) -> DeviceResources {
+        self.assigned_resources.clone()
+    }
+
+    fn get_trapped_io_resources(&self) -> DeviceResources {
+        let mut resources = DeviceResources::new();
+
+        resources.append(self.mmio_cfg_res.clone());
+
+        resources
+    }
+}

--- a/crates/dbs-virtio-devices/src/mmio/mod.rs
+++ b/crates/dbs-virtio-devices/src/mmio/mod.rs
@@ -1,0 +1,17 @@
+// Copyright (C) 2019 Alibaba Cloud. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
+//
+// Portions Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Portions Copyright 2017 The Chromium OS Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the THIRD-PARTY file.
+
+//! Implementations of the Virtio MMIO Transport Layer.
+//!
+//! The Virtio specifications have defined two versions for the Virtio MMIO transport layer. The
+//! version 1 is called legacy mode, and the version 2 is preferred currently. The common parts
+//! of both versions are defined here.
+
+mod dragonball;
+pub use self::dragonball::*;

--- a/crates/dbs-virtio-devices/src/mmio/mod.rs
+++ b/crates/dbs-virtio-devices/src/mmio/mod.rs
@@ -19,6 +19,116 @@ pub use self::mmio_state::*;
 mod dragonball;
 pub use self::dragonball::*;
 
+/// Magic number for MMIO virtio devices.
+/// Required by the virtio mmio device register layout at offset 0 from base
+pub const MMIO_MAGIC_VALUE: u32 = 0x74726976;
+
+/// Version number for legacy MMIO virito devices.
+pub const MMIO_VERSION_1: u32 = 1;
+
+/// Current version specified by the mmio standard.
+pub const MMIO_VERSION_2: u32 = 2;
+
 /// Offset from the base MMIO address of a virtio device used by the guest to notify the device of
 /// queue events.
 pub const MMIO_NOTIFY_REG_OFFSET: u32 = 0x50;
+
+/// Default size for MMIO device configuration address space.
+///
+/// This represents the size of the mmio device specified to the kernel as a cmdline option
+/// It has to be larger than 0x100 (the offset where the configuration space starts from
+/// the beginning of the memory mapped device registers) + the size of the configuration space
+/// Currently hardcoded to 4K
+pub const MMIO_DEFAULT_CFG_SIZE: u64 = 0x1000;
+
+///
+/// Control registers
+
+// Magic value ("virt" string) - Read Only
+pub const REG_MMIO_MAGIC_VALUE: u64 = 0x000;
+
+// Virtio device version - Read Only
+pub const REG_MMIO_VERSION: u64 = 0x004;
+
+// Virtio device ID - Read Only
+pub const REG_MMIO_DEVICE_ID: u64 = 0x008;
+
+// Virtio vendor ID - Read Only
+pub const REG_MMIO_VENDOR_ID: u64 = 0x00c;
+
+// Bitmask of the features supported by the device (host)
+// (32 bits per set) - Read Only
+pub const REG_MMIO_DEVICE_FEATURE: u64 = 0x010;
+
+// Device (host) features set selector - Write Only
+pub const REG_MMIO_DEVICE_FEATURES_S: u64 = 0x014;
+
+// Bitmask of features activated by the driver (guest)
+//  (32 bits per set) - Write Only
+pub const REG_MMIO_DRIVER_FEATURE: u64 = 0x020;
+
+// Activated features set selector - Write Only */
+pub const REG_MMIO_DRIVER_FEATURES_S: u64 = 0x024;
+
+// Guest's memory page size in bytes - Write Only
+pub const REG_MMIO_GUEST_PAGE_SIZ: u64 = 0x028;
+
+// Queue selector - Write Only
+pub const REG_MMIO_QUEUE_SEL: u64 = 0x030;
+
+// Maximum size of the currently selected queue - Read Only
+pub const REG_MMIO_QUEUE_NUM_MA: u64 = 0x034;
+
+// Queue size for the currently selected queue - Write Only
+pub const REG_MMIO_QUEUE_NUM: u64 = 0x038;
+
+// Used Ring alignment for the currently selected queue - Write Only
+pub const REG_MMIO_QUEUE_ALIGN: u64 = 0x03c;
+
+// Guest's PFN for the currently selected queue - Read Write
+pub const REG_MMIO_QUEUE_PFN: u64 = 0x040;
+
+// Ready bit for the currently selected queue - Read Write
+pub const REG_MMIO_QUEUE_READY: u64 = 0x044;
+
+// Queue notifier - Write Only
+pub const REG_MMIO_QUEUE_NOTIF: u64 = 0x050;
+
+// Interrupt status - Read Only
+pub const REG_MMIO_INTERRUPT_STAT: u64 = 0x060;
+
+// Interrupt acknowledge - Write Only
+pub const REG_MMIO_INTERRUPT_AC: u64 = 0x064;
+
+// Device status register - Read Write
+pub const REG_MMIO_STATUS: u64 = 0x070;
+
+// Selected queue's Descriptor Table address, 64 bits in two halves
+pub const REG_MMIO_QUEUE_DESC_LOW: u64 = 0x080;
+pub const REG_MMIO_QUEUE_DESC_HIGH: u64 = 0x084;
+
+// Selected queue's Available Ring address, 64 bits in two halves
+pub const REG_MMIO_QUEUE_AVAIL_LOW: u64 = 0x090;
+pub const REG_MMIO_QUEUE_AVAIL_HIGH: u64 = 0x094;
+
+// Selected queue's Used Ring address, 64 bits in two halves
+pub const REG_MMIO_QUEUE_USED_LOW: u64 = 0x0a0;
+pub const REG_MMIO_QUEUE_USED_HIGH: u64 = 0x0a4;
+
+// Shared memory region id
+pub const REG_MMIO_SHM_SEL: u64 = 0x0ac;
+
+// Shared memory region length, 64 bits in two halves
+pub const REG_MMIO_SHM_LEN_LOW: u64 = 0x0b0;
+pub const REG_MMIO_SHM_LEN_HIGH: u64 = 0x0b4;
+
+// Shared memory region base address, 64 bits in two halves
+pub const REG_MMIO_SHM_BASE_LOW: u64 = 0x0b8;
+pub const REG_MMIO_SHM_BASE_HIGH: u64 = 0x0bc;
+
+// Configuration atomicity value
+pub const REG_MMIO_CONFIG_GENERATI: u64 = 0x0fc;
+
+// The config space is defined by each driver
+// the per-driver configuration space - Read Write
+pub const REG_MMIO_CONFIG: u64 = 0x100;

--- a/crates/dbs-virtio-devices/src/mmio/mod.rs
+++ b/crates/dbs-virtio-devices/src/mmio/mod.rs
@@ -13,5 +13,12 @@
 //! version 1 is called legacy mode, and the version 2 is preferred currently. The common parts
 //! of both versions are defined here.
 
+mod mmio_state;
+pub use self::mmio_state::*;
+
 mod dragonball;
 pub use self::dragonball::*;
+
+/// Offset from the base MMIO address of a virtio device used by the guest to notify the device of
+/// queue events.
+pub const MMIO_NOTIFY_REG_OFFSET: u32 = 0x50;

--- a/crates/dbs-virtio-devices/src/mmio/mod.rs
+++ b/crates/dbs-virtio-devices/src/mmio/mod.rs
@@ -16,6 +16,9 @@
 mod mmio_state;
 pub use self::mmio_state::*;
 
+mod mmio_v2;
+pub use self::mmio_v2::*;
+
 mod dragonball;
 pub use self::dragonball::*;
 


### PR DESCRIPTION
Added MmioV2Device structure to implement MMIO transport for virtio devices.
Added MmioV2DeviceState for saving mmio state.