### PR TITLE
interrupt: update dbs-interrupt to v0.2.0

### DIFF
--- a/crates/dbs-interrupt/CHANGELOG.md
+++ b/crates/dbs-interrupt/CHANGELOG.md
@@ -1,5 +1,18 @@
-# v0.1.0
+# CHANGELOG
 
-## Added
+## v0.1.0
+
+### Added
 
 - This is the initial release for dbs-interrupt
+
+
+## v0.2.0
+
+### Updated
+
+- Update vmm-sys-util to 0.10.0 
+
+### Fixed
+
+- Several clippy warnings

--- a/crates/dbs-interrupt/Cargo.toml
+++ b/crates/dbs-interrupt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dbs-interrupt"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Alibaba Dragonball Team"]
 description = "Traits and structs to manage interrupts for virtual devices"
 license = "Apache-2.0"

--- a/crates/dbs-virtio-devices/Cargo.toml
+++ b/crates/dbs-virtio-devices/Cargo.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 byteorder = "1.4.3"
 caps = "0.5.3"
 dbs-device = { version = "0.2.0", path = "../dbs-device" }
-dbs-interrupt = { version = "0.1.0", path = "../dbs-interrupt", features = ["kvm-legacy-irq", "kvm-msi-irq"] }
+dbs-interrupt = { version = "0.2.0", path = "../dbs-interrupt", features = ["kvm-legacy-irq", "kvm-msi-irq"] }
 dbs-utils = { version = "0.2.0", path = "../dbs-utils" }
 epoll = "4.0.1"
 io-uring = "0.5.2"


### PR DESCRIPTION
- Several clippy warnings
- Update vmm-sys-util to 0.10.0

Signed-off-by: Chao Wu <chaowu@linux.alibaba.com>