### PR TITLE
dbs-virtio-devices: Replace nydus dependencies with crates.io

### DIFF
--- a/crates/dbs-interrupt/src/kvm/mod.rs
+++ b/crates/dbs-interrupt/src/kvm/mod.rs
@@ -188,9 +188,9 @@ impl KvmIrqRouting {
         let mut routes = self.routes.lock().unwrap();
 
         #[cfg(feature = "kvm-legacy-irq")]
-        LegacyIrq::initialize_legacy(&mut *routes)?;
+        LegacyIrq::initialize_legacy(&mut routes)?;
 
-        self.set_routing(&*routes)?;
+        self.set_routing(&routes)?;
 
         Ok(())
     }

--- a/crates/dbs-interrupt/src/kvm/msi_irq.rs
+++ b/crates/dbs-interrupt/src/kvm/msi_irq.rs
@@ -100,7 +100,7 @@ impl InterruptSourceGroup for MsiIrq {
         for i in 0..self.count {
             // Safe to unwrap because there's no legal way to break the mutex.
             let msicfg = self.msi_configs[i as usize].config.lock().unwrap();
-            let entry = new_msi_routing_entry(self.base + i, &*msicfg);
+            let entry = new_msi_routing_entry(self.base + i, &msicfg);
             entries.push(entry);
         }
         self.irq_routing.remove(&entries)?;
@@ -122,7 +122,7 @@ impl InterruptSourceGroup for MsiIrq {
                 msicfg.low_addr = cfg.low_addr;
                 msicfg.data = cfg.data;
                 msicfg.device_id = cfg.device_id;
-                new_msi_routing_entry(self.base + index, &*msicfg)
+                new_msi_routing_entry(self.base + index, &msicfg)
             };
             self.irq_routing.modify(&entry)
         } else {

--- a/crates/dbs-virtio-devices/Cargo.toml
+++ b/crates/dbs-virtio-devices/Cargo.toml
@@ -24,8 +24,8 @@ kvm-ioctls = "0.11.0"
 libc = "0.2.119"
 log = "0.4.14"
 nix = "0.23.1"
-nydus-blobfs = { git = "https://github.com/dragonflyoss/image-service.git", rev = "e429be3e8623d47db0f97186f761aeda2983c6f4", optional = true }
-nydus-rafs = { git = "https://github.com/dragonflyoss/image-service.git", rev = "e429be3e8623d47db0f97186f761aeda2983c6f4", optional = true }
+nydus-blobfs = { version = "0.1.1", optional = true }
+nydus-rafs = { version = "0.1.1", optional = true }
 rlimit = "0.7.0"
 serde = "1.0.27"
 serde_json = "1.0.9"

--- a/crates/dbs-virtio-devices/src/block/ufile/aio.rs
+++ b/crates/dbs-virtio-devices/src/block/ufile/aio.rs
@@ -86,14 +86,13 @@ impl IoEngine for Aio {
     // and may only return permanent errors. So the virtio-blk driver layer will not try to
     // recover and only pass errors up onto the device manager. When changing the error handling
     // policy, please do help to update BlockEpollHandler::io_complete().
-    #[allow(clippy::uninit_assumed_init)]
     fn complete(&mut self) -> io::Result<Vec<(u64, i64)>> {
         let count = self.aio_evtfd.read()?;
         let mut v = Vec::with_capacity(count as usize);
         if count > 0 {
             let mut events =
                 vec![
-                    unsafe { std::mem::MaybeUninit::<IoEvent>::uninit().assume_init() };
+                    unsafe { std::mem::MaybeUninit::<IoEvent>::zeroed().assume_init() };
                     count as usize
                 ];
             while v.len() < count as usize {


### PR DESCRIPTION
Signed-off-by: wllenyj <wllenyj@linux.alibaba.com>