### PR TITLE
address-space: add directory support for hugetlbfs

### DIFF
--- a/crates/dbs-address-space/src/lib.rs
+++ b/crates/dbs-address-space/src/lib.rs
@@ -53,6 +53,10 @@ pub enum AddressSpaceError {
     #[error("can not open memory file")]
     OpenFile(#[source] std::io::Error),
 
+    /// Failed to create directory.
+    #[error("can not create directory")]
+    CreateDir(#[source] std::io::Error),
+
     /// Failed to set size for memory file.
     #[error("can not set size for memory file")]
     SetFileSize(#[source] std::io::Error),

--- a/crates/dbs-address-space/src/region.rs
+++ b/crates/dbs-address-space/src/region.rs
@@ -4,6 +4,7 @@
 use std::ffi::CString;
 use std::fs::{File, OpenOptions};
 use std::os::unix::io::FromRawFd;
+use std::path::Path;
 use std::str::FromStr;
 
 use nix::sys::memfd;
@@ -202,6 +203,11 @@ impl AddressSpaceRegion {
                 )
             }
             MemorySourceType::FileOnHugeTlbFs => {
+                let path = Path::new(mem_file_path);
+                if let Some(parent_dir) = path.parent() {
+                    // Ensure that the parent directory is existed for the mem file path.
+                    std::fs::create_dir_all(parent_dir).map_err(AddressSpaceError::CreateDir)?;
+                }
                 let file = OpenOptions::new()
                     .read(true)
                     .write(true)


### PR DESCRIPTION
The memory path may container directory that doesnt existed for hugetlbfs. This commit will check the directory and try to create the directory if it doesn't exist.

Signed-off-by: Chao Wu <chaowu@linux.alibaba.com>