### PR TITLE
upgrade nix to 0.23.1

### DIFF
--- a/crates/dbs-address-space/Cargo.toml
+++ b/crates/dbs-address-space/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 [dependencies]
 arc-swap = ">=0.4.8"
 libc = "0.2.39"
-nix = "0.15"
+nix = "0.23.1"
 thiserror = "1"
 vmm-sys-util = "0.9.0"
 vm-memory = { version = "0.7", features = ["backend-mmap", "backend-atomic"] }

--- a/crates/dbs-virtio-devices/Cargo.toml
+++ b/crates/dbs-virtio-devices/Cargo.toml
@@ -24,7 +24,7 @@ kvm-bindings = "0.5.0"
 kvm-ioctls = "0.11.0"
 libc = "0.2.119"
 log = "0.4.14"
-nix = "0.15.0"
+nix = "0.23.1"
 rafs = { git = "https://github.com/dragonflyoss/image-service.git", optional = true }
 rlimit = "0.7.0"
 serde = "1.0.27"


### PR DESCRIPTION
This is to fix the warning of `cargo deny check bans`.
```
warning[B004]: found 3 duplicate entries for crate 'nix'
   ┌─ ./dragonball-sandbox/Cargo.lock:87:1
   │
87 │ ╭ nix 0.15.0 registry+https://github.com/rust-lang/crates.io-index
88 │ │ nix 0.22.3 registry+https://github.com/rust-lang/crates.io-index
89 │ │ nix 0.23.1 registry+https://github.com/rust-lang/crates.io-index
   │ ╰────────────────────────────────────────────────────────────────^ lock entries
   │
   = nix v0.15.0
     ├── dbs-address-space v0.1.0
     └── dbs-virtio-devices v0.1.0
   = nix v0.22.3
     └── fuse-backend-rs v0.4.0
         ├── blobfs v0.1.0
         │   └── dbs-virtio-devices v0.1.0
         ├── dbs-virtio-devices v0.1.0 (*)
         ├── nydus-utils v0.1.0
         │   ├── rafs v0.1.0
         │   │   ├── blobfs v0.1.0 (*)
         │   │   └── dbs-virtio-devices v0.1.0 (*)
         │   └── storage v0.5.0
         │       ├── blobfs v0.1.0 (*)
         │       └── rafs v0.1.0 (*)
         ├── rafs v0.1.0 (*)
         └── storage v0.5.0 (*)
   = nix v0.23.1
     ├── rafs v0.1.0
     │   ├── blobfs v0.1.0
     │   │   └── dbs-virtio-devices v0.1.0
     │   └── dbs-virtio-devices v0.1.0 (*)
     └── storage v0.5.0
         ├── blobfs v0.1.0 (*)
         └── rafs v0.1.0 (*)
```

Signed-off-by: wllenyj <wllenyj@linux.alibaba.com>