### PR TITLE
arch: update dbs-arch to version 0.2.0

### DIFF
--- a/crates/dbs-arch/CHANGELOG.md
+++ b/crates/dbs-arch/CHANGELOG.md
@@ -1,5 +1,20 @@
-# v0.1.0
+# CHANGELOG
 
-## Added
+## v0.1.0
+
+### Added
 
 - This is the initial release for dbs-arch.
+
+## v0.2.0
+
+### Added
+- Add Hygon CPU Support
+
+### Updated
+- Update vm-memory to version 0.9
+- Update vmm-sys-util to version 0.10
+- Update license for crosvm dependencies
+
+### Fixed
+- Fix several clippy warnings

--- a/crates/dbs-arch/Cargo.toml
+++ b/crates/dbs-arch/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dbs-arch"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Alibaba Dragonball Team"]
 license = "Apache-2.0 AND BSD-3-Clause"
 edition = "2018"

--- a/crates/dbs-boot/Cargo.toml
+++ b/crates/dbs-boot/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["dragonball", "boot", "VMM"]
 readme = "README.md"
 
 [dependencies]
-dbs-arch = { path = "../dbs-arch", version = "0.1" }
+dbs-arch = { path = "../dbs-arch", version = "0.2.0" }
 kvm-bindings = { version = "0.5.0", features = ["fam-wrappers"] }
 kvm-ioctls = ">=0.9.0"
 lazy_static = "1"


### PR DESCRIPTION
- Add Hygon CPU Support
- Update vm-memory to version 0.9
- Update vmm-sys-util to version 0.10
- Update license for crosvm dependencies
- Fix several clippy warnings

Signed-off-by: Chao Wu <chaowu@linux.alibaba.com>