### PR TITLE
Fix clippy warnings.

### DIFF
--- a/crates/dbs-address-space/src/numa.rs
+++ b/crates/dbs-address-space/src/numa.rs
@@ -20,7 +20,7 @@ pub struct NumaIdTable {
 }
 
 /// Record numa node memory information.
-#[derive(Debug, Default, Clone, Copy, PartialEq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub struct NumaNodeInfo {
     /// Base address of the region in guest physical address space.
     pub base: GuestAddress,
@@ -29,7 +29,7 @@ pub struct NumaNodeInfo {
 }
 
 /// Record all region's info of a numa node.
-#[derive(Debug, Default, Clone, PartialEq)]
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct NumaNode {
     region_infos: Vec<NumaNodeInfo>,
     vcpu_ids: Vec<u32>,

--- a/crates/dbs-allocator/src/interval_tree.rs
+++ b/crates/dbs-allocator/src/interval_tree.rs
@@ -245,7 +245,7 @@ impl<T> From<NodeState<T>> for Option<T> {
 }
 
 /// Internal tree node to implement interval tree.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 struct InnerNode<T> {
     /// Interval handled by this node.
     key: Range,
@@ -275,7 +275,7 @@ impl<T> InnerNode<T> {
 }
 
 /// Newtype for interval tree nodes.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 struct Node<T>(Box<InnerNode<T>>);
 
 impl<T> Node<T> {
@@ -578,7 +578,7 @@ fn max_key<T>(node: &Option<Node<T>>) -> u64 {
 }
 
 /// An interval tree implementation specialized for VMM resource management.
-#[derive(Debug, Default, PartialEq)]
+#[derive(Debug, Default, PartialEq, Eq)]
 pub struct IntervalTree<T> {
     root: Option<Node<T>>,
 }

--- a/crates/dbs-allocator/src/lib.rs
+++ b/crates/dbs-allocator/src/lib.rs
@@ -15,7 +15,7 @@ pub mod interval_tree;
 pub use interval_tree::{IntervalTree, NodeState, Range};
 
 /// Error codes for resource allocation operations.
-#[derive(thiserror::Error, Debug, PartialEq)]
+#[derive(thiserror::Error, Debug, Eq, PartialEq)]
 pub enum Error {
     /// Invalid boundary for resource allocation.
     #[error("invalid boundary constraint: min ({0}), max ({1})")]
@@ -26,7 +26,7 @@ pub enum Error {
 pub type Result<T> = std::result::Result<T, Error>;
 
 /// Resource allocation policies.
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum AllocPolicy {
     /// Default resource allocation policy.
     Default,

--- a/crates/dbs-arch/src/aarch64/mod.rs
+++ b/crates/dbs-arch/src/aarch64/mod.rs
@@ -56,7 +56,7 @@ pub trait DeviceInfoForFDT {
 }
 
 /// MMIO device info used for FDT generating.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MMIODeviceInfo {
     /// MMIO address base
     pub base: u64,

--- a/crates/dbs-arch/src/x86_64/cpuid/brand_string.rs
+++ b/crates/dbs-arch/src/x86_64/cpuid/brand_string.rs
@@ -7,7 +7,7 @@ use std::slice;
 
 use crate::cpuid::common::{VENDOR_ID_AMD, VENDOR_ID_INTEL};
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, Eq, PartialEq, Clone)]
 pub enum Error {
     NotSupported,
     Overflow(String),

--- a/crates/dbs-arch/src/x86_64/cpuid/transformer/mod.rs
+++ b/crates/dbs-arch/src/x86_64/cpuid/transformer/mod.rs
@@ -11,7 +11,7 @@ pub mod common;
 pub mod intel;
 
 /// Enum indicating vpmu feature level
-#[derive(Debug, PartialEq, Copy, Clone)]
+#[derive(Debug, Eq, PartialEq, Copy, Clone)]
 pub enum VpmuFeatureLevel {
     /// Disabled means vpmu feature is off (by default)
     Disabled,

--- a/crates/dbs-boot/src/x86_64/mod.rs
+++ b/crates/dbs-boot/src/x86_64/mod.rs
@@ -43,7 +43,7 @@ pub struct BootParamsWrapper(pub bootparam::boot_params);
 unsafe impl ByteValued for BootParamsWrapper {}
 
 /// Errors thrown while configuring x86_64 system.
-#[derive(Debug, PartialEq, thiserror::Error)]
+#[derive(Debug, Eq, PartialEq, thiserror::Error)]
 pub enum Error {
     /// Invalid e820 setup params.
     #[error("invalid e820 setup parameters")]

--- a/crates/dbs-boot/src/x86_64/mptable.rs
+++ b/crates/dbs-boot/src/x86_64/mptable.rs
@@ -56,7 +56,7 @@ unsafe impl ByteValued for MpfIntelWrapper {}
 // MPTABLE, describing VCPUS.
 const MPTABLE_START: u64 = 0x9fc00;
 
-#[derive(Debug, PartialEq, thiserror::Error)]
+#[derive(Debug, Eq, PartialEq, thiserror::Error)]
 /// MP Table related errors
 pub enum Error {
     /// There was too little guest memory to store the entire MP table.

--- a/crates/dbs-device/src/resources.rs
+++ b/crates/dbs-device/src/resources.rs
@@ -23,7 +23,7 @@
 use std::ops::Deref;
 
 /// Enumeration describing a device's resource allocation requirements and constraints.
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum ResourceConstraint {
     /// Constraint for an IO Port address range.
     PioAddress {
@@ -156,7 +156,7 @@ impl ResourceConstraint {
 }
 
 /// Type of Message Singaled Interrupt
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum MsiIrqType {
     /// PCI MSI IRQ numbers.
     PciMsi,
@@ -167,7 +167,7 @@ pub enum MsiIrqType {
 }
 
 /// Enumeration for device resources.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Resource {
     /// IO Port resource range.
     PioAddressRange {
@@ -208,7 +208,7 @@ pub enum Resource {
 }
 
 /// Newtype to store a set of device resources.
-#[derive(Clone, Debug, Default, PartialEq)]
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct DeviceResources(Vec<Resource>);
 
 impl DeviceResources {

--- a/crates/dbs-interrupt/src/lib.rs
+++ b/crates/dbs-interrupt/src/lib.rs
@@ -78,7 +78,7 @@ pub type Result<T> = std::io::Result<T>;
 pub type InterruptIndex = u32;
 
 /// Type of interrupt source.
-#[derive(Clone, PartialEq, Debug)]
+#[derive(Clone, Eq, PartialEq, Debug)]
 pub enum InterruptSourceType {
     #[cfg(feature = "legacy-irq")]
     /// Legacy Pin-based Interrupt.
@@ -91,7 +91,7 @@ pub enum InterruptSourceType {
 }
 
 /// Configuration data for an interrupt source.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum InterruptSourceConfig {
     #[cfg(feature = "legacy-irq")]
     /// Configuration data for Legacy interrupts.
@@ -105,12 +105,12 @@ pub enum InterruptSourceConfig {
 ///
 /// On x86 platforms, legacy interrupts means those interrupts routed through PICs or IOAPICs.
 #[cfg(feature = "legacy-irq")]
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct LegacyIrqSourceConfig {}
 
 /// Configuration data for GenericMsi, PciMsi, PciMsix interrupts.
 #[cfg(feature = "msi-irq")]
-#[derive(Default, Clone, Debug, PartialEq)]
+#[derive(Default, Clone, Debug, Eq, PartialEq)]
 pub struct MsiIrqSourceConfig {
     /// High address to deliver message signaled interrupt.
     pub high_addr: u32,

--- a/crates/dbs-interrupt/src/manager.rs
+++ b/crates/dbs-interrupt/src/manager.rs
@@ -33,7 +33,7 @@ const MSI_INT_MASK_BIT: u8 = 0;
 const MSI_INT_MASK: u32 = (1 << MSI_INT_MASK_BIT) as u32;
 
 /// Device interrupt working modes.
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum DeviceInterruptMode {
     /// The device interrupt manager has been disabled.
     Disabled = 0,

--- a/crates/dbs-upcall/src/dev_mgr_service.rs
+++ b/crates/dbs-upcall/src/dev_mgr_service.rs
@@ -47,7 +47,7 @@ struct DevMgrMsgHeader {
 
 /// Command struct to add/del a MMIO Virtio Device.
 #[repr(C)]
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct MmioDevRequest {
     /// base address of the virtio MMIO configuration window.
     pub mmio_base: u64,
@@ -159,14 +159,14 @@ impl DevMgrRequest {
 
 /// Device manager's response from cpu device.
 #[repr(C)]
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct CpuDevResponse {
     /// apic id index of last act cpu
     pub apic_id_index: u32,
 }
 
 /// Device manager's response inner message.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct DevMgrResponseInfo<I> {
     /// 0 means success and other result is the error code.
     pub result: i32,
@@ -175,7 +175,7 @@ pub struct DevMgrResponseInfo<I> {
 }
 
 /// Device manager's response representation in client side.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub enum DevMgrResponse {
     /// Add mmio device's response (no response body)
     AddMmioDev(DevMgrResponseInfo<()>),

--- a/crates/dbs-upcall/src/lib.rs
+++ b/crates/dbs-upcall/src/lib.rs
@@ -67,7 +67,7 @@ pub type Result<T> = std::result::Result<T, UpcallClientError>;
 // NOTE: here's not a state like `ServerDisconnect`, because we always connect
 // to server immediately when constructing the connection or disconnected from
 // server.
-#[derive(Clone, PartialEq, Debug)]
+#[derive(Clone, Eq, PartialEq, Debug)]
 pub enum UpcallClientState {
     /// There are two possible scenarios for a connection in this state:
     /// - Server's connection is broken, waiting for reconnect.
@@ -95,7 +95,7 @@ pub enum UpcallClientRequest {
 }
 
 /// Upcall client response of different services.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub enum UpcallClientResponse {
     /// Device manager's response.
     DevMgr(DevMgrResponse),

--- a/crates/dbs-utils/src/net/mac.rs
+++ b/crates/dbs-utils/src/net/mac.rs
@@ -20,7 +20,7 @@ pub enum MacError {
 }
 
 /// MAC address for ethernet NIC.
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct MacAddr {
     bytes: [u8; MAC_ADDR_LEN],
 }

--- a/crates/dbs-utils/src/rate_limiter.rs
+++ b/crates/dbs-utils/src/rate_limiter.rs
@@ -90,7 +90,7 @@ pub enum BucketReduction {
 
 /// TokenBucket provides a lower level interface to rate limiting with a
 /// configurable capacity, refill-rate and initial burst.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct TokenBucket {
     // Bucket defining traits.
     size: u64,

--- a/crates/dbs-virtio-devices/src/block/request.rs
+++ b/crates/dbs-virtio-devices/src/block/request.rs
@@ -29,7 +29,7 @@ pub(crate) enum ExecuteError {
 }
 
 /// Type of request from driver to device.
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum RequestType {
     /// Read request.
     In,

--- a/crates/dbs-virtio-devices/src/device.rs
+++ b/crates/dbs-virtio-devices/src/device.rs
@@ -260,7 +260,7 @@ where
 
 /// Device memory shared between guest and the device backend driver, defined by the Virtio
 /// specification for Virtio-fs devices.
-#[derive(Clone, PartialEq, Debug)]
+#[derive(Clone, Eq, PartialEq, Debug)]
 pub struct VirtioSharedMemory {
     /// offset from the bar base
     pub offset: u64,

--- a/crates/dbs-virtio-devices/src/lib.rs
+++ b/crates/dbs-virtio-devices/src/lib.rs
@@ -46,7 +46,7 @@ impl<T> DbsGuestAddressSpace for T where T: GuestAddressSpace + 'static + Clone 
 
 /// Version of virtio specifications supported by PCI virtio devices.
 #[allow(non_camel_case_types)]
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum VirtioVersion {
     /// Unknown/non-virtio VFIO device.
     VIRTIO_VERSION_UNKNOWN,

--- a/crates/dbs-virtio-devices/src/vsock/csm/mod.rs
+++ b/crates/dbs-virtio-devices/src/vsock/csm/mod.rs
@@ -39,7 +39,7 @@ pub enum Error {
 type Result<T> = std::result::Result<T, Error>;
 
 /// A vsock connection state.
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum ConnState {
     /// The connection has been initiated by the host end, but is yet to be
     /// confirmed by the guest.
@@ -67,7 +67,7 @@ pub enum ConnState {
 /// For instance, after being notified that there is available data to be read
 /// from the host stream (via `notify()`), the connection will store a
 /// `PendingRx::Rw` to be later inspected by `recv_pkt()`.
-#[derive(Clone, Copy, PartialEq)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 enum PendingRx {
     /// We need to yield a connection request packet (VSOCK_OP_REQUEST).
     Request = 0,
@@ -90,7 +90,7 @@ impl PendingRx {
 }
 
 /// A set of RX indications (`PendingRx` items).
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct PendingRxSet {
     data: u16,
 }

--- a/crates/dbs-virtio-devices/src/vsock/csm/txbuf.rs
+++ b/crates/dbs-virtio-devices/src/vsock/csm/txbuf.rs
@@ -10,7 +10,7 @@ use super::{Error, Result};
 /// A simple ring-buffer implementation, used by vsock connections to buffer TX
 /// (guest -> host) data.  Memory for this buffer is allocated lazily, since
 /// buffering will only be needed when the host can't read fast enough.
-#[derive(PartialEq)]
+#[derive(Eq, PartialEq)]
 pub struct TxBuf {
     /// The actual u8 buffer - only allocated after the first push.
     pub data: Option<Box<[u8]>>,

--- a/crates/dbs-virtio-devices/src/vsock/muxer/muxer_impl.rs
+++ b/crates/dbs-virtio-devices/src/vsock/muxer/muxer_impl.rs
@@ -59,7 +59,7 @@ pub struct ConnMapKey {
 }
 
 /// A muxer RX queue item.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum MuxerRx {
     /// The packet must be fetched from the connection identified by
     /// `ConnMapKey`.

--- a/crates/dbs-virtio-devices/src/vsock/muxer/muxer_rxq.rs
+++ b/crates/dbs-virtio-devices/src/vsock/muxer/muxer_rxq.rs
@@ -26,7 +26,7 @@ use super::defs;
 use super::muxer_impl::{ConnMapKey, MuxerRx};
 
 /// The muxer RX queue.
-#[derive(PartialEq)]
+#[derive(Eq, PartialEq)]
 pub struct MuxerRxQ {
     /// The RX queue data.
     pub(crate) q: VecDeque<MuxerRx>,


### PR DESCRIPTION
By adding required attribute Eq to the structs which derived attribute PartialEq.

Signed-off-by: Ruoqing He <farronwatcher@outlook.com>