### PR TITLE
dbs-address-space: refactor README and other files to make it more readable

### DIFF
--- a/crates/dbs-address-space/CHANGELOG.md
+++ b/crates/dbs-address-space/CHANGELOG.md
@@ -1,0 +1,5 @@
+# v0.1.0
+
+## Added
+
+- This is the initial release for dbs-address-space

--- a/crates/dbs-address-space/README.md
+++ b/crates/dbs-address-space/README.md
@@ -2,42 +2,77 @@
 
 ## Design
 
-The dbs-address-space crate is an address space manager for virtual machines, which manages memory and MMIO resources resident in the guest physical address space.
+The `dbs-address-space` crate is an address space manager for virtual machines, which manages memory and MMIO resources resident in the guest physical address space.
 
+Main components are:
+- *AddressSpaceRegion*: Struct to maintain configuration information about a guest address region.
 ```rust
+#[derive(Debug, Clone)]
 pub struct AddressSpaceRegion {
     /// Type of address space regions.
-    ty: AddressSpaceRegionType,
+    pub ty: AddressSpaceRegionType,
     /// Base address of the region in virtual machine's physical address space.
-    base: GuestAddress,
+    pub base: GuestAddress,
     /// Size of the address space region.
-    size: GuestUsize,
+    pub size: GuestUsize,
+    /// Host NUMA node ids assigned to this region.
+    pub host_numa_node_id: Option<u32>,
+
     /// File/offset tuple to back the memory allocation.
     file_offset: Option<FileOffset>,
     /// Mmap permission flags.
     perm_flags: i32,
-    /// Hugepage madvise hint, this needs 'advise' or 'always' policy in host shmem config
+    /// Hugepage madvise hint.
+    ///
+    /// It needs 'advise' or 'always' policy in host shmem config.
     is_hugepage: bool,
-    /// hotplug hint, for hotplug_size region, should set 'true'
+    /// Hotplug hint.
     is_hotplug: bool,
-    /// anonymous memory, for add MADV_DONTFORK, should set 'true'
+    /// Anonymous memory hint.
+    ///
+    /// It should be true for regions with the MADV_DONTFORK flag enabled.
     is_anon: bool,
-    /// host numa node id for this address space region to be allocated from
-    host_numa_node_id: Option<u32>,
 }
 ```
-AddressSpaceRegion is used to describe information about a region in the address space of guest memory, including type, base address, resgion size, and other corresponding arrtibutes.
-
+- *AddressSpaceBase*: Base implementation to manage guest physical address space, without support of region hotplug.
+```rust
+#[derive(Clone)]
+pub struct AddressSpaceBase {
+    regions: Vec<Arc<AddressSpaceRegion>>,
+    layout: AddressSpaceLayout,
+}
+```
+- *AddressSpaceBase*: An address space implementation with region hotplug capability.
+```rust
+/// The `AddressSpace` is a wrapper over [AddressSpaceBase] to support hotplug of
+/// address space regions.
+#[derive(Clone)]
+pub struct AddressSpace {
+    state: Arc<ArcSwap<AddressSpaceBase>>,
+}
+```
 
 ## Usage
 ```rust
+// 1. create several memory regions
 let reg = Arc::new(
-    AddressSpaceRegion::create_device_region(GuestAddress(0x100000), 0x1000).unwrap(),
+    AddressSpaceRegion::create_default_memory_region(
+        GuestAddress(0x100000),
+        0x100000,
+        None,
+        "shmem",
+        "",
+        false,
+        false,
+        false,
+    )
+    .unwrap()
 );
 let regions = vec![reg];
-let boundary = AddressSpaceBoundary::new(GUEST_PHYS_END, GUEST_MEM_START, GUEST_MEM_END);
-let address_space = AddressSpaceInternal::from_regions(regions, boundary.clone());
-assert_eq!(address_space.get_boundary(), boundary);
+// 2. create layout (depending on archs)
+let layout = AddressSpaceLayout::new(GUEST_PHYS_END, GUEST_MEM_START, GUEST_MEM_END);
+// 3. create address space from regions and layout
+let address_space = AddressSpace::from_regions(regions, layout.clone());
 ```
 
 ## License


### PR DESCRIPTION
In order to make this crate more readable, we refactor several files,  including:
1. address-space.rs
we changed name of some variables to support cargo doc check and make it more readable.
2. README.md
we refactor it to support latest version of this crate.
3. CHANGELOG.md
we add a new file to record change log.