### PR TITLE
ci: add static check for aarch64 target

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -11,17 +11,23 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    continue-on-error: true
+    strategy:
+      matrix:
+        arch: [x86_64, aarch64]
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: stable
+          target: ${{ matrix.arch }}-unknown-linux-gnu
           override: true
       - uses: actions-rs/cargo@v1
         with:
+          use-cross: true
           command: check
-          args: --all-features
+          args: --all-features --target ${{ matrix.arch }}-unknown-linux-gnu
 
   fmt:
     name: Rustfmt
@@ -42,17 +48,23 @@ jobs:
   clippy:
     name: Clippy
     runs-on: ubuntu-latest
+    continue-on-error: true
+    strategy:
+      matrix:
+        arch: [x86_64, aarch64]
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
           components: clippy
+          target: ${{ matrix.arch }}-unknown-linux-gnu
           override: true
       - uses: actions-rs/clippy-check@v1
         with:
+          use-cross: true
           token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-features --all-targets -- -D warnings
+          args: --all-features --all-targets --target ${{ matrix.arch }}-unknown-linux-gnu -- -D warnings
           name: Clippy Output
 
   deny:

--- a/crates/dbs-arch/src/aarch64/gic/gicv2.rs
+++ b/crates/dbs-arch/src/aarch64/gic/gicv2.rs
@@ -74,22 +74,22 @@ impl GICDevice for GICv2 {
 
     fn create_device(fd: DeviceFd, vcpu_count: u64) -> Box<dyn GICDevice> {
         Box::new(GICv2 {
-            fd: fd,
+            fd,
             properties: [
                 GICv2::get_dist_addr(),
                 GICv2::get_dist_size(),
                 GICv2::get_cpu_addr(),
                 GICv2::get_cpu_size(),
             ],
-            vcpu_count: vcpu_count,
+            vcpu_count,
         })
     }
 
-    fn init_device_attributes(gic_device: &Box<dyn GICDevice>) -> Result<()> {
+    fn init_device_attributes(gic_device: &dyn GICDevice) -> Result<()> {
         /* Setting up the distributor attribute.
         We are placing the GIC below 1GB so we need to substract the size of the distributor. */
         Self::set_device_attribute(
-            &gic_device.device_fd(),
+            gic_device.device_fd(),
             kvm_bindings::KVM_DEV_ARM_VGIC_GRP_ADDR,
             u64::from(kvm_bindings::KVM_VGIC_V2_ADDR_TYPE_DIST),
             &GICv2::get_dist_addr() as *const u64 as u64,
@@ -98,7 +98,7 @@ impl GICDevice for GICv2 {
 
         /* Setting up the CPU attribute. */
         Self::set_device_attribute(
-            &gic_device.device_fd(),
+            gic_device.device_fd(),
             kvm_bindings::KVM_DEV_ARM_VGIC_GRP_ADDR,
             u64::from(kvm_bindings::KVM_VGIC_V2_ADDR_TYPE_CPU),
             &GICv2::get_cpu_addr() as *const u64 as u64,

--- a/crates/dbs-arch/src/aarch64/gic/mod.rs
+++ b/crates/dbs-arch/src/aarch64/gic/mod.rs
@@ -102,7 +102,7 @@ pub trait GICDevice: Send {
         Self: Sized;
 
     /// Setup the device-specific attributes
-    fn init_device_attributes(gic_device: &Box<dyn GICDevice>) -> Result<()>
+    fn init_device_attributes(gic_device: &dyn GICDevice) -> Result<()>
     where
         Self: Sized;
 
@@ -132,10 +132,10 @@ pub trait GICDevice: Send {
         Self: Sized,
     {
         let attr = kvm_bindings::kvm_device_attr {
-            group: group,
-            attr: attr,
-            addr: addr,
-            flags: flags,
+            group,
+            attr,
+            addr,
+            flags,
         };
         fd.set_device_attr(&attr)
             .map_err(Error::SetDeviceAttribute)?;
@@ -144,7 +144,7 @@ pub trait GICDevice: Send {
     }
 
     /// Finalize the setup of a GIC device
-    fn finalize_device(gic_device: &Box<dyn GICDevice>) -> Result<()>
+    fn finalize_device(gic_device: &dyn GICDevice) -> Result<()>
     where
         Self: Sized,
     {
@@ -175,6 +175,7 @@ pub trait GICDevice: Send {
         Ok(())
     }
 
+    #[allow(clippy::new_ret_no_self)]
     /// Method to initialize the GIC device
     fn new(vm: &VmFd, vcpu_count: u64) -> Result<Box<dyn GICDevice>>
     where
@@ -186,9 +187,9 @@ pub trait GICDevice: Send {
 
         device.attach_its(vm)?;
 
-        Self::init_device_attributes(&device)?;
+        Self::init_device_attributes(device.as_ref())?;
 
-        Self::finalize_device(&device)?;
+        Self::finalize_device(device.as_ref())?;
 
         Ok(device)
     }

--- a/crates/dbs-arch/src/aarch64/mod.rs
+++ b/crates/dbs-arch/src/aarch64/mod.rs
@@ -95,7 +95,7 @@ impl DeviceInfoForFDT for MMIODeviceInfo {
             return Err(Error::MMIODeviceInfoError);
         }
         let irq = self.irqs[0];
-        if irq < gic::IRQ_BASE || irq > gic::IRQ_MAX {
+        if !(gic::IRQ_BASE..=gic::IRQ_MAX).contains(&irq) {
             return Err(Error::MMIODeviceInfoError);
         }
 

--- a/crates/dbs-boot/src/aarch64/mod.rs
+++ b/crates/dbs-boot/src/aarch64/mod.rs
@@ -55,9 +55,9 @@ pub fn initrd_load_addr<M: GuestMemory>(guest_mem: &M, initrd_size: u64) -> supe
     match GuestAddress(get_fdt_addr(guest_mem)).checked_sub(round_to_pagesize(initrd_size) as u64) {
         Some(offset) => {
             if guest_mem.address_in_range(offset) {
-                return Ok(offset.raw_value());
+                Ok(offset.raw_value())
             } else {
-                return Err(Error::InitrdAddress);
+                Err(Error::InitrdAddress)
             }
         }
         None => Err(Error::InitrdAddress),

--- a/crates/dbs-interrupt/src/manager.rs
+++ b/crates/dbs-interrupt/src/manager.rs
@@ -384,14 +384,13 @@ impl<T: InterruptManager> DeviceInterruptManager<T> {
     pub fn set_msi_device_id(&mut self, index: u32) -> Result<()> {
         if (index as usize) < self.msi_config.len() {
             if let InterruptSourceConfig::MsiIrq(ref mut msi) = self.msi_config[index as usize] {
-                msi.device_id = match self.device_id {
+                msi.device_id = self.device_id.map(|dev_id| {
                     // An pci device attach to ITS will have a new device id which is use for msi
                     // irq routing.  It is calculated according to kernel function PCI_DEVID(),
                     // new_dev_id = (bus << 8) | devfn. In addition, devfn = device_id << 3,
                     // according to pci-host-ecam-generic's spec, and we implement bus = 0.
-                    Some(dev_id) => Some(dev_id << MSI_DEVICE_ID_SHIFT),
-                    None => None,
-                };
+                    dev_id << MSI_DEVICE_ID_SHIFT
+                });
                 return Ok(());
             }
         }


### PR DESCRIPTION
Added `cargo check` for aarch64.
Added `cargo clippy` for aarch64.

Signed-off-by: wllenyj <wllenyj@linux.alibaba.com>