### PR TITLE
upcall: Fix failed UT and add remove mmio device support

### DIFF
--- a/crates/dbs-upcall/src/lib.rs
+++ b/crates/dbs-upcall/src/lib.rs
@@ -694,7 +694,7 @@ mod tests {
             .is_ok());
         assert!(info.lock().unwrap().result_callback.is_some());
 
-        let mut read_buffer = vec![0; 10];
+        let mut read_buffer = vec![0; 8];
         assert!(inner_stream.read_exact(&mut read_buffer).is_ok());
 
         let writer_buffer = String::from("TEST RESP").into_bytes();
@@ -726,7 +726,7 @@ mod tests {
             .is_ok());
         assert!(info.lock().unwrap().result_callback.is_none());
 
-        let mut read_buffer = vec![0; 10];
+        let mut read_buffer = vec![0; 8];
         assert!(inner_stream.read_exact(&mut read_buffer).is_ok());
 
         let writer_buffer = String::from("TEST RESP").into_bytes();

--- a/crates/dbs-upcall/src/lib.rs
+++ b/crates/dbs-upcall/src/lib.rs
@@ -23,7 +23,7 @@ use log::{error, info, trace, warn};
 use timerfd::{SetTimeFlags, TimerFd, TimerState};
 
 pub use crate::dev_mgr_service::{
-    AddMmioDevRequest, CpuDevRequest, DevMgrRequest, DevMgrResponse, DevMgrService,
+    CpuDevRequest, DevMgrRequest, DevMgrResponse, DevMgrService, MmioDevRequest,
 };
 
 const SERVER_PORT: u32 = 0xDB;


### PR DESCRIPTION
We add support for removing mmio device in this PR.

read_buffer is initialized with wrong size which will cause `read_exact`
returns an error in the UT.
We fix the problem in this commit.

Signed-off-by: Chao Wu <chaowu@linux.alibaba.com>
