### PR TITLE
cpuid: add hygon cpu support

### DIFF
--- a/crates/dbs-arch/src/x86_64/cpuid/common.rs
+++ b/crates/dbs-arch/src/x86_64/cpuid/common.rs
@@ -7,6 +7,7 @@ use super::cpu_leaf::*;
 
 pub(crate) const VENDOR_ID_INTEL: &[u8; 12] = b"GenuineIntel";
 pub(crate) const VENDOR_ID_AMD: &[u8; 12] = b"AuthenticAMD";
+pub(crate) const VENDOR_ID_HYGON: &[u8; 12] = b"HygonGenuine";
 
 #[derive(Clone, Debug)]
 pub enum Error {

--- a/crates/dbs-arch/src/x86_64/cpuid/mod.rs
+++ b/crates/dbs-arch/src/x86_64/cpuid/mod.rs
@@ -53,6 +53,9 @@ pub fn process_cpuid(kvm_cpuid: &mut CpuId, vm_spec: &VmSpec) -> Result<(), Erro
         self::common::VENDOR_ID_AMD => {
             self::transformer::amd::AmdCpuidTransformer::new().process_cpuid(kvm_cpuid, vm_spec)
         }
+        self::common::VENDOR_ID_HYGON => {
+            self::transformer::amd::AmdCpuidTransformer::new().process_cpuid(kvm_cpuid, vm_spec)
+        }
         _ => Err(Error::CpuNotSupported),
     }
 }


### PR DESCRIPTION
We need to add vendor_id support for hygon AMD cpu.

Signed-off-by: Chao Wu <chaowu@linux.alibaba.com>