### PR TITLE
miniball: update linux-loader

### DIFF
--- a/crates/dbs-miniball/src/api/Cargo.toml
+++ b/crates/dbs-miniball/src/api/Cargo.toml
@@ -16,4 +16,4 @@ clap = "3.2.17"
 vmm = { path = "../vmm" }
 
 [dev-dependencies]
-linux-loader = "0.5.0"
+linux-loader = "0.6.0"

--- a/crates/dbs-miniball/src/vmm/Cargo.toml
+++ b/crates/dbs-miniball/src/vmm/Cargo.toml
@@ -17,7 +17,7 @@ event-manager = "0.2.1"
 kvm-bindings = { version = "0.5.0", features = ["fam-wrappers"] }
 kvm-ioctls = "0.11.0"
 libc = "0.2.91"
-linux-loader = { version = "0.5.0", features = ["bzimage", "elf"] }
+linux-loader = { version = "0.6.0", features = ["bzimage", "elf"] }
 vm-allocator = "0.1.0"
 vm-memory = { version = "0.9.0", features = ["backend-mmap"] }
 vm-superio = "0.5.0"


### PR DESCRIPTION
Since linux-loader 0.4.0 and 0.5.0 is yanked due to null terminator bug, we need to update linux-loader to 0.6.0.

And as_str() function should also be changed.

Signed-off-by: Chao Wu <chaowu@linux.alibaba.com>