### PR TITLE
 boot: update to version 0.3.0

### DIFF
--- a/crates/dbs-boot/CHANGELOG.md
+++ b/crates/dbs-boot/CHANGELOG.md
@@ -1,11 +1,27 @@
-# v0.1.0
+# CHANGELOG
+## v0.1.0
 
-## Added
+### Added
 
 - This is the initial release for dbs-boot
 
-# v0.2.0
+## v0.2.0
 
-## Added
+### Added
 
 - Add arm layout related constant
+
+## v0.3.0
+
+### Added
+
+- aarch64 export fdt address
+
+### Fixed
+
+- several clippy warnings
+
+### Updated
+
+- update the license information for dbs-boot
+- vm-memory update to 0.9.0

--- a/crates/dbs-boot/Cargo.toml
+++ b/crates/dbs-boot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dbs-boot"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Alibaba Dragonball Team"]
 description = "Traits and structs for booting sandbox"
 license = "Apache-2.0 AND BSD-3-Clause"


### PR DESCRIPTION
    boot: update to version 0.3.0
    
    - Aarch64 export fdt address
    - Several clippy warnings
    - Update the license information for dbs-boot
    - vm-memory update to 0.9.0
    
    Signed-off-by: Chao Wu <chaowu@linux.alibaba.com>