### PR TITLE
boot: prepare to publish v0.3.1

### DIFF
--- a/crates/dbs-boot/CHANGELOG.md
+++ b/crates/dbs-boot/CHANGELOG.md
@@ -25,3 +25,12 @@
 
 - update the license information for dbs-boot
 - vm-memory update to 0.9.0
+
+## v0.3.1
+
+### Updated
+
+- Update kvm-bindings to v0.6.0
+- Use caret dependencies for kvm-ioctls
+- Update kvm-ioctls to v0.12.0
+- Update fdt in aarch64 to support vPMU

--- a/crates/dbs-boot/Cargo.toml
+++ b/crates/dbs-boot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dbs-boot"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Alibaba Dragonball Team"]
 description = "Traits and structs for booting sandbox"
 license = "Apache-2.0 AND BSD-3-Clause"


### PR DESCRIPTION
- Update kvm-bindings to v0.6.0
- Use caret dependencies for kvm-ioctls

Signed-off-by: Chao Wu <chaowu@linux.alibaba.com>