### PR TITLE
legacy: initial release for legacy devices

### DIFF
--- a/crates/dbs-legacy-devices/CHANGELOG.md
+++ b/crates/dbs-legacy-devices/CHANGELOG.md
@@ -1,0 +1,7 @@
+# CHANGELOG
+
+## v0.1.0
+
+### Added
+
+This is the initial release for the dbs-legacy-devices.


### PR DESCRIPTION
This is the initial release for the dbs-legacy-devices version 0.1.0.

Signed-off-by: Chao Wu <chaowu@linux.alibaba.com>