### PR TITLE
dbs-arch: prepare to release dbs-arch

### DIFF
--- a/crates/dbs-arch/Cargo.toml
+++ b/crates/dbs-arch/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["Alibaba Dragonball Team"]
 license = "Apache-2.0"
 edition = "2018"
+description = "A collection of CPU architecture specific constants and utilities."
 homepage = "https://github.com/openanolis/dragonball-sandbox"
 repository = "https://github.com/openanolis/dragonball-sandbox"
 keywords = ["dragonball", "secure-sandbox", "arch", "ARM64", "x86", "VMM"]


### PR DESCRIPTION
fix warning: manifest has no description.

Signed-off-by: wllenyj <wllenyj@linux.alibaba.com>