### PR TITLE
arch/boot: optimize setup_sregs and page initialization

### DIFF
--- a/crates/dbs-arch/Cargo.toml
+++ b/crates/dbs-arch/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["dragonball", "secure-sandbox", "arch", "ARM64", "x86", "VMM"]
 readme = "README.md"
 
 [dependencies]
-kvm-bindings = { version = ">=0.5.0", features = ["fam-wrappers"] }
+kvm-bindings = { version = "0.5.0", features = ["fam-wrappers"] }
 kvm-ioctls = ">=0.9.0"
 vm-memory = { version = "0.7" }
 vmm-sys-util = "0.9.0"

--- a/crates/dbs-boot/Cargo.toml
+++ b/crates/dbs-boot/Cargo.toml
@@ -11,6 +11,8 @@ readme = "README.md"
 
 [dependencies]
 dbs-arch = { path = "../dbs-arch", version = "0.1" }
+kvm-bindings = { version = "0.5.0", features = ["fam-wrappers"] }
+kvm-ioctls = ">=0.9.0"
 lazy_static = "1"
 libc = "0.2.39"
 thiserror = "1"


### PR DESCRIPTION
separate the page setup process in the setup_sregs to make clear
boundary between dbs-arch and dbs-boot.

Signed-off-by: Chao Wu <chaowu@linux.alibaba.com>