### PR TITLE
dbs-device: add as_any for DeviceIo trait

### DIFF
--- a/crates/dbs-device/src/device_manager.rs
+++ b/crates/dbs-device/src/device_manager.rs
@@ -23,6 +23,7 @@
 //!
 //! ```
 //! use std::sync::Arc;
+//! use std::any::Any;
 //!
 //! use dbs_device::device_manager::IoManager;
 //! use dbs_device::resources::{DeviceResources, Resource};
@@ -61,6 +62,10 @@
 //!             base.raw_value(),
 //!             offset.raw_value()
 //!         );
+//!     }
+//!
+//!     fn as_any(&self) -> &dyn Any {
+//!         self
 //!     }
 //! }
 //!
@@ -466,6 +471,9 @@ mod tests {
         fn pio_write(&self, _base: PioAddress, _offset: PioAddress, data: &[u8]) {
             let mut config = self.config.lock().expect("failed to acquire lock");
             *config = u32::from(data[0]) & 0xff;
+        }
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
         }
     }
 

--- a/crates/dbs-virtio-devices/src/mmio/mmio_v2.rs
+++ b/crates/dbs-virtio-devices/src/mmio/mmio_v2.rs
@@ -338,9 +338,9 @@ where
 
 impl<AS, Q, R> DeviceIo for MmioV2Device<AS, Q, R>
 where
-    AS: 'static + GuestAddressSpace + Clone + Send + Sync,
-    Q: QueueStateT + Send + Clone,
-    R: GuestMemoryRegion + Send + Sync,
+    AS: 'static + GuestAddressSpace + Send + Sync + Clone,
+    Q: 'static + QueueStateT + Send + Clone,
+    R: 'static + GuestMemoryRegion + Send + Sync,
 {
     fn read(&self, _base: IoAddress, offset: IoAddress, data: &mut [u8]) {
         let offset = offset.raw_value();
@@ -470,6 +470,10 @@ where
         resources.append(self.mmio_cfg_res.clone());
 
         resources
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
     }
 }
 

--- a/crates/dbs-virtio-devices/src/vsock/backend/inner.rs
+++ b/crates/dbs-virtio-devices/src/vsock/backend/inner.rs
@@ -886,7 +886,7 @@ mod tests {
                     ErrorKind::TimedOut
                 );
                 let end_time1 = Instant::now().duration_since(start_time1).as_millis();
-                assert!((150..200).contains(&end_time1));
+                assert!((150..250).contains(&end_time1));
 
                 // second read would ok
                 assert!(outer_stream.read_exact(&mut reader_buf).is_ok());


### PR DESCRIPTION
Sometimes we need to downcast out the specific type.