### PR TITLE
Exclude mpspec.rs from coverage report.

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -93,3 +93,4 @@ flags:
 ignore:
   - "crates/dbs-boot/src/x86_64/bootparam.rs"
   - "crates/dbs-utils/src/net/net_gen"
+  - "crates/dbs-boot/src/x86_64/mpspec.rs"


### PR DESCRIPTION
File crates/dbs-boot/src/x86_64/mpspec is automatically generated, and thus should be excluded.

Signed-off-by: Ruoqing He <farronwatcher@outlook.com>