### PR TITLE
dbs-interrupt: reduce keywords to meet crates.io's requirements

### DIFF
--- a/crates/dbs-interrupt/Cargo.toml
+++ b/crates/dbs-interrupt/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 edition = "2018"
 homepage = "https://github.com/openanolis/dragonball-sandbox"
 repository = "https://github.com/openanolis/dragonball-sandbox/tree/main/crates/dbs-interrupt"
-keywords = ["dragonball", "secure-sandbox", "device", "interrupt", "MSI", "MSI-x", "legacy-irq"]
+keywords = ["dragonball", "secure-sandbox", "device", "interrupt"]
 readme = "README.md"
 
 [dependencies]


### PR DESCRIPTION
crates.io only support maxium 5 keywords per crate, so we need to reduce the
count before publish.

Signed-off-by: Zizheng Bian <zizheng.bian@linux.alibaba.com>