### PR TITLE
dbs-arch: arm add gic and cpu registers releated feature

### DIFF
--- a/crates/dbs-arch/Cargo.toml
+++ b/crates/dbs-arch/Cargo.toml
@@ -14,6 +14,7 @@ kvm-bindings = { version = "0.5.0", features = ["fam-wrappers"] }
 kvm-ioctls = ">=0.9.0"
 vm-memory = { version = "0.7" }
 vmm-sys-util = "0.9.0"
+libc = ">=0.2.39"
 
 [dev-dependencies]
 vm-memory = { version = "0.7", features = ["backend-mmap"] }

--- a/crates/dbs-arch/src/aarch64/gic/gicv2.rs
+++ b/crates/dbs-arch/src/aarch64/gic/gicv2.rs
@@ -1,0 +1,114 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{boxed::Box, result};
+
+use kvm_ioctls::DeviceFd;
+
+use super::{Error, GICDevice};
+
+type Result<T> = result::Result<T, Error>;
+
+/// Represent a GIC v2 device
+pub struct GICv2 {
+    /// The file descriptor for the KVM device
+    fd: DeviceFd,
+
+    /// GIC device properties, to be used for setting up the fdt entry
+    properties: [u64; 4],
+
+    /// Number of CPUs handled by the device
+    vcpu_count: u64,
+}
+
+impl GICv2 {
+    // Unfortunately bindgen omits defines that are based on other defines.
+    // See arch/arm64/include/uapi/asm/kvm.h file from the linux kernel.
+    const KVM_VGIC_V2_DIST_SIZE: u64 = 0x1000;
+    const KVM_VGIC_V2_CPU_SIZE: u64 = 0x2000;
+
+    // Device trees specific constants
+    const ARCH_GIC_V2_MAINT_IRQ: u32 = 8;
+
+    /// Get the address of the GICv2 distributor.
+    const fn get_dist_addr() -> u64 {
+        crate::aarch64::gic::GIC_REG_END_ADDRESS - GICv2::KVM_VGIC_V2_DIST_SIZE
+    }
+
+    /// Get the size of the GIC_v2 distributor.
+    const fn get_dist_size() -> u64 {
+        GICv2::KVM_VGIC_V2_DIST_SIZE
+    }
+
+    /// Get the address of the GIC_v2 CPU.
+    const fn get_cpu_addr() -> u64 {
+        GICv2::get_dist_addr() - GICv2::KVM_VGIC_V2_CPU_SIZE
+    }
+
+    /// Get the size of the GIC_v2 CPU.
+    const fn get_cpu_size() -> u64 {
+        GICv2::KVM_VGIC_V2_CPU_SIZE
+    }
+}
+
+impl GICDevice for GICv2 {
+    fn version() -> u32 {
+        kvm_bindings::kvm_device_type_KVM_DEV_TYPE_ARM_VGIC_V2
+    }
+
+    fn device_fd(&self) -> &DeviceFd {
+        &self.fd
+    }
+
+    fn device_properties(&self) -> &[u64] {
+        &self.properties
+    }
+
+    fn vcpu_count(&self) -> u64 {
+        self.vcpu_count
+    }
+
+    fn fdt_compatibility(&self) -> &str {
+        "arm,gic-400"
+    }
+
+    fn fdt_maint_irq(&self) -> u32 {
+        GICv2::ARCH_GIC_V2_MAINT_IRQ
+    }
+
+    fn create_device(fd: DeviceFd, vcpu_count: u64) -> Box<dyn GICDevice> {
+        Box::new(GICv2 {
+            fd: fd,
+            properties: [
+                GICv2::get_dist_addr(),
+                GICv2::get_dist_size(),
+                GICv2::get_cpu_addr(),
+                GICv2::get_cpu_size(),
+            ],
+            vcpu_count: vcpu_count,
+        })
+    }
+
+    fn init_device_attributes(gic_device: &Box<dyn GICDevice>) -> Result<()> {
+        /* Setting up the distributor attribute.
+        We are placing the GIC below 1GB so we need to substract the size of the distributor. */
+        Self::set_device_attribute(
+            &gic_device.device_fd(),
+            kvm_bindings::KVM_DEV_ARM_VGIC_GRP_ADDR,
+            u64::from(kvm_bindings::KVM_VGIC_V2_ADDR_TYPE_DIST),
+            &GICv2::get_dist_addr() as *const u64 as u64,
+            0,
+        )?;
+
+        /* Setting up the CPU attribute. */
+        Self::set_device_attribute(
+            &gic_device.device_fd(),
+            kvm_bindings::KVM_DEV_ARM_VGIC_GRP_ADDR,
+            u64::from(kvm_bindings::KVM_VGIC_V2_ADDR_TYPE_CPU),
+            &GICv2::get_cpu_addr() as *const u64 as u64,
+            0,
+        )?;
+
+        Ok(())
+    }
+}

