### PR TITLE
dbs-virtio-devices: update fuse-backend-rs to 0.9.0

### DIFF
--- a/crates/dbs-address-space/Cargo.toml
+++ b/crates/dbs-address-space/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 [dependencies]
 arc-swap = ">=0.4.8"
 libc = "0.2.39"
-nix = "0.15"
+nix = "0.23.1"
 thiserror = "1"
 vmm-sys-util = "0.9.0"
 vm-memory = { version = "0.7", features = ["backend-mmap", "backend-atomic"] }

--- a/crates/dbs-virtio-devices/Cargo.toml
+++ b/crates/dbs-virtio-devices/Cargo.toml
@@ -24,7 +24,7 @@ kvm-bindings = "0.5.0"
 kvm-ioctls = "0.11.0"
 libc = "0.2.119"
 log = "0.4.14"
-nix = "0.15.0"
+nix = "0.23.1"
 rafs = { git = "https://github.com/dragonflyoss/image-service.git", rev = "316380792092f73c99f832c4cb44ef4319d6f76b", optional = true }
 rlimit = "0.7.0"
 serde = "1.0.27"

--- a/crates/dbs-virtio-devices/Cargo.toml
+++ b/crates/dbs-virtio-devices/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["dragonball", "secure-sandbox", "devices", "virtio"]
 readme = "README.md"
 
 [dependencies]
-blobfs = { git = "https://github.com/dragonflyoss/image-service.git", optional = true }
+blobfs = { git = "https://github.com/dragonflyoss/image-service.git", rev = "316380792092f73c99f832c4cb44ef4319d6f76b", optional = true }
 byteorder = "1.4.3"
 caps = "0.5.3"
 dbs-device = { version = "0.1.0", path = "../dbs-device" }
@@ -19,13 +19,13 @@ dbs-interrupt = { version = "0.1.0", path = "../dbs-interrupt", features = ["kvm
 dbs-utils = { version = "0.1.0", path = "../dbs-utils" }
 epoll = "4.0.1"
 io-uring = "0.5.2"
-fuse-backend-rs = { version = "0.4.0", optional = true }
+fuse-backend-rs = { version = "0.9.0", optional = true }
 kvm-bindings = "0.5.0"
 kvm-ioctls = "0.11.0"
 libc = "0.2.119"
 log = "0.4.14"
 nix = "0.15.0"
-rafs = { git = "https://github.com/dragonflyoss/image-service.git", optional = true }
+rafs = { git = "https://github.com/dragonflyoss/image-service.git", rev = "316380792092f73c99f832c4cb44ef4319d6f76b", optional = true }
 rlimit = "0.7.0"
 serde = "1.0.27"
 serde_json = "1.0.9"

--- a/deny.toml
+++ b/deny.toml
@@ -191,10 +191,6 @@ skip = [
 # dependencies starting at the specified crate, up to a certain depth, which is
 # by default infinite
 skip-tree = [
-    # TODO(wanglei01): Need to fix.
-    #{ name = "rafs", version = "0.1.0", depth = 4 },
-    { name = "storage", version = "0.5.0", depth = 4 },
-    #{ name = "fuse-backend-rs", version = "0.4.0", depth = 2 },
 ]
 
 # This section is considered when running `cargo deny check sources`.


### PR DESCRIPTION
Version 0.9.0 of fuse-backend-rs fixed an EBADF error, see
https://github.com/cloud-hypervisor/fuse-backend-rs/pull/71 for details.