### PR TITLE
dbs-virtio-devices: publish v0.1.1

### DIFF
--- a/crates/dbs-virtio-devices/CHANGELOG.md
+++ b/crates/dbs-virtio-devices/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## v0.1.1
+
+### Updated
+
+- Update vmm-sys-util to 0.11.0
+
 ## v0.1.0
 
 ### Added 

--- a/crates/dbs-virtio-devices/Cargo.toml
+++ b/crates/dbs-virtio-devices/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dbs-virtio-devices"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Alibaba Dragonball Team"]
 license = "Apache-2.0 AND BSD-3-Clause"
 edition = "2018"


### PR DESCRIPTION
Updated vmm-sys-util to 0.11.0.

Signed-off-by: wllenyj <wllenyj@linux.alibaba.com>