--- a/crates/dbs-arch/src/aarch64/gic/gicv3.rs
+++ b/crates/dbs-arch/src/aarch64/gic/gicv3.rs
@@ -1,0 +1,118 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{boxed::Box, result};
+
+use kvm_ioctls::DeviceFd;
+
+use super::{Error, GICDevice};
+
+type Result<T> = result::Result<T, Error>;
+
+/// GICv3 instance
+pub struct GICv3 {
+    /// The file descriptor for the KVM device
+    fd: DeviceFd,
+
+    /// GIC device properties, to be used for setting up the fdt entry
+    properties: [u64; 4],
+
+    /// Number of CPUs handled by the device
+    vcpu_count: u64,
+}
+
+impl GICv3 {
+    // Unfortunately bindgen omits defines that are based on other defines.
+    // See arch/arm64/include/uapi/asm/kvm.h file from the linux kernel.
+    const SZ_64K: u64 = 0x0001_0000;
+    const KVM_VGIC_V3_DIST_SIZE: u64 = GICv3::SZ_64K;
+    const KVM_VGIC_V3_REDIST_SIZE: u64 = (2 * GICv3::SZ_64K);
+
+    // Device trees specific constants
+    const ARCH_GIC_V3_MAINT_IRQ: u32 = 9;
+
+    /// Get the address of the GIC distributor.
+    fn get_dist_addr() -> u64 {
+        crate::aarch64::gic::GIC_REG_END_ADDRESS - GICv3::KVM_VGIC_V3_DIST_SIZE
+    }
+
+    /// Get the size of the GIC distributor.
+    fn get_dist_size() -> u64 {
+        GICv3::KVM_VGIC_V3_DIST_SIZE
+    }
+
+    /// Get the address of the GIC redistributors.
+    pub fn get_redists_addr(vcpu_count: u64) -> u64 {
+        GICv3::get_dist_addr() - GICv3::get_redists_size(vcpu_count)
+    }
+
+    /// Get the size of the GIC redistributors.
+    fn get_redists_size(vcpu_count: u64) -> u64 {
+        vcpu_count * GICv3::KVM_VGIC_V3_REDIST_SIZE
+    }
+}
+
+impl GICDevice for GICv3 {
+    fn version() -> u32 {
+        kvm_bindings::kvm_device_type_KVM_DEV_TYPE_ARM_VGIC_V3
+    }
+
+    fn device_fd(&self) -> &DeviceFd {
+        &self.fd
+    }
+
+    fn device_properties(&self) -> &[u64] {
+        &self.properties
+    }
+
+    fn vcpu_count(&self) -> u64 {
+        self.vcpu_count
+    }
+
+    fn fdt_compatibility(&self) -> &str {
+        "arm,gic-v3"
+    }
+
+    fn fdt_maint_irq(&self) -> u32 {
+        GICv3::ARCH_GIC_V3_MAINT_IRQ
+    }
+
+    fn create_device(fd: DeviceFd, vcpu_count: u64) -> Box<dyn GICDevice> {
+        Box::new(GICv3 {
+            fd: fd,
+            properties: [
+                GICv3::get_dist_addr(),
+                GICv3::get_dist_size(),
+                GICv3::get_redists_addr(vcpu_count),
+                GICv3::get_redists_size(vcpu_count),
+            ],
+            vcpu_count: vcpu_count,
+        })
+    }
+
+    fn init_device_attributes(gic_device: &Box<dyn GICDevice>) -> Result<()> {
+        /* Setting up the distributor attribute.
+         We are placing the GIC below 1GB so we need to substract the size of the distributor.
+        */
+        Self::set_device_attribute(
+            &gic_device.device_fd(),
+            kvm_bindings::KVM_DEV_ARM_VGIC_GRP_ADDR,
+            u64::from(kvm_bindings::KVM_VGIC_V3_ADDR_TYPE_DIST),
+            &GICv3::get_dist_addr() as *const u64 as u64,
+            0,
+        )?;
+
+        /* Setting up the redistributors' attribute.
+        We are calculating here the start of the redistributors address. We have one per CPU.
+        */
+        Self::set_device_attribute(
+            &gic_device.device_fd(),
+            kvm_bindings::KVM_DEV_ARM_VGIC_GRP_ADDR,
+            u64::from(kvm_bindings::KVM_VGIC_V3_ADDR_TYPE_REDIST),
+            &GICv3::get_redists_addr(u64::from(gic_device.vcpu_count())) as *const u64 as u64,
+            0,
+        )?;
+
+        Ok(())
+    }
+}

