### PR TITLE
dbs-legacy-devices: fix clippy warning for rtc device.

### DIFF
--- a/crates/dbs-legacy-devices/src/rtc_pl031.rs
+++ b/crates/dbs-legacy-devices/src/rtc_pl031.rs
@@ -40,6 +40,12 @@ pub struct RTCDevice {
     pub rtc: Rtc<RTCDeviceMetrics>,
 }
 
+impl Default for RTCDevice {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl RTCDevice {
     pub fn new() -> Self {
         let metrics = RTCDeviceMetrics::default();


### PR DESCRIPTION
Signed-off-by: wllenyj <wllenyj@linux.alibaba.com>