### PR TITLE
dbs-boot: modify the version of dbs-boot to v0.2.0

### DIFF
--- a/crates/dbs-boot/Cargo.toml
+++ b/crates/dbs-boot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dbs-boot"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Alibaba Dragonball Team"]
 description = "Traits and structs for booting sandbox"
 license = "Apache-2.0"


### PR DESCRIPTION
Modify the version number in the Cargo.toml file to v0.2.0.