--- a/crates/dbs-arch/src/aarch64/gic/mod.rs
+++ b/crates/dbs-arch/src/aarch64/gic/mod.rs
@@ -1,0 +1,209 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Export gicv2 interface
+pub mod gicv2;
+/// Export gicv3 interface
+pub mod gicv3;
+
+use std::{boxed::Box, result};
+
+use kvm_ioctls::{DeviceFd, VmFd};
+
+use gicv2::GICv2;
+use gicv3::GICv3;
+
+// As per virt/kvm/arm/vgic/vgic-kvm-device.c we need
+// the number of interrupts our GIC will support to be:
+// * bigger than 32
+// * less than 1023 and
+// * a multiple of 32.
+// We are setting up our interrupt controller to support a maximum of 128 interrupts.
+/// First usable interrupt on aarch64.
+pub const IRQ_BASE: u32 = 32;
+
+/// Last usable interrupt on aarch64.
+pub const IRQ_MAX: u32 = 159;
+
+/// Define the gic register end address.
+pub const GIC_REG_END_ADDRESS: u64 = 1 << 30; // 1GB
+
+/// Errors thrown while setting up the GIC.
+#[derive(Debug)]
+pub enum Error {
+    /// Error while calling KVM ioctl for setting up the global interrupt controller.
+    CreateGIC(kvm_ioctls::Error),
+    /// Error while setting device attributes for the GIC.
+    SetDeviceAttribute(kvm_ioctls::Error),
+    /// The number of vCPUs in the GicState doesn't match the number of vCPUs on the system
+    InconsistentVcpuCount,
+    /// The VgicSysRegsState is invalid
+    InvalidVgicSysRegState,
+    /// ERROR while create ITS fail
+    CreateITS(kvm_ioctls::Error),
+    /// ERROR while set ITS attr fail
+    SetITSAttribute(kvm_ioctls::Error),
+}
+type Result<T> = result::Result<T, Error>;
+
+/// Function that flushes
+/// RDIST pending tables into guest RAM.
+///
+/// The tables get flushed to guest RAM whenever the VM gets stopped.
+pub fn save_pending_tables(fd: &DeviceFd) -> Result<()> {
+    let init_gic_attr = kvm_bindings::kvm_device_attr {
+        group: kvm_bindings::KVM_DEV_ARM_VGIC_GRP_CTRL,
+        attr: u64::from(kvm_bindings::KVM_DEV_ARM_VGIC_SAVE_PENDING_TABLES),
+        addr: 0,
+        flags: 0,
+    };
+    fd.set_device_attr(&init_gic_attr)
+        .map_err(Error::SetDeviceAttribute)
+}
+
+/// Trait for GIC devices.
+pub trait GICDevice: Send {
+    /// Returns the file descriptor of the GIC device
+    fn device_fd(&self) -> &DeviceFd;
+
+    /// Returns an array with GIC device properties
+    fn device_properties(&self) -> &[u64];
+
+    /// Returns the number of vCPUs this GIC handles
+    fn vcpu_count(&self) -> u64;
+
+    /// Returns the fdt compatibility property of the device
+    fn fdt_compatibility(&self) -> &str;
+
+    /// Returns the maint_irq fdt property of the device
+    fn fdt_maint_irq(&self) -> u32;
+
+    /// Returns the GIC version of the device
+    fn version() -> u32
+    where
+        Self: Sized;
+
+    /// Create the GIC device object
+    fn create_device(fd: DeviceFd, vcpu_count: u64) -> Box<dyn GICDevice>
+    where
+        Self: Sized;
+
+    /// Setup the device-specific attributes
+    fn init_device_attributes(gic_device: &Box<dyn GICDevice>) -> Result<()>
+    where
+        Self: Sized;
+
+    /// Only gic-v3 has its
+    fn attach_its(&mut self, _vm: &VmFd) -> Result<()> {
+        Ok(())
+    }
+
+    /// Initialize a GIC device
+    fn init_device(vm: &VmFd) -> Result<DeviceFd>
+    where
+        Self: Sized,
+    {
+        let mut gic_device = kvm_bindings::kvm_create_device {
+            type_: Self::version(),
+            fd: 0,
+            flags: 0,
+        };
+
+        vm.create_device(&mut gic_device).map_err(Error::CreateGIC)
+    }
+
+    /// Set a GIC device attribute
+    fn set_device_attribute(
+        fd: &DeviceFd,
+        group: u32,
+        attr: u64,
+        addr: u64,
+        flags: u32,
+    ) -> Result<()>
+    where
+        Self: Sized,
+    {
+        let attr = kvm_bindings::kvm_device_attr {
+            group: group,
+            attr: attr,
+            addr: addr,
+            flags: flags,
+        };
+        fd.set_device_attr(&attr)
+            .map_err(Error::SetDeviceAttribute)?;
+
+        Ok(())
+    }
+
+    /// Finalize the setup of a GIC device
+    fn finalize_device(gic_device: &Box<dyn GICDevice>) -> Result<()>
+    where
+        Self: Sized,
+    {
+        /* We need to tell the kernel how many irqs to support with this vgic.
+         * See the `layout` module for details.
+         */
+        let nr_irqs: u32 = IRQ_MAX - IRQ_BASE + 1;
+        let nr_irqs_ptr = &nr_irqs as *const u32;
+        Self::set_device_attribute(
+            gic_device.device_fd(),
+            kvm_bindings::KVM_DEV_ARM_VGIC_GRP_NR_IRQS,
+            0,
+            nr_irqs_ptr as u64,
+            0,
+        )?;
+
+        /* Finalize the GIC.
+         * See https://code.woboq.org/linux/linux/virt/kvm/arm/vgic/vgic-kvm-device.c.html#211.
+         */
+        Self::set_device_attribute(
+            gic_device.device_fd(),
+            kvm_bindings::KVM_DEV_ARM_VGIC_GRP_CTRL,
+            u64::from(kvm_bindings::KVM_DEV_ARM_VGIC_CTRL_INIT),
+            0,
+            0,
+        )?;
+
+        Ok(())
+    }
+
+    /// Method to initialize the GIC device
+    fn new(vm: &VmFd, vcpu_count: u64) -> Result<Box<dyn GICDevice>>
+    where
+        Self: Sized,
+    {
+        let vgic_fd = Self::init_device(vm)?;
+
+        let mut device = Self::create_device(vgic_fd, vcpu_count);
+
+        device.attach_its(vm)?;
+
+        Self::init_device_attributes(&device)?;
+
+        Self::finalize_device(&device)?;
+
+        Ok(device)
+    }
+}
+
+/// Create a GIC device.
+///
+/// It will try to create by default a GICv3 device. If that fails it will try
+/// to fall-back to a GICv2 device.
+pub fn create_gic(vm: &VmFd, vcpu_count: u64) -> Result<Box<dyn GICDevice>> {
+    GICv3::new(vm, vcpu_count).or_else(|_| GICv2::new(vm, vcpu_count))
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+    use kvm_ioctls::Kvm;
+
+    #[test]
+    fn test_create_gic() {
+        let kvm = Kvm::new().unwrap();
+        let vm = kvm.create_vm().unwrap();
+        assert!(create_gic(&vm, 1).is_ok());
+    }
+}

