### PR TITLE
dbs-address-space: fix update fuse-backend-rs version error

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -25,7 +25,7 @@ jobs:
           override: true
       - name: Lock dependencies
         run: |
-          cargo update -p fuse-backend-rs:0.9.5 --precise 0.9.4 || true
+          cargo update -p fuse-backend-rs:0.9.2 --precise 0.9.4 || true
           cargo update -p vmm-sys-util:0.10.0 --precise 0.9.0 || true
       - uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Test dbs-address-space
         run: |
-          cargo update -p fuse-backend-rs:0.9.5 --precise 0.9.4
+          cargo update -p fuse-backend-rs:0.9.2 --precise 0.9.4
           cargo llvm-cov --all-features -p dbs-address-space --lcov --output-path dbs-address-space.info
       - name: Test dbs-allocator
         run: cargo llvm-cov --all-features -p dbs-allocator --lcov --output-path dbs-allocator.info


### PR DESCRIPTION
When cargo update prompts, the original version of fuse-backend-rs should be 0.9.2 before the update.

```
Run cargo update -p fuse-backend-rs:0.9.5 --precise 0.9.4
error: package ID specification `fuse-backend-rs@0.9.[5](https://github.com/openanolis/dragonball-sandbox/runs/7870860355?check_suite_focus=true#step:6:6)` did not match any packages
Did you mean one of these?

  fuse-backend-rs@0.9.2
```

Fixes: https://github.com/openanolis/dragonball-sandbox/issues/193

Signed-off-by: yaoyinnan <yaoyinnan@foxmail.com>