### PR TITLE
upcall: fix ut hang problem

### DIFF
--- a/crates/dbs-upcall/src/dev_mgr_service.rs
+++ b/crates/dbs-upcall/src/dev_mgr_service.rs
@@ -478,9 +478,9 @@ mod tests {
         let dev_mgr_service = DevMgrService {};
 
         assert!(dev_mgr_service.connection_start(&mut inner_stream).is_ok());
-        let mut reader_buf = [0; 2];
+        let mut reader_buf = [0; 1];
         outer_stream.read_exact(&mut reader_buf).unwrap();
-        assert_eq!(reader_buf, [b'd', 0]);
+        assert_eq!(reader_buf, [b'd']);
     }
 
     #[test]


### PR DESCRIPTION
We use `read_exact` to read from vsock stream, but the buf size is not
compatible with the message size in the stream, which causes the failure
in UT.

This PR is to fix the problem

Signed-off-by: Chao Wu <chaowu@linux.alibaba.com>