--- a/crates/dbs-arch/src/aarch64/mod.rs
+++ b/crates/dbs-arch/src/aarch64/mod.rs
@@ -1,4 +1,9 @@
 // Copyright 2021 Alibaba Cloud. All Rights Reserved.
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 //! CPU architecture specific constants, structures and utilities for the `aarch64` architecture.
+/// Module for the global interrupt controller configuration.
+pub mod gic;
+/// Logic for configuring aarch64 registers.
+pub mod regs;

--- a/crates/dbs-arch/src/aarch64/regs.rs
+++ b/crates/dbs-arch/src/aarch64/regs.rs
@@ -1,0 +1,207 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Portions Copyright 2017 The Chromium OS Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the THIRD-PARTY file.
+
+use std::{mem, result};
+
+use kvm_bindings::*;
+use kvm_ioctls::VcpuFd;
+use vmm_sys_util;
+
+/// Errors thrown while setting aarch64 registers.
+#[derive(Debug)]
+pub enum Error {
+    /// Failed to get core register (PC, PSTATE or general purpose ones).
+    GetCoreRegister(kvm_ioctls::Error),
+    /// Failed to set core register (PC, PSTATE or general purpose ones).
+    SetCoreRegister(kvm_ioctls::Error),
+    /// Failed to get a system register.
+    GetSysRegister(kvm_ioctls::Error),
+    /// Failed to get the register list.
+    GetRegList(kvm_ioctls::Error),
+    /// Failed to get a system register.
+    SetRegister(kvm_ioctls::Error),
+    /// Failed to init fam reglist
+    FamRegister(vmm_sys_util::fam::Error),
+}
+type Result<T> = result::Result<T, Error>;
+
+#[allow(non_upper_case_globals)]
+// PSR (Processor State Register) bits.
+// Taken from arch/arm64/include/uapi/asm/ptrace.h.
+const PSR_MODE_EL1h: u64 = 0x0000_0005;
+const PSR_F_BIT: u64 = 0x0000_0040;
+const PSR_I_BIT: u64 = 0x0000_0080;
+const PSR_A_BIT: u64 = 0x0000_0100;
+const PSR_D_BIT: u64 = 0x0000_0200;
+// Taken from arch/arm64/kvm/inject_fault.c.
+const PSTATE_FAULT_BITS_64: u64 = PSR_MODE_EL1h | PSR_A_BIT | PSR_F_BIT | PSR_I_BIT | PSR_D_BIT;
+
+// Following are macros that help with getting the ID of a aarch64 core register.
+// The core register are represented by the user_pt_regs structure. Look for it in
+// arch/arm64/include/uapi/asm/ptrace.h.
+
+// This macro gets the offset of a structure (i.e `str`) member (i.e `field`) without having
+// an instance of that structure.
+// It uses a null pointer to retrieve the offset to the field.
+// Inspired by C solution: `#define offsetof(str, f) ((size_t)(&((str *)0)->f))`.
+// Doing `offset__of!(user_pt_regs, pstate)` in our rust code will trigger the following:
+// unsafe { &(*(0 as *const user_pt_regs)).pstate as *const _ as usize }
+// The dereference expression produces an lvalue, but that lvalue is not actually read from,
+// we're just doing pointer math on it, so in theory, it should safe.
+macro_rules! offset__of {
+    ($str:ty, $field:ident) => {
+        unsafe { &(*(0 as *const $str)).$field as *const _ as usize }
+    };
+}
+
+macro_rules! arm64_core_reg {
+    ($reg: tt) => {
+        // As per `kvm_arm_copy_reg_indices`, the id of a core register can be obtained like this:
+        // `const u64 core_reg = KVM_REG_ARM64 | KVM_REG_SIZE_U64 | KVM_REG_ARM_CORE | i`, where i is obtained with:
+        // `for (i = 0; i < sizeof(struct kvm_regs) / sizeof(__u32); i++) {`
+        // We are using here `user_pt_regs` since this structure contains the core register and it is at
+        // the start of `kvm_regs`.
+        // struct kvm_regs {
+        //	struct user_pt_regs regs;	/* sp = sp_el0 */
+        //
+        //	__u64	sp_el1;
+        //	__u64	elr_el1;
+        //
+        //	__u64	spsr[KVM_NR_SPSR];
+        //
+        //	struct user_fpsimd_state fp_regs;
+        //};
+        // struct user_pt_regs {
+        //	__u64		regs[31];
+        //	__u64		sp;
+        //	__u64		pc;
+        //	__u64		pstate;
+        //};
+        // In our implementation we need: pc, pstate and user_pt_regs->regs[0].
+        KVM_REG_ARM64 as u64
+            | KVM_REG_SIZE_U64 as u64
+            | u64::from(KVM_REG_ARM_CORE)
+            | ((offset__of!(user_pt_regs, $reg) / mem::size_of::<u32>()) as u64)
+    };
+}
+
+// This macro computes the ID of a specific ARM64 system register similar to how
+// the kernel C macro does.
+// https://elixir.bootlin.com/linux/v4.20.17/source/arch/arm64/include/uapi/asm/kvm.h#L203
+macro_rules! arm64_sys_reg {
+    ($name: tt, $op0: tt, $op1: tt, $crn: tt, $crm: tt, $op2: tt) => {
+        const $name: u64 = KVM_REG_ARM64 as u64
+            | KVM_REG_SIZE_U64 as u64
+            | KVM_REG_ARM64_SYSREG as u64
+            | ((($op0 as u64) << KVM_REG_ARM64_SYSREG_OP0_SHIFT)
+                & KVM_REG_ARM64_SYSREG_OP0_MASK as u64)
+            | ((($op1 as u64) << KVM_REG_ARM64_SYSREG_OP1_SHIFT)
+                & KVM_REG_ARM64_SYSREG_OP1_MASK as u64)
+            | ((($crn as u64) << KVM_REG_ARM64_SYSREG_CRN_SHIFT)
+                & KVM_REG_ARM64_SYSREG_CRN_MASK as u64)
+            | ((($crm as u64) << KVM_REG_ARM64_SYSREG_CRM_SHIFT)
+                & KVM_REG_ARM64_SYSREG_CRM_MASK as u64)
+            | ((($op2 as u64) << KVM_REG_ARM64_SYSREG_OP2_SHIFT)
+                & KVM_REG_ARM64_SYSREG_OP2_MASK as u64);
+    };
+}
+
+// Constant imported from the Linux kernel:
+// https://elixir.bootlin.com/linux/v4.20.17/source/arch/arm64/include/asm/sysreg.h#L135
+arm64_sys_reg!(MPIDR_EL1, 3, 0, 0, 0, 5);
+
+/// Configure core registers for a given CPU.
+///
+/// # Arguments
+///
+/// * `vcpu` - Structure for the VCPU that holds the VCPU's fd.
+/// * `cpu_id` - Index of current vcpu.
+/// * `boot_ip` - Starting instruction pointer.
+/// * `mem` - Reserved DRAM for current VM.
+pub fn setup_regs(vcpu: &VcpuFd, cpu_id: u8, boot_ip: u64, fdt_address: u64) -> Result<()> {
+    // Get the register index of the PSTATE (Processor State) register.
+    vcpu.set_one_reg(arm64_core_reg!(pstate), PSTATE_FAULT_BITS_64)
+        .map_err(Error::SetCoreRegister)?;
+
+    // Other vCPUs are powered off initially awaiting PSCI wakeup.
+    if cpu_id == 0 {
+        // Setting the PC (Processor Counter) to the current program address (kernel address).
+        vcpu.set_one_reg(arm64_core_reg!(pc), boot_ip)
+            .map_err(Error::SetCoreRegister)?;
+
+        // Last mandatory thing to set -> the address pointing to the FDT (also called DTB).
+        // "The device tree blob (dtb) must be placed on an 8-byte boundary and must
+        // not exceed 2 megabytes in size." -> https://www.kernel.org/doc/Documentation/arm64/booting.txt.
+        // We are choosing to place it the end of DRAM. See `get_fdt_addr`.
+        vcpu.set_one_reg(arm64_core_reg!(regs), fdt_address)
+            .map_err(Error::SetCoreRegister)?;
+    }
+    Ok(())
+}
+
+/// Specifies whether a particular register is a system register or not.
+/// The kernel splits the registers on aarch64 in core registers and system registers.
+/// So, below we get the system registers by checking that they are not core registers.
+///
+/// # Arguments
+///
+/// * `regid` - The index of the register we are checking.
+pub fn is_system_register(regid: u64) -> bool {
+    if (regid & KVM_REG_ARM_COPROC_MASK as u64) == KVM_REG_ARM_CORE as u64 {
+        return false;
+    }
+
+    let size = regid & KVM_REG_SIZE_MASK;
+    if size != KVM_REG_SIZE_U32 && size != KVM_REG_SIZE_U64 {
+        panic!("Unexpected register size for system register {}", size);
+    }
+    true
+}
+/// Read the MPIDR - Multiprocessor Affinity Register.
+///
+/// # Arguments
+///
+/// * `vcpu` - Structure for the VCPU that holds the VCPU's fd.
+pub fn read_mpidr(vcpu: &VcpuFd) -> Result<u64> {
+    vcpu.get_one_reg(MPIDR_EL1).map_err(Error::GetSysRegister)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kvm_ioctls::Kvm;
+
+    #[test]
+    fn test_setup_regs() {
+        let kvm = Kvm::new().unwrap();
+        let vm = kvm.create_vm().unwrap();
+        let vcpu = vm.create_vcpu(0).unwrap();
+        match setup_regs(&vcpu, 0, 0x0, crate::gic::GIC_REG_END_ADDRESS).unwrap_err() {
+            Error::SetCoreRegister(ref e) => assert_eq!(e.errno(), libc::ENOEXEC),
+            _ => panic!("Expected to receive Error::SetCoreRegister"),
+        }
+        let mut kvi: kvm_bindings::kvm_vcpu_init = kvm_bindings::kvm_vcpu_init::default();
+        vm.get_preferred_target(&mut kvi).unwrap();
+        vcpu.vcpu_init(&kvi).unwrap();
+
+        assert!(setup_regs(&vcpu, 0, 0x0, crate::gic::GIC_REG_END_ADDRESS).is_ok());
+    }
+    #[test]
+    fn test_read_mpidr() {
+        let kvm = Kvm::new().unwrap();
+        let vm = kvm.create_vm().unwrap();
+        let vcpu = vm.create_vcpu(0).unwrap();
+        let mut kvi: kvm_bindings::kvm_vcpu_init = kvm_bindings::kvm_vcpu_init::default();
+        vm.get_preferred_target(&mut kvi).unwrap();
+
+        // Must fail when vcpu is not initialized yet.
+        assert!(read_mpidr(&vcpu).is_err());
+
+        vcpu.vcpu_init(&kvi).unwrap();
+        assert_eq!(read_mpidr(&vcpu).unwrap(), 0x80000000);
+    }
+}


### PR DESCRIPTION
This PR adds features related to ARM GIC and CPU registers, including VIRTUALIZATION of GIC and vcpu startup related configuration.