### PR TITLE
dbs-boot: use the vm-fdt crate to replace libfdt

### DIFF
--- a/crates/dbs-boot/Cargo.toml
+++ b/crates/dbs-boot/Cargo.toml
@@ -17,6 +17,7 @@ lazy_static = "1"
 libc = "0.2.39"
 thiserror = "1"
 vm-memory = "0.7.0"
+vm-fdt = "0.2.0"
 
 [dev-dependencies]
 vm-memory = { version = "0.7.0", features = ["backend-mmap"] }

--- a/crates/dbs-boot/src/aarch64/fdt.rs
+++ b/crates/dbs-boot/src/aarch64/fdt.rs
@@ -469,7 +469,7 @@ mod tests {
         let kvm = Kvm::new().unwrap();
         let vm = kvm.create_vm().unwrap();
         let gic = create_gic(&vm, 1).unwrap();
-        let mut dtb = create_fdt(
+        let dtb = create_fdt(
             &mem,
             vec![0],
             "console=tty0",
@@ -502,7 +502,6 @@ mod tests {
         buf.extend_from_slice(bytes);
 
         set_size(&mut buf, pos, val);
-        set_size(&mut dtb, pos, val);
         let original_fdt = device_tree::DeviceTree::load(&buf).unwrap();
         let generated_fdt = device_tree::DeviceTree::load(&dtb).unwrap();
         assert!(format!("{:?}", original_fdt) == format!("{:?}", generated_fdt));
@@ -520,7 +519,7 @@ mod tests {
             size: 0x1000,
         };
 
-        let mut dtb = create_fdt(
+        let dtb = create_fdt(
             &mem,
             vec![0],
             "console=tty0",
@@ -553,7 +552,6 @@ mod tests {
         buf.extend_from_slice(bytes);
 
         set_size(&mut buf, pos, val);
-        set_size(&mut dtb, pos, val);
         let original_fdt = device_tree::DeviceTree::load(&buf).unwrap();
         let generated_fdt = device_tree::DeviceTree::load(&dtb).unwrap();
         assert!(format!("{:?}", original_fdt) == format!("{:?}", generated_fdt));

--- a/crates/dbs-boot/src/aarch64/fdt.rs
+++ b/crates/dbs-boot/src/aarch64/fdt.rs
@@ -9,15 +9,13 @@
 //! Create Flatten Device Tree (FDT) for ARM64 systems.
 
 use std::collections::HashMap;
-use std::ffi::{CStr, CString};
 use std::fmt::Debug;
-use std::io;
-use std::ptr::null;
 
 use dbs_arch::gic::its::ItsType::{self, PciMsiIts, PlatformMsiIts};
 use dbs_arch::gic::GICDevice;
 use dbs_arch::{DeviceInfoForFDT, DeviceType};
-use libc::{c_char, c_int, c_void};
+
+use vm_fdt::FdtWriter;
 use vm_memory::GuestMemoryRegion;
 use vm_memory::{Address, Bytes, GuestAddress, GuestMemory};
 
@@ -50,22 +48,6 @@ const GIC_FDT_IRQ_TYPE_PPI: u32 = 1;
 const IRQ_TYPE_EDGE_RISING: u32 = 1;
 const IRQ_TYPE_LEVEL_HI: u32 = 4;
 
-// This links to libfdt which handles the creation of the binary blob
-// flattened device tree (fdt) that is passed to the kernel and indicates
-// the hardware configuration of the machine.
-#[link(name = "fdt")]
-extern "C" {
-    fn fdt_create(buf: *mut c_void, bufsize: c_int) -> c_int;
-    fn fdt_finish_reservemap(fdt: *mut c_void) -> c_int;
-    fn fdt_begin_node(fdt: *mut c_void, name: *const c_char) -> c_int;
-    fn fdt_property(fdt: *mut c_void, name: *const c_char, val: *const c_void, len: c_int)
-        -> c_int;
-    fn fdt_end_node(fdt: *mut c_void) -> c_int;
-    fn fdt_open_into(fdt: *const c_void, buf: *mut c_void, bufsize: c_int) -> c_int;
-    fn fdt_finish(fdt: *const c_void) -> c_int;
-    fn fdt_pack(fdt: *mut c_void) -> c_int;
-}
-
 // Auxiliary function to get the address where the device tree blob is loaded.
 fn get_fdt_addr<M: GuestMemory>(mem: &M) -> u64 {
     // If the memory allocated is smaller than the size allocated for the FDT,
@@ -89,25 +71,22 @@ pub fn create_fdt<T: DeviceInfoForFDT + Clone + Debug, M: GuestMemory>(
     gic_device: &Box<dyn GICDevice>,
     initrd: &Option<InitrdConfig>,
 ) -> Result<Vec<u8>> {
-    // Alocate stuff necessary for the holding the blob.
-    let mut fdt = vec![0; FDT_MAX_SIZE];
-
-    allocate_fdt(&mut fdt)?;
+    let mut fdt = FdtWriter::new()?;
 
     // For an explanation why these nodes were introduced in the blob take a look at
     // https://github.com/torvalds/linux/blob/master/Documentation/devicetree/booting-without-of.txt#L845
     // Look for "Required nodes and properties".
 
     // Header or the root node as per above mentioned documentation.
-    append_begin_node(&mut fdt, "")?;
-    append_property_string(&mut fdt, "compatible", "linux,dummy-virt")?;
+    let root_node = fdt.begin_node("")?;
+    fdt.property_string("compatible", "linux,dummy-virt")?;
     // For info on #address-cells and size-cells read "Note about cells and address representation"
     // from the above mentioned txt file.
-    append_property_u32(&mut fdt, "#address-cells", ADDRESS_CELLS)?;
-    append_property_u32(&mut fdt, "#size-cells", SIZE_CELLS)?;
+    fdt.property_u32("#address-cells", ADDRESS_CELLS)?;
+    fdt.property_u32("#size-cells", SIZE_CELLS)?;
     // This is not mandatory but we use it to point the root node to the node
     // containing description of the interrupt controller for this VM.
-    append_property_u32(&mut fdt, "interrupt-parent", GIC_PHANDLE)?;
+    fdt.property_u32("interrupt-parent", GIC_PHANDLE)?;
     create_cpu_nodes(&mut fdt, &vcpu_mpidr)?;
     create_memory_node(&mut fdt, guest_mem)?;
     create_chosen_node(&mut fdt, cmdline, initrd)?;
@@ -118,11 +97,10 @@ pub fn create_fdt<T: DeviceInfoForFDT + Clone + Debug, M: GuestMemory>(
     device_info.map_or(Ok(()), |v| create_devices_node(&mut fdt, v))?;
 
     // End Header node.
-    append_end_node(&mut fdt)?;
+    fdt.end_node(root_node)?;
 
     // Allocate another buffer so we can format and then write fdt to guest.
-    let mut fdt_final = vec![0; FDT_MAX_SIZE];
-    finish_fdt(&mut fdt, &mut fdt_final)?;
+    let fdt_final = fdt.finish()?;
 
     // Write FDT to memory.
     let fdt_address = GuestAddress(get_fdt_addr(guest_mem));
@@ -132,322 +110,153 @@ pub fn create_fdt<T: DeviceInfoForFDT + Clone + Debug, M: GuestMemory>(
     Ok(fdt_final)
 }
 
-// Following are auxiliary functions for allocating and finishing the FDT.
-fn allocate_fdt(fdt: &mut Vec<u8>) -> Result<()> {
-    // Safe since we allocated this array with FDT_MAX_SIZE.
-    let mut fdt_ret = unsafe { fdt_create(fdt.as_mut_ptr() as *mut c_void, FDT_MAX_SIZE as c_int) };
-
-    if fdt_ret != 0 {
-        return Err(Error::CreateFDT(io::Error::last_os_error()));
-    }
-
-    // The flattened device trees created with fdt_create() contains a list of
-    // reserved memory areas. We need to call `fdt_finish_reservemap` so as to make sure that there is a
-    // terminator in the reservemap list and whatever happened to be at the
-    // start of the FDT data section would end up being interpreted as
-    // reservemap entries.
-    // Safe since we previously allocated this array.
-    fdt_ret = unsafe { fdt_finish_reservemap(fdt.as_mut_ptr() as *mut c_void) };
-    if fdt_ret != 0 {
-        return Err(Error::FinishFDTReserveMap(io::Error::last_os_error()));
-    }
-    Ok(())
-}
-
-fn finish_fdt(from_fdt: &mut Vec<u8>, to_fdt: &mut Vec<u8>) -> Result<()> {
-    // Safe since we allocated `fdt_final` and previously passed in its size.
-    let mut fdt_ret = unsafe { fdt_finish(from_fdt.as_mut_ptr() as *mut c_void) };
-    if fdt_ret != 0 {
-        return Err(Error::FinishFDTReserveMap(io::Error::last_os_error()));
-    }
-
-    // Safe because we allocated both arrays with the correct size.
-    fdt_ret = unsafe {
-        fdt_open_into(
-            from_fdt.as_mut_ptr() as *mut c_void,
-            to_fdt.as_mut_ptr() as *mut c_void,
-            FDT_MAX_SIZE as i32,
-        )
-    };
-    if fdt_ret != 0 {
-        return Err(Error::FinishFDTReserveMap(io::Error::last_os_error()));
-    }
-
-    // Safe since we allocated `to_fdt`.
-    fdt_ret = unsafe { fdt_pack(to_fdt.as_mut_ptr() as *mut c_void) };
-    if fdt_ret != 0 {
-        return Err(Error::FinishFDTReserveMap(io::Error::last_os_error()));
-    }
-    Ok(())
-}
-
-// Following are auxiliary functions for appending nodes to FDT.
-fn append_begin_node(fdt: &mut Vec<u8>, name: &str) -> Result<()> {
-    let cstr_name = CString::new(name).map_err(Error::CstringFDTTransform)?;
-
-    // Safe because we allocated fdt and converted name to a CString
-    let fdt_ret = unsafe { fdt_begin_node(fdt.as_mut_ptr() as *mut c_void, cstr_name.as_ptr()) };
-    if fdt_ret != 0 {
-        return Err(Error::AppendFDTNode(io::Error::last_os_error()));
-    }
-    Ok(())
-}
-
-fn append_end_node(fdt: &mut Vec<u8>) -> Result<()> {
-    // Safe because we allocated fdt.
-    let fdt_ret = unsafe { fdt_end_node(fdt.as_mut_ptr() as *mut c_void) };
-    if fdt_ret != 0 {
-        return Err(Error::AppendFDTNode(io::Error::last_os_error()));
-    }
-    Ok(())
-}
-
-// Following are auxiliary functions for appending property nodes to the nodes of the FDT.
-fn append_property_u32(fdt: &mut Vec<u8>, name: &str, val: u32) -> Result<()> {
-    append_property(fdt, name, &to_be32(val))
-}
-
-fn append_property_u64(fdt: &mut Vec<u8>, name: &str, val: u64) -> Result<()> {
-    append_property(fdt, name, &to_be64(val))
-}
-
-fn append_property_string(fdt: &mut Vec<u8>, name: &str, value: &str) -> Result<()> {
-    let cstr_value = CString::new(value).map_err(Error::CstringFDTTransform)?;
-    append_property_cstring(fdt, name, &cstr_value)
-}
-
-fn append_property_cstring(fdt: &mut Vec<u8>, name: &str, cstr_value: &CStr) -> Result<()> {
-    let value_bytes = cstr_value.to_bytes_with_nul();
-    let cstr_name = CString::new(name).map_err(Error::CstringFDTTransform)?;
-    // Safe because we allocated fdt, converted name and value to CStrings
-    let fdt_ret = unsafe {
-        fdt_property(
-            fdt.as_mut_ptr() as *mut c_void,
-            cstr_name.as_ptr(),
-            value_bytes.as_ptr() as *mut c_void,
-            value_bytes.len() as i32,
-        )
-    };
-    if fdt_ret != 0 {
-        return Err(Error::AppendFDTProperty(io::Error::last_os_error()));
-    }
-    Ok(())
-}
-
-fn append_property_null(fdt: &mut Vec<u8>, name: &str) -> Result<()> {
-    let cstr_name = CString::new(name).map_err(Error::CstringFDTTransform)?;
-
-    // Safe because we allocated fdt, converted name to a CString
-    let fdt_ret = unsafe {
-        fdt_property(
-            fdt.as_mut_ptr() as *mut c_void,
-            cstr_name.as_ptr(),
-            null(),
-            0,
-        )
-    };
-    if fdt_ret != 0 {
-        return Err(Error::AppendFDTProperty(io::Error::last_os_error()));
-    }
-    Ok(())
-}
-
-fn append_property(fdt: &mut Vec<u8>, name: &str, val: &[u8]) -> Result<()> {
-    let cstr_name = CString::new(name).map_err(Error::CstringFDTTransform)?;
-    let val_ptr = val.as_ptr() as *const c_void;
-
-    // Safe because we allocated fdt and converted name to a CString
-    let fdt_ret = unsafe {
-        fdt_property(
-            fdt.as_mut_ptr() as *mut c_void,
-            cstr_name.as_ptr(),
-            val_ptr,
-            val.len() as i32,
-        )
-    };
-    if fdt_ret != 0 {
-        return Err(Error::AppendFDTProperty(io::Error::last_os_error()));
-    }
-    Ok(())
-}
-
-// Auxiliary functions for writing u32/u64 numbers in big endian order.
-fn to_be32(input: u32) -> [u8; 4] {
-    u32::to_be_bytes(input)
-}
-
-fn to_be64(input: u64) -> [u8; 8] {
-    u64::to_be_bytes(input)
-}
-
-// Helper functions for generating a properly formatted byte vector using 32-bit/64-bit cells.
-fn generate_prop32(cells: &[u32]) -> Vec<u8> {
-    let mut ret: Vec<u8> = Vec::new();
-    for &e in cells {
-        ret.extend(to_be32(e).iter());
-    }
-    ret
-}
-
-fn generate_prop64(cells: &[u64]) -> Vec<u8> {
-    let mut ret: Vec<u8> = Vec::new();
-    for &e in cells {
-        ret.extend(to_be64(e).iter());
-    }
-    ret
-}
-
 // Following are the auxiliary function for creating the different nodes that we append to our FDT.
-fn create_cpu_nodes(fdt: &mut Vec<u8>, vcpu_mpidr: &Vec<u64>) -> Result<()> {
+fn create_cpu_nodes(fdt: &mut FdtWriter, vcpu_mpidr: &Vec<u64>) -> Result<()> {
     // See https://github.com/torvalds/linux/blob/master/Documentation/devicetree/bindings/arm/cpus.yaml.
-    append_begin_node(fdt, "cpus")?;
+    let cpus_node = fdt.begin_node("cpus")?;
     // As per documentation, on ARM v8 64-bit systems value should be set to 2.
-    append_property_u32(fdt, "#address-cells", 0x02)?;
-    append_property_u32(fdt, "#size-cells", 0x0)?;
+    fdt.property_u32("#address-cells", 0x02)?;
+    fdt.property_u32("#size-cells", 0x0)?;
     let num_cpus = vcpu_mpidr.len();
 
     for cpu_index in 0..num_cpus {
         let cpu_name = format!("cpu@{:x}", cpu_index);
-        append_begin_node(fdt, &cpu_name)?;
-        append_property_string(fdt, "device_type", "cpu")?;
-        append_property_string(fdt, "compatible", "arm,arm-v8")?;
+        let cpu_node = fdt.begin_node(&cpu_name)?;
+        fdt.property_string("device_type", "cpu")?;
+        fdt.property_string("compatible", "arm,arm-v8")?;
         if num_cpus > 1 {
             // This is required on armv8 64-bit. See aforementioned documentation.
-            append_property_string(fdt, "enable-method", "psci")?;
+            fdt.property_string("enable-method", "psci")?;
         }
         // Set the field to first 24 bits of the MPIDR - Multiprocessor Affinity Register.
         // See http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.ddi0488c/BABHBJCI.html.
-        append_property_u64(fdt, "reg", vcpu_mpidr[cpu_index] & 0x7FFFFF)?;
-        append_end_node(fdt)?;
+        fdt.property_u64("reg", vcpu_mpidr[cpu_index] & 0x7FFFFF)?;
+        fdt.end_node(cpu_node)?;
     }
-    append_end_node(fdt)?;
+    fdt.end_node(cpus_node)?;
     Ok(())
 }
 
-fn create_memory_node<M: GuestMemory>(fdt: &mut Vec<u8>, guest_mem: &M) -> Result<()> {
+fn create_memory_node<M: GuestMemory>(fdt: &mut FdtWriter, guest_mem: &M) -> Result<()> {
     // See https://github.com/torvalds/linux/blob/v5.9/Documentation/devicetree/booting-without-of.rst
     for region in guest_mem.iter() {
         let memory_name = format!("memory@{:x}", region.start_addr().raw_value());
-        let mem_reg_prop = generate_prop64(&[region.start_addr().raw_value(), region.len()]);
-        append_begin_node(fdt, &memory_name)?;
-        append_property_string(fdt, "device_type", "memory")?;
-        append_property(fdt, "reg", &mem_reg_prop)?;
-        append_end_node(fdt)?;
+        let mem_reg_prop = &[region.start_addr().raw_value(), region.len()];
+        let memory_node = fdt.begin_node(&memory_name)?;
+        fdt.property_string("device_type", "memory")?;
+        fdt.property_array_u64("reg", mem_reg_prop)?;
+        fdt.end_node(memory_node)?;
     }
     Ok(())
 }
 
 fn create_chosen_node(
-    fdt: &mut Vec<u8>,
+    fdt: &mut FdtWriter,
     cmdline: &str,
     initrd: &Option<InitrdConfig>,
 ) -> Result<()> {
-    append_begin_node(fdt, "chosen")?;
-    append_property_string(fdt, "bootargs", cmdline)?;
+    let chosen_node = fdt.begin_node("chosen")?;
+    fdt.property_string("bootargs", cmdline)?;
 
     if let Some(initrd_config) = initrd {
-        append_property_u64(
-            fdt,
+        fdt.property_u64(
             "linux,initrd-start",
             initrd_config.address.raw_value() as u64,
         )?;
-        append_property_u64(
-            fdt,
+        fdt.property_u64(
             "linux,initrd-end",
             initrd_config.address.raw_value() + initrd_config.size as u64,
         )?;
     }
 
-    append_end_node(fdt)?;
+    fdt.end_node(chosen_node)?;
 
     Ok(())
 }
 
-fn append_its_common_property(fdt: &mut Vec<u8>, registers_prop: &[u8]) -> Result<()> {
-    append_property_string(fdt, "compatible", "arm,gic-v3-its")?;
-    append_property_null(fdt, "msi-controller")?;
-    append_property(fdt, "reg", registers_prop)?;
+fn append_its_common_property(fdt: &mut FdtWriter, registers_prop: &[u64]) -> Result<()> {
+    fdt.property_string("compatible", "arm,gic-v3-its")?;
+    fdt.property_null("msi-controller")?;
+    fdt.property_array_u64("reg", registers_prop)?;
     Ok(())
 }
 
 fn create_its_node(
-    fdt: &mut Vec<u8>,
+    fdt: &mut FdtWriter,
     gic_device: &Box<dyn GICDevice>,
     its_type: ItsType,
 ) -> Result<()> {
     let reg = gic_device.get_its_reg_range(&its_type);
     if let Some(registers) = reg {
-        let registers_prop = generate_prop64(&registers);
-
         // There are two types of its, pci_msi_its and platform_msi_its.
         // If this is pci_msi_its, the fdt node of its is required to have no
         // #msi-cells attribute. If this is platform_msi_its, the #msi-cells
         // attribute of its fdt node is required, and the value is 1.
         match its_type {
             PlatformMsiIts => {
-                append_begin_node(fdt, "gic-platform-its")?;
-                append_its_common_property(fdt, &registers_prop)?;
-                append_property_u32(fdt, "phandle", GIC_PLATFORM_MSI_ITS_PHANDLE)?;
-                append_property_u32(fdt, "#msi-cells", GIC_PLATFORM_MSI_ITS_CELLS_SIZE)?;
+                let its_node = fdt.begin_node("gic-platform-its")?;
+                append_its_common_property(fdt, &registers)?;
+                fdt.property_u32("phandle", GIC_PLATFORM_MSI_ITS_PHANDLE)?;
+                fdt.property_u32("#msi-cells", GIC_PLATFORM_MSI_ITS_CELLS_SIZE)?;
+                fdt.end_node(its_node)?;
             }
             PciMsiIts => {
-                append_begin_node(fdt, "gic-pci-its")?;
-                append_its_common_property(fdt, &registers_prop)?;
-                append_property_u32(fdt, "phandle", GIC_PCI_MSI_ITS_PHANDLE)?;
+                let its_node = fdt.begin_node("gic-pci-its")?;
+                append_its_common_property(fdt, &registers)?;
+                fdt.property_u32("phandle", GIC_PCI_MSI_ITS_PHANDLE)?;
+                fdt.end_node(its_node)?;
             }
         }
-        append_end_node(fdt)?;
     }
     Ok(())
 }
 
-fn create_gic_node(fdt: &mut Vec<u8>, gic_device: &Box<dyn GICDevice>) -> Result<()> {
-    let gic_reg_prop = generate_prop64(gic_device.device_properties());
+fn create_gic_node(fdt: &mut FdtWriter, gic_device: &Box<dyn GICDevice>) -> Result<()> {
+    let gic_reg_prop = gic_device.device_properties();
 
-    append_begin_node(fdt, "intc")?;
-    append_property_string(fdt, "compatible", gic_device.fdt_compatibility())?;
-    append_property_null(fdt, "interrupt-controller")?;
+    let intc_node = fdt.begin_node("intc")?;
+    fdt.property_string("compatible", gic_device.fdt_compatibility())?;
+    fdt.property_null("interrupt-controller")?;
     // "interrupt-cells" field specifies the number of cells needed to encode an
     // interrupt source. The type shall be a <u32> and the value shall be 3 if no PPI affinity description
     // is required.
-    append_property_u32(fdt, "#interrupt-cells", 3)?;
-    append_property(fdt, "reg", &gic_reg_prop)?;
-    append_property_u32(fdt, "phandle", GIC_PHANDLE)?;
-    append_property_u32(fdt, "#address-cells", 2)?;
-    append_property_u32(fdt, "#size-cells", 2)?;
-    append_property_null(fdt, "ranges")?;
-    let gic_intr = [
+    fdt.property_u32("#interrupt-cells", 3)?;
+    fdt.property_array_u64("reg", gic_reg_prop)?;
+    fdt.property_u32("phandle", GIC_PHANDLE)?;
+    fdt.property_u32("#address-cells", 2)?;
+    fdt.property_u32("#size-cells", 2)?;
+    fdt.property_null("ranges")?;
+    let gic_intr_prop = &[
         GIC_FDT_IRQ_TYPE_PPI,
         gic_device.fdt_maint_irq(),
         IRQ_TYPE_LEVEL_HI,
     ];
-    let gic_intr_prop = generate_prop32(&gic_intr);
 
-    append_property(fdt, "interrupts", &gic_intr_prop)?;
+    fdt.property_array_u32("interrupts", gic_intr_prop)?;
     create_its_node(fdt, gic_device, PlatformMsiIts)?;
     create_its_node(fdt, gic_device, PciMsiIts)?;
-    append_end_node(fdt)?;
+    fdt.end_node(intc_node)?;
 
     Ok(())
 }
 
-fn create_clock_node(fdt: &mut Vec<u8>) -> Result<()> {
+fn create_clock_node(fdt: &mut FdtWriter) -> Result<()> {
     // The Advanced Peripheral Bus (APB) is part of the Advanced Microcontroller Bus Architecture
     // (AMBA) protocol family. It defines a low-cost interface that is optimized for minimal power
     // consumption and reduced interface complexity.
     // PCLK is the clock source and this node defines exactly the clock for the APB.
-    append_begin_node(fdt, "apb-pclk")?;
-    append_property_string(fdt, "compatible", "fixed-clock")?;
-    append_property_u32(fdt, "#clock-cells", 0x0)?;
-    append_property_u32(fdt, "clock-frequency", 24000000)?;
-    append_property_string(fdt, "clock-output-names", "clk24mhz")?;
-    append_property_u32(fdt, "phandle", CLOCK_PHANDLE)?;
-    append_end_node(fdt)?;
+    let clock_node = fdt.begin_node("apb-pclk")?;
+    fdt.property_string("compatible", "fixed-clock")?;
+    fdt.property_u32("#clock-cells", 0x0)?;
+    fdt.property_u32("clock-frequency", 24000000)?;
+    fdt.property_string("clock-output-names", "clk24mhz")?;
+    fdt.property_u32("phandle", CLOCK_PHANDLE)?;
+    fdt.end_node(clock_node)?;
 
     Ok(())
 }
 
-fn create_timer_node(fdt: &mut Vec<u8>) -> Result<()> {
+fn create_timer_node(fdt: &mut FdtWriter) -> Result<()> {
     // See
     // https://github.com/torvalds/linux/blob/master/Documentation/devicetree/bindings/interrupt-controller/arch_timer.txt
     // These are fixed interrupt numbers for the timer device.
@@ -460,89 +269,88 @@ fn create_timer_node(fdt: &mut Vec<u8>) -> Result<()> {
         timer_reg_cells.push(irq);
         timer_reg_cells.push(IRQ_TYPE_LEVEL_HI);
     }
-    let timer_reg_prop = generate_prop32(timer_reg_cells.as_slice());
 
-    append_begin_node(fdt, "timer")?;
-    append_property_string(fdt, "compatible", compatible)?;
-    append_property_null(fdt, "always-on")?;
-    append_property(fdt, "interrupts", &timer_reg_prop)?;
-    append_end_node(fdt)?;
+    let timer_node = fdt.begin_node("timer")?;
+    fdt.property_string("compatible", compatible)?;
+    fdt.property_null("always-on")?;
+    fdt.property_array_u32("interrupts", &timer_reg_cells)?;
+    fdt.end_node(timer_node)?;
 
     Ok(())
 }
 
-fn create_psci_node(fdt: &mut Vec<u8>) -> Result<()> {
+fn create_psci_node(fdt: &mut FdtWriter) -> Result<()> {
     let compatible = "arm,psci-0.2";
-    append_begin_node(fdt, "psci")?;
-    append_property_string(fdt, "compatible", compatible)?;
+    let psci_node = fdt.begin_node("psci")?;
+    fdt.property_string("compatible", compatible)?;
     // Two methods available: hvc and smc.
     // As per documentation, PSCI calls between a guest and hypervisor may use the HVC conduit instead of SMC.
     // So, since we are using kvm, we need to use hvc.
-    append_property_string(fdt, "method", "hvc")?;
-    append_end_node(fdt)?;
+    fdt.property_string("method", "hvc")?;
+    fdt.end_node(psci_node)?;
 
     Ok(())
 }
 
 fn create_virtio_node<T: DeviceInfoForFDT + Clone + Debug>(
-    fdt: &mut Vec<u8>,
+    fdt: &mut FdtWriter,
     dev_info: &T,
 ) -> Result<()> {
-    let device_reg_prop = generate_prop64(&[dev_info.addr(), dev_info.length()]);
+    let device_reg_prop = &[dev_info.addr(), dev_info.length()];
     let irq_number = dev_info.irq().map_err(|_| Error::InvalidArguments)?;
-    let irq_property = generate_prop32(&[GIC_FDT_IRQ_TYPE_SPI, irq_number, IRQ_TYPE_EDGE_RISING]);
+    let irq_property = &[GIC_FDT_IRQ_TYPE_SPI, irq_number, IRQ_TYPE_EDGE_RISING];
 
-    append_begin_node(fdt, &format!("virtio_mmio@{:x}", dev_info.addr()))?;
-    append_property_string(fdt, "compatible", "virtio,mmio")?;
-    append_property(fdt, "reg", &device_reg_prop)?;
-    append_property(fdt, "interrupts", &irq_property)?;
-    append_property_u32(fdt, "interrupt-parent", GIC_PHANDLE)?;
-    append_end_node(fdt)?;
+    let virtio_mmio_node = fdt.begin_node(&format!("virtio_mmio@{:x}", dev_info.addr()))?;
+    fdt.property_string("compatible", "virtio,mmio")?;
+    fdt.property_array_u64("reg", device_reg_prop)?;
+    fdt.property_array_u32("interrupts", irq_property)?;
+    fdt.property_u32("interrupt-parent", GIC_PHANDLE)?;
+    fdt.end_node(virtio_mmio_node)?;
 
     Ok(())
 }
 
 fn create_serial_node<T: DeviceInfoForFDT + Clone + Debug>(
-    fdt: &mut Vec<u8>,
+    fdt: &mut FdtWriter,
     dev_info: &T,
 ) -> Result<()> {
-    let serial_reg_prop = generate_prop64(&[dev_info.addr(), dev_info.length()]);
+    let serial_reg_prop = &[dev_info.addr(), dev_info.length()];
     let irq_number = dev_info.irq().map_err(|_| Error::InvalidArguments)?;
-    let irq_property = generate_prop32(&[GIC_FDT_IRQ_TYPE_SPI, irq_number, IRQ_TYPE_EDGE_RISING]);
+    let irq_property = &[GIC_FDT_IRQ_TYPE_SPI, irq_number, IRQ_TYPE_EDGE_RISING];
 
-    append_begin_node(fdt, &format!("uart@{:x}", dev_info.addr()))?;
-    append_property_string(fdt, "compatible", "ns16550a")?;
-    append_property(fdt, "reg", &serial_reg_prop)?;
-    append_property_u32(fdt, "clocks", CLOCK_PHANDLE)?;
-    append_property_string(fdt, "clock-names", "apb_pclk")?;
-    append_property(fdt, "interrupts", &irq_property)?;
-    append_end_node(fdt)?;
+    let uart_node = fdt.begin_node(&format!("uart@{:x}", dev_info.addr()))?;
+    fdt.property_string("compatible", "ns16550a")?;
+    fdt.property_array_u64("reg", serial_reg_prop)?;
+    fdt.property_u32("clocks", CLOCK_PHANDLE)?;
+    fdt.property_string("clock-names", "apb_pclk")?;
+    fdt.property_array_u32("interrupts", irq_property)?;
+    fdt.end_node(uart_node)?;
 
     Ok(())
 }
 
 fn create_rtc_node<T: DeviceInfoForFDT + Clone + Debug>(
-    fdt: &mut Vec<u8>,
+    fdt: &mut FdtWriter,
     dev_info: &T,
 ) -> Result<()> {
     let compatible = b"arm,pl031\0arm,primecell\0";
-    let rtc_reg_prop = generate_prop64(&[dev_info.addr(), dev_info.length()]);
+    let rtc_reg_prop = &[dev_info.addr(), dev_info.length()];
     let irq_number = dev_info.irq().map_err(|_| Error::InvalidArguments)?;
-    let irq_property = generate_prop32(&[GIC_FDT_IRQ_TYPE_SPI, irq_number, IRQ_TYPE_LEVEL_HI]);
+    let irq_property = &[GIC_FDT_IRQ_TYPE_SPI, irq_number, IRQ_TYPE_LEVEL_HI];
 
-    append_begin_node(fdt, &format!("rtc@{:x}", dev_info.addr()))?;
-    append_property(fdt, "compatible", compatible)?;
-    append_property(fdt, "reg", &rtc_reg_prop)?;
-    append_property(fdt, "interrupts", &irq_property)?;
-    append_property_u32(fdt, "clocks", CLOCK_PHANDLE)?;
-    append_property_string(fdt, "clock-names", "apb_pclk")?;
-    append_end_node(fdt)?;
+    let rtc_node = fdt.begin_node(&format!("rtc@{:x}", dev_info.addr()))?;
+    fdt.property("compatible", compatible)?;
+    fdt.property_array_u64("reg", rtc_reg_prop)?;
+    fdt.property_array_u32("interrupts", irq_property)?;
+    fdt.property_u32("clocks", CLOCK_PHANDLE)?;
+    fdt.property_string("clock-names", "apb_pclk")?;
+    fdt.end_node(rtc_node)?;
 
     Ok(())
 }
 
 fn create_devices_node<T: DeviceInfoForFDT + Clone + Debug>(
-    fdt: &mut Vec<u8>,
+    fdt: &mut FdtWriter,
     dev_info: &HashMap<(DeviceType, String), T>,
 ) -> Result<()> {
     // Serial devices need to be registered in order

--- a/crates/dbs-boot/src/aarch64/mod.rs
+++ b/crates/dbs-boot/src/aarch64/mod.rs
@@ -3,8 +3,7 @@
 
 //! VM boot related constants and utilities for `aarch64` architecture.
 
-use std::ffi::NulError;
-use std::io;
+use vm_fdt::Error as VmFdtError;
 use vm_memory::GuestMemoryError;
 /// Magic addresses externally used to lay out aarch64 VMs.
 pub mod layout;
@@ -12,21 +11,19 @@ pub mod layout;
 /// FDT is used to inform the guest kernel of device tree information.
 pub mod fdt;
 
-/// Errors thrown while configuring aarch64 system.
+/// Errors thrown while configuring the Flattened Device Tree for aarch64.
 #[derive(Debug)]
 pub enum Error {
-    /// Failed to append node to the FDT.
-    AppendFDTNode(io::Error),
-    /// Failed to append a property to the FDT.
-    AppendFDTProperty(io::Error),
-    /// Syscall for creating FDT failed.
-    CreateFDT(io::Error),
-    /// Failed to obtain a C style string.
-    CstringFDTTransform(NulError),
-    /// Failure in calling syscall for terminating this FDT.
-    FinishFDTReserveMap(io::Error),
+    /// Failure in creating FDT
+    CreateFdt(VmFdtError),
     /// Failure in writing FDT in memory.
     WriteFDTToMemory(GuestMemoryError),
     /// Invalid arguments
     InvalidArguments,
+}
+
+impl From<VmFdtError> for Error {
+    fn from(e: VmFdtError) -> Self {
+        Error::CreateFdt(e)
+    }
 }


### PR DESCRIPTION
This modification replaces libfdt with vm-fdt crate, which mainly involves the following 3 aspects:
1. Replace the original interface of libfdt with the related interface of vm-fdt crate.
3. Encapsulate the error of the vm-fdt crate to replace the original libfdt error.
4. The fdt test case is adapted to the vm-fdt crate.