### PR TITLE
vmm-sys-util: upgrade version to v0.11.0

### DIFF
--- a/crates/dbs-address-space/Cargo.toml
+++ b/crates/dbs-address-space/Cargo.toml
@@ -15,5 +15,5 @@ arc-swap = ">=0.4.8"
 libc = "0.2.39"
 nix = "0.23.1"
 thiserror = "1"
-vmm-sys-util = "0.10.0"
+vmm-sys-util = "0.11.0"
 vm-memory = { version = "0.9", features = ["backend-mmap", "backend-atomic"] }

--- a/crates/dbs-arch/Cargo.toml
+++ b/crates/dbs-arch/Cargo.toml
@@ -15,7 +15,7 @@ memoffset = "0.6"
 kvm-bindings = { version = "0.5.0", features = ["fam-wrappers"] }
 kvm-ioctls = ">=0.9.0"
 vm-memory = { version = "0.9" }
-vmm-sys-util = "0.10.0"
+vmm-sys-util = "0.11.0"
 libc = ">=0.2.39"
 
 [dev-dependencies]

--- a/crates/dbs-interrupt/Cargo.toml
+++ b/crates/dbs-interrupt/Cargo.toml
@@ -15,7 +15,7 @@ dbs-device = { path = "../dbs-device", version = "0.2.0" }
 kvm-bindings = { version = "0.5.0", optional = true }
 kvm-ioctls = { version = "0.11.0", optional = true }
 libc = "0.2"
-vmm-sys-util = "0.10.0"
+vmm-sys-util = "0.11.0"
 
 [features]
 default = ["legacy-irq", "msi-irq"]

--- a/crates/dbs-legacy-devices/Cargo.toml
+++ b/crates/dbs-legacy-devices/Cargo.toml
@@ -16,7 +16,7 @@ dbs-utils = { version = "0.2.0", path = "../dbs-utils" }
 log = "0.4.14"
 serde = { version = "1.0.27", features = ["derive", "rc"] }
 vm-superio = "0.5.0"
-vmm-sys-util = "0.10.0"
+vmm-sys-util = "0.11.0"
 
 [dev-dependencies]
 libc = "0.2.39"

--- a/crates/dbs-miniball/src/vm-vcpu/Cargo.toml
+++ b/crates/dbs-miniball/src/vm-vcpu/Cargo.toml
@@ -18,7 +18,7 @@ libc = "0.2.76"
 kvm-bindings = { version = "0.5.0", features = ["fam-wrappers"] }
 kvm-ioctls = "0.11.0"
 vm-memory = "0.9.0"
-vmm-sys-util = "0.10.0"
+vmm-sys-util = "0.11.0"
 vm-device = "0.1.0"
 
 utils = { path = "../utils" }

--- a/crates/dbs-miniball/src/vmm/Cargo.toml
+++ b/crates/dbs-miniball/src/vmm/Cargo.toml
@@ -21,7 +21,7 @@ linux-loader = { version = "0.6.0", features = ["bzimage", "elf"] }
 vm-allocator = "0.1.0"
 vm-memory = { version = "0.9.0", features = ["backend-mmap"] }
 vm-superio = "0.5.0"
-vmm-sys-util = "0.10.0"
+vmm-sys-util = "0.11.0"
 vm-device = "0.1.0"
 virtio-queue = "0.4.0"
 slog = "2.5.2"

--- a/crates/dbs-utils/Cargo.toml
+++ b/crates/dbs-utils/Cargo.toml
@@ -18,7 +18,7 @@ log = "0.4.14"
 serde = { version = "1.0.27", features = ["derive", "rc"] }
 thiserror = "1.0"
 timerfd = "1.0"
-vmm-sys-util = "0.10.0"
+vmm-sys-util = "0.11.0"
 
 [dev-dependencies]
 serde_json = "1.0.9"

--- a/crates/dbs-virtio-devices/Cargo.toml
+++ b/crates/dbs-virtio-devices/Cargo.toml
@@ -33,7 +33,7 @@ thiserror = "1"
 threadpool = "1"
 virtio-bindings = "0.1.0"
 virtio-queue = "0.4.0"
-vmm-sys-util = "0.10.0"
+vmm-sys-util = "0.11.0"
 vm-memory = { version = "0.9.0", features = [ "backend-mmap" ] }
 
 [dev-dependencies]


### PR DESCRIPTION
Since the upstream has published vmm-sys-util to 0.11.0, we also need to upgrade it.

Signed-off-by: Chao Wu <chaowu@linux.alibaba.com>