### PR TITLE
virtio-queue: update virtio-queue to v0.6.0

### DIFF
--- a/crates/dbs-address-space/src/lib.rs
+++ b/crates/dbs-address-space/src/lib.rs
@@ -74,8 +74,8 @@ mod tests {
     fn test_error_code() {
         let e = AddressSpaceError::InvalidRegionType;
 
-        assert_eq!(format!("{}", e), "invalid address space region type");
-        assert_eq!(format!("{:?}", e), "InvalidRegionType");
+        assert_eq!(format!("{e}"), "invalid address space region type");
+        assert_eq!(format!("{e:?}"), "InvalidRegionType");
         assert_eq!(
             format!(
                 "{}",

--- a/crates/dbs-address-space/src/memory/hybrid.rs
+++ b/crates/dbs-address-space/src/memory/hybrid.rs
@@ -652,9 +652,7 @@ mod tests {
             .write_all(original_content)
             .unwrap();
         // Rewind file pointer after write operation.
-        file_to_write_mmap_region
-            .seek(std::io::SeekFrom::Start(0))
-            .unwrap();
+        file_to_write_mmap_region.rewind().unwrap();
         guest_region
             .read_from(write_addr, &mut file_to_write_mmap_region, size_of_file)
             .unwrap();
@@ -666,9 +664,7 @@ mod tests {
             .write_all_to(write_addr, &mut file_read_from_mmap_region, size_of_file)
             .unwrap();
         // Rewind file pointer after write operation.
-        file_read_from_mmap_region
-            .seek(std::io::SeekFrom::Start(0))
-            .unwrap();
+        file_read_from_mmap_region.rewind().unwrap();
         let mut content = String::new();
         file_read_from_mmap_region
             .read_to_string(&mut content)
@@ -721,9 +717,7 @@ mod tests {
             .write_all(original_content)
             .unwrap();
         // Rewind file pointer after write operation.
-        file_to_write_mmap_region
-            .seek(std::io::SeekFrom::Start(0))
-            .unwrap();
+        file_to_write_mmap_region.rewind().unwrap();
         guest_region
             .read_from(write_addr, &mut file_to_write_mmap_region, size_of_file)
             .unwrap();
@@ -735,9 +729,7 @@ mod tests {
             .write_all_to(write_addr, &mut file_read_from_mmap_region, size_of_file)
             .unwrap();
         // Rewind file pointer after write operation.
-        file_read_from_mmap_region
-            .seek(std::io::SeekFrom::Start(0))
-            .unwrap();
+        file_read_from_mmap_region.rewind().unwrap();
         let mut content = String::new();
         file_read_from_mmap_region
             .read_to_string(&mut content)
@@ -794,9 +786,7 @@ mod tests {
         file_to_write_mmap_region
             .write_all(original_content)
             .unwrap();
-        file_to_write_mmap_region
-            .seek(std::io::SeekFrom::Start(0))
-            .unwrap();
+        file_to_write_mmap_region.rewind().unwrap();
         guest_mmap_region
             .read_exact_from(write_addr, &mut file_to_write_mmap_region, size_of_file)
             .unwrap();
@@ -807,9 +797,7 @@ mod tests {
         guest_mmap_region
             .write_all_to(write_addr, &mut file_read_from_mmap_region, size_of_file)
             .unwrap();
-        file_read_from_mmap_region
-            .seek(std::io::SeekFrom::Start(0))
-            .unwrap();
+        file_read_from_mmap_region.rewind().unwrap();
         let mut content = String::new();
         file_read_from_mmap_region
             .read_to_string(&mut content)
@@ -828,9 +816,7 @@ mod tests {
         file_to_write_raw_region
             .write_all(original_content)
             .unwrap();
-        file_to_write_raw_region
-            .seek(std::io::SeekFrom::Start(0))
-            .unwrap();
+        file_to_write_raw_region.rewind().unwrap();
         guest_raw_region
             .read_exact_from(write_addr, &mut file_to_write_raw_region, size_of_file)
             .unwrap();
@@ -841,9 +827,7 @@ mod tests {
         guest_raw_region
             .write_all_to(write_addr, &mut file_read_from_raw_region, size_of_file)
             .unwrap();
-        file_read_from_raw_region
-            .seek(std::io::SeekFrom::Start(0))
-            .unwrap();
+        file_read_from_raw_region.rewind().unwrap();
         let mut content = String::new();
         file_read_from_raw_region
             .read_to_string(&mut content)

--- a/crates/dbs-address-space/src/memory/hybrid.rs
+++ b/crates/dbs-address-space/src/memory/hybrid.rs
@@ -656,11 +656,7 @@ mod tests {
             .seek(std::io::SeekFrom::Start(0))
             .unwrap();
         guest_region
-            .read_from(
-                write_addr,
-                &mut file_to_write_mmap_region,
-                size_of_file as usize,
-            )
+            .read_from(write_addr, &mut file_to_write_mmap_region, size_of_file)
             .unwrap();
         let mut file_read_from_mmap_region = TempFile::new().unwrap().into_file();
         file_read_from_mmap_region
@@ -729,11 +725,7 @@ mod tests {
             .seek(std::io::SeekFrom::Start(0))
             .unwrap();
         guest_region
-            .read_from(
-                write_addr,
-                &mut file_to_write_mmap_region,
-                size_of_file as usize,
-            )
+            .read_from(write_addr, &mut file_to_write_mmap_region, size_of_file)
             .unwrap();
         let mut file_read_from_mmap_region = TempFile::new().unwrap().into_file();
         file_read_from_mmap_region

--- a/crates/dbs-address-space/src/memory/mod.rs
+++ b/crates/dbs-address-space/src/memory/mod.rs
@@ -63,7 +63,7 @@ impl FromStr for MemorySourceType {
             "mmap" => Ok(MemorySourceType::MmapAnonymous),
             "hugeanon" => Ok(MemorySourceType::MmapAnonymousHugeTlbFs),
             "hugemmap" => Ok(MemorySourceType::MmapAnonymousHugeTlbFs),
-            _ => Err(format!("unknown memory source type {}", s)),
+            _ => Err(format!("unknown memory source type {s}")),
         }
     }
 }

--- a/crates/dbs-address-space/src/region.rs
+++ b/crates/dbs-address-space/src/region.rs
@@ -175,8 +175,7 @@ impl AddressSpaceRegion {
                     .map_err(AddressSpaceError::CreateMemFd)?;
                 // Safe because we have just created the fd.
                 let file: File = unsafe { File::from_raw_fd(fd) };
-                file.set_len(size as u64)
-                    .map_err(AddressSpaceError::SetFileSize)?;
+                file.set_len(size).map_err(AddressSpaceError::SetFileSize)?;
                 Self::build(
                     AddressSpaceRegionType::DefaultMemory,
                     base,
@@ -215,8 +214,7 @@ impl AddressSpaceRegion {
                     .open(mem_file_path)
                     .map_err(AddressSpaceError::OpenFile)?;
                 nix::unistd::unlink(mem_file_path).map_err(AddressSpaceError::UnlinkFile)?;
-                file.set_len(size as u64)
-                    .map_err(AddressSpaceError::SetFileSize)?;
+                file.set_len(size).map_err(AddressSpaceError::SetFileSize)?;
                 let file_offset = FileOffset::new(file, 0);
                 Self::build(
                     AddressSpaceRegionType::DefaultMemory,

--- a/crates/dbs-arch/src/aarch64/mod.rs
+++ b/crates/dbs-arch/src/aarch64/mod.rs
@@ -39,7 +39,7 @@ pub enum DeviceType {
 
 impl fmt::Display for DeviceType {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 

--- a/crates/dbs-arch/src/x86_64/cpuid/common.rs
+++ b/crates/dbs-arch/src/x86_64/cpuid/common.rs
@@ -28,18 +28,14 @@ pub fn get_cpuid(function: u32, count: u32) -> Result<CpuidResult, Error> {
     let max_function = unsafe { __get_cpuid_max(function & leaf_0x80000000::LEAF_NUM).0 };
     if function > max_function {
         return Err(Error::InvalidParameters(format!(
-            "Function not supported: 0x{:x}",
-            function
+            "Function not supported: 0x{function:x}",
         )));
     }
 
     // this is safe because the host supports the `cpuid` instruction
     let entry = unsafe { __cpuid_count(function, count) };
     if entry.eax == 0 && entry.ebx == 0 && entry.ecx == 0 && entry.edx == 0 {
-        return Err(Error::InvalidParameters(format!(
-            "Invalid count: {}",
-            count
-        )));
+        return Err(Error::InvalidParameters(format!("Invalid count: {count}")));
     }
 
     Ok(entry)

--- a/crates/dbs-arch/src/x86_64/cpuid/transformer/common.rs
+++ b/crates/dbs-arch/src/x86_64/cpuid/transformer/common.rs
@@ -72,7 +72,7 @@ pub fn update_extended_topology_entry(
             // maximum 2 hyperthreads per core that can be represented by 1 bit.
             entry
                 .eax
-                .write_bits_in_range(&eax::APICID_BITRANGE, thread_width as u32);
+                .write_bits_in_range(&eax::APICID_BITRANGE, thread_width);
             // When cpu_count == 1 or HT is disabled, there is 1 logical core at this level
             // Otherwise there are 2
             entry.ebx.write_bits_in_range(
@@ -88,14 +88,14 @@ pub fn update_extended_topology_entry(
         1 => {
             entry
                 .eax
-                .write_bits_in_range(&eax::APICID_BITRANGE, core_width as u32);
+                .write_bits_in_range(&eax::APICID_BITRANGE, core_width);
             entry.ebx.write_bits_in_range(
                 &ebx::NUM_LOGICAL_PROCESSORS_BITRANGE,
                 u32::from(vm_spec.threads_per_core * vm_spec.cores_per_die),
             );
             entry
                 .ecx
-                .write_bits_in_range(&ecx::LEVEL_NUMBER_BITRANGE, entry.index as u32);
+                .write_bits_in_range(&ecx::LEVEL_NUMBER_BITRANGE, entry.index);
             entry
                 .ecx
                 .write_bits_in_range(&ecx::LEVEL_TYPE_BITRANGE, LEVEL_TYPE_CORE);
@@ -148,7 +148,7 @@ pub fn update_extended_topology_v2_entry(
             // maximum 2 hyperthreads per core that can be represented by 1 bit.
             entry
                 .eax
-                .write_bits_in_range(&eax::APICID_BITRANGE, thread_width as u32);
+                .write_bits_in_range(&eax::APICID_BITRANGE, thread_width);
             // When cpu_count == 1 or HT is disabled, there is 1 logical core at this level
             // Otherwise there are 2
             entry.ebx.write_bits_in_range(
@@ -163,14 +163,14 @@ pub fn update_extended_topology_v2_entry(
         1 => {
             entry
                 .eax
-                .write_bits_in_range(&eax::APICID_BITRANGE, core_width as u32);
+                .write_bits_in_range(&eax::APICID_BITRANGE, core_width);
             entry.ebx.write_bits_in_range(
                 &ebx::NUM_LOGICAL_PROCESSORS_BITRANGE,
                 u32::from(vm_spec.threads_per_core * vm_spec.cores_per_die),
             );
             entry
                 .ecx
-                .write_bits_in_range(&ecx::LEVEL_NUMBER_BITRANGE, entry.index as u32);
+                .write_bits_in_range(&ecx::LEVEL_NUMBER_BITRANGE, entry.index);
             entry
                 .ecx
                 .write_bits_in_range(&ecx::LEVEL_TYPE_BITRANGE, LEVEL_TYPE_CORE);
@@ -179,7 +179,7 @@ pub fn update_extended_topology_v2_entry(
         5 => {
             entry
                 .eax
-                .write_bits_in_range(&eax::APICID_BITRANGE, die_width as u32);
+                .write_bits_in_range(&eax::APICID_BITRANGE, die_width);
             entry.ebx.write_bits_in_range(
                 &ebx::NUM_LOGICAL_PROCESSORS_BITRANGE,
                 u32::from(
@@ -188,7 +188,7 @@ pub fn update_extended_topology_v2_entry(
             );
             entry
                 .ecx
-                .write_bits_in_range(&ecx::LEVEL_NUMBER_BITRANGE, entry.index as u32);
+                .write_bits_in_range(&ecx::LEVEL_NUMBER_BITRANGE, entry.index);
             entry
                 .ecx
                 .write_bits_in_range(&ecx::LEVEL_TYPE_BITRANGE, LEVEL_TYPE_DIE);

--- a/crates/dbs-arch/src/x86_64/regs.rs
+++ b/crates/dbs-arch/src/x86_64/regs.rs
@@ -168,7 +168,7 @@ fn configure_segments_and_sregs<M: GuestMemory>(
 
     /* 64-bit protected mode */
     sregs.cr0 |= X86_CR0_PE;
-    sregs.cr3 = pgtable_addr.raw_value() as u64;
+    sregs.cr3 = pgtable_addr.raw_value();
     sregs.cr4 |= X86_CR4_PAE;
     sregs.cr0 |= X86_CR0_PG;
     sregs.efer |= EFER_LME | EFER_LMA;
@@ -275,7 +275,7 @@ mod tests {
     }
 
     fn read_u64(gm: &GuestMemoryMmap, offset: u64) -> u64 {
-        let read_addr = GuestAddress(offset as u64);
+        let read_addr = GuestAddress(offset);
         gm.read_obj(read_addr).unwrap()
     }
 
@@ -303,7 +303,7 @@ mod tests {
     fn test_configure_segments_and_sregs() {
         let mut sregs: kvm_sregs = Default::default();
         let gm = create_guest_mem();
-        let gdt_table: [u64; BOOT_GDT_MAX as usize] = [
+        let gdt_table: [u64; BOOT_GDT_MAX] = [
             gdt_entry(0, 0, 0),            // NULL
             gdt_entry(0xa09b, 0, 0xfffff), // CODE
             gdt_entry(0xc093, 0, 0xfffff), // DATA
@@ -381,9 +381,9 @@ mod tests {
         let expected_regs: kvm_regs = kvm_regs {
             rflags: 0x0000_0000_0000_0002u64,
             rip: 1,
-            rsp: BOOT_STACK_POINTER as u64,
-            rbp: BOOT_STACK_POINTER as u64,
-            rsi: ZERO_PAGE_START as u64,
+            rsp: BOOT_STACK_POINTER,
+            rbp: BOOT_STACK_POINTER,
+            rsi: ZERO_PAGE_START,
             ..Default::default()
         };
 

--- a/crates/dbs-boot/src/aarch64/fdt.rs
+++ b/crates/dbs-boot/src/aarch64/fdt.rs
@@ -104,7 +104,7 @@ fn create_cpu_nodes(fdt: &mut FdtWriter, vcpu_mpidr: &[u64]) -> Result<()> {
     let num_cpus = vcpu_mpidr.len();
 
     for (cpu_index, iter) in vcpu_mpidr.iter().enumerate().take(num_cpus) {
-        let cpu_name = format!("cpu@{:x}", cpu_index);
+        let cpu_name = format!("cpu@{cpu_index:x}");
         let cpu_node = fdt.begin_node(&cpu_name)?;
         fdt.property_string("device_type", "cpu")?;
         fdt.property_string("compatible", "arm,arm-v8")?;
@@ -143,10 +143,7 @@ fn create_chosen_node(
     fdt.property_string("bootargs", cmdline)?;
 
     if let Some(initrd_config) = initrd {
-        fdt.property_u64(
-            "linux,initrd-start",
-            initrd_config.address.raw_value() as u64,
-        )?;
+        fdt.property_u64("linux,initrd-start", initrd_config.address.raw_value())?;
         fdt.property_u64(
             "linux,initrd-end",
             initrd_config.address.raw_value() + initrd_config.size as u64,
@@ -485,7 +482,7 @@ mod tests {
         set_size(&mut buf, pos, val);
         let original_fdt = device_tree::DeviceTree::load(&buf).unwrap();
         let generated_fdt = device_tree::DeviceTree::load(&dtb).unwrap();
-        assert!(format!("{:?}", original_fdt) == format!("{:?}", generated_fdt));
+        assert!(format!("{original_fdt:?}") == format!("{generated_fdt:?}"));
     }
 
     #[test]
@@ -535,6 +532,6 @@ mod tests {
         set_size(&mut buf, pos, val);
         let original_fdt = device_tree::DeviceTree::load(&buf).unwrap();
         let generated_fdt = device_tree::DeviceTree::load(&dtb).unwrap();
-        assert!(format!("{:?}", original_fdt) == format!("{:?}", generated_fdt));
+        assert!(format!("{original_fdt:?}") == format!("{generated_fdt:?}"));
     }
 }

--- a/crates/dbs-boot/src/aarch64/mod.rs
+++ b/crates/dbs-boot/src/aarch64/mod.rs
@@ -52,7 +52,7 @@ pub fn get_fdt_addr<M: GuestMemory>(mem: &M) -> u64 {
 /// Returns the memory address where the initrd could be loaded.
 pub fn initrd_load_addr<M: GuestMemory>(guest_mem: &M, initrd_size: u64) -> super::Result<u64> {
     let round_to_pagesize = |size| (size + (PAGE_SIZE as u64 - 1)) & !(PAGE_SIZE as u64 - 1);
-    match GuestAddress(get_fdt_addr(guest_mem)).checked_sub(round_to_pagesize(initrd_size) as u64) {
+    match GuestAddress(get_fdt_addr(guest_mem)).checked_sub(round_to_pagesize(initrd_size)) {
         Some(offset) => {
             if guest_mem.address_in_range(offset) {
                 Ok(offset.raw_value())

--- a/crates/dbs-device/src/device_manager.rs
+++ b/crates/dbs-device/src/device_manager.rs
@@ -623,13 +623,13 @@ mod tests {
 
         assert!(err.source().is_none());
         assert_eq!(
-            format!("{}", err),
+            format!("{err}"),
             "device address conflicts with existing devices"
         );
 
         let err = super::Error::NoDevice;
         assert!(err.source().is_none());
-        assert_eq!(format!("{:#?}", err), "NoDevice");
+        assert_eq!(format!("{err:#?}"), "NoDevice");
     }
 
     #[test]

--- a/crates/dbs-interrupt/src/manager.rs
+++ b/crates/dbs-interrupt/src/manager.rs
@@ -270,7 +270,7 @@ impl<T: InterruptManager> DeviceInterruptManager<T> {
             DeviceInterruptMode::GenericMsiIrq
             | DeviceInterruptMode::PciMsiIrq
             | DeviceInterruptMode::PciMsixIrq => {
-                let group = &self.intr_groups[self.current_idx as usize];
+                let group = &self.intr_groups[self.current_idx];
                 if index >= group.len() || index >= self.msi_config.len() as u32 {
                     return Err(Error::from_raw_os_error(libc::EINVAL));
                 }

--- a/crates/dbs-legacy-devices/src/serial.rs
+++ b/crates/dbs-legacy-devices/src/serial.rs
@@ -107,7 +107,7 @@ impl ConsoleHandler for SerialWrapper<EventFdTrigger, SerialEventsWrapper> {
     fn raw_input(&mut self, data: &[u8]) -> std::io::Result<usize> {
         self.serial
             .enqueue_raw_bytes(data)
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, format!("{:?}", e)))
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, format!("{e:?}")))
     }
 
     fn set_output_stream(&mut self, out: Option<Box<dyn Write + Send>>) {

--- a/crates/dbs-miniball/src/api/src/api.rs
+++ b/crates/dbs-miniball/src/api/src/api.rs
@@ -61,8 +61,8 @@ impl Cli {
         let help_msg = String::from_utf8_lossy(&help_msg_buf);
 
         let matches = app.get_matches_from_safe(cmdline_args).map_err(|e| {
-            eprintln!("{}", help_msg);
-            format!("Invalid command line arguments: {}", e)
+            eprintln!("{help_msg}");
+            format!("Invalid command line arguments: {e}")
         })?;
 
         VMMConfig::builder()
@@ -72,7 +72,7 @@ impl Cli {
             .net_config(matches.value_of("net"))
             .block_config(matches.value_of("block"))
             .build()
-            .map_err(|e| format!("{:?}", e))
+            .map_err(|e| format!("{e:?}"))
     }
 }
 

--- a/crates/dbs-miniball/src/main.rs
+++ b/crates/dbs-miniball/src/main.rs
@@ -29,7 +29,7 @@ fn main() {
             vmm.run().unwrap();
         }
         Err(e) => {
-            eprintln!("Failed to parse command line options. {}", e);
+            eprintln!("Failed to parse command line options. {e}");
         }
     }
 }

--- a/crates/dbs-miniball/src/vm-vcpu/src/vcpu/mod.rs
+++ b/crates/dbs-miniball/src/vm-vcpu/src/vcpu/mod.rs
@@ -459,7 +459,7 @@ impl KvmVcpu {
     // Configure sregs.
     #[cfg(target_arch = "x86_64")]
     fn configure_sregs<M: GuestMemory>(&self, guest_memory: &M) -> Result<()> {
-        let gdt_table: [u64; dbs_boot::layout::BOOT_GDT_MAX as usize] = [
+        let gdt_table: [u64; dbs_boot::layout::BOOT_GDT_MAX] = [
             gdt::gdt_entry(0, 0, 0),            // NULL
             gdt::gdt_entry(0xa09b, 0, 0xfffff), // CODE
             gdt::gdt_entry(0xc093, 0, 0xfffff), // DATA
@@ -549,7 +549,7 @@ impl KvmVcpu {
                     // println!("{:#?}", exit_reason);
                     match exit_reason {
                         VcpuExit::Shutdown | VcpuExit::Hlt => {
-                            println!("Guest shutdown: {:?}. Bye!", exit_reason);
+                            println!("Guest shutdown: {exit_reason:?}. Bye!");
                             if stdin().lock().set_canon_mode().is_err() {
                                 eprintln!("Failed to set canon mode. Stdin will not echo.");
                             }

--- a/crates/dbs-miniball/src/vm-vcpu/src/vm.rs
+++ b/crates/dbs-miniball/src/vm-vcpu/src/vm.rs
@@ -275,7 +275,7 @@ impl<EH: 'static + ExitHandler + Send> KvmVm<EH> {
             let memory_region = kvm_userspace_memory_region {
                 slot: index as u32,
                 guest_phys_addr: region.start_addr().raw_value(),
-                memory_size: region.len() as u64,
+                memory_size: region.len(),
                 // It's safe to unwrap because the guest address is valid.
                 userspace_addr: guest_memory.get_host_address(region.start_addr()).unwrap() as u64,
                 flags: 0,
@@ -399,7 +399,7 @@ impl<EH: 'static + ExitHandler + Send> KvmVm<EH> {
         for (id, mut vcpu) in self.vcpus.drain(..).enumerate() {
             let vcpu_exit_handler = self.exit_handler.clone();
             let vcpu_handle = thread::Builder::new()
-                .name(format!("vcpu_{}", id))
+                .name(format!("vcpu_{id}"))
                 .spawn(move || {
                     vcpu.run(vcpu_run_addr).unwrap();
                     vcpu_exit_handler.kick().unwrap();

--- a/crates/dbs-miniball/src/vmm/Cargo.toml
+++ b/crates/dbs-miniball/src/vmm/Cargo.toml
@@ -23,7 +23,7 @@ vm-memory = { version = "0.9.0", features = ["backend-mmap"] }
 vm-superio = "0.5.0"
 vmm-sys-util = "0.11.0"
 vm-device = "0.1.0"
-virtio-queue = "0.4.0"
+virtio-queue = "0.6.0"
 slog = "2.5.2"
 slog-scope = "4.4.0"
 

--- a/crates/dbs-miniball/src/vmm/src/boot.rs
+++ b/crates/dbs-miniball/src/vmm/src/boot.rs
@@ -114,7 +114,7 @@ pub fn build_bootparams(
             // * last_addr - himem_start is also smaller than mmio_gap_start
             last_addr
                 .checked_offset_from(himem_start)
-                .ok_or(Error::HimemStartPastMemEnd)? as u64
+                .ok_or(Error::HimemStartPastMemEnd)?
                 + 1,
             E820_RAM,
         )
@@ -138,7 +138,7 @@ pub fn build_bootparams(
                 // The unchecked + 1 is safe because:
                 // * overflow could only occur if last_addr == u64::MAX and mmio_gap_end == 0
                 // * mmio_gap_end > mmio_gap_start, which is a valid u64 => mmio_gap_end > 0
-                last_addr.unchecked_offset_from(mmio_gap_end) as u64 + 1,
+                last_addr.unchecked_offset_from(mmio_gap_end) + 1,
                 E820_RAM,
             )
             .map_err(Error::BootSystem)?;
@@ -205,12 +205,12 @@ mod tests {
                 GuestAddress(layout::MMIO_LOW_START),
                 GuestAddress(layout::MMIO_LOW_START - 1),
                 GuestAddress(cmdline_addr),
-                (kernel_cfg
+                kernel_cfg
                     .cmdline
                     .as_cstring()
                     .unwrap()
                     .as_bytes_with_nul()
-                    .len()) as usize,
+                    .len(),
             )
             .err(),
             Some(Error::MmioGapStartPastMmioGapEnd)
@@ -229,12 +229,12 @@ mod tests {
                 GuestAddress(layout::MMIO_LOW_START),
                 GuestAddress(layout::MMIO_LOW_END),
                 GuestAddress(cmdline_addr),
-                (kernel_cfg
+                kernel_cfg
                     .cmdline
                     .as_cstring()
                     .unwrap()
                     .as_bytes_with_nul()
-                    .len()) as usize,
+                    .len(),
             )
             .err(),
             Some(Error::HimemStartPastMemEnd)
@@ -256,12 +256,12 @@ mod tests {
                 GuestAddress(layout::MMIO_LOW_START),
                 GuestAddress(layout::MMIO_LOW_END),
                 GuestAddress(cmdline_addr),
-                (kernel_cfg
+                kernel_cfg
                     .cmdline
                     .as_cstring()
                     .unwrap()
                     .as_bytes_with_nul()
-                    .len()) as usize,
+                    .len(),
             )
             .err(),
             Some(Error::HimemStartPastMmioGapStart)
@@ -280,12 +280,12 @@ mod tests {
             GuestAddress(layout::MMIO_LOW_START),
             GuestAddress(layout::MMIO_LOW_END),
             GuestAddress(cmdline_addr),
-            (kernel_cfg
+            kernel_cfg
                 .cmdline
                 .as_cstring()
                 .unwrap()
                 .as_bytes_with_nul()
-                .len()) as usize,
+                .len(),
         )
         .is_ok());
     }

--- a/crates/dbs-miniball/src/vmm/src/config/arg_parser.rs
+++ b/crates/dbs-miniball/src/vmm/src/config/arg_parser.rs
@@ -17,9 +17,9 @@ impl fmt::Display for CfgArgParseError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::ParsingFailed(param, err) => {
-                write!(f, "Param '{}', parsing failed: {}", param, err)
+                write!(f, "Param '{param}', parsing failed: {err}")
             }
-            Self::UnknownArg(err) => write!(f, "Unknown arguments found: '{}'", err),
+            Self::UnknownArg(err) => write!(f, "Unknown arguments found: '{err}'"),
         }
     }
 }

--- a/crates/dbs-miniball/src/vmm/src/config/mod.rs
+++ b/crates/dbs-miniball/src/vmm/src/config/mod.rs
@@ -64,11 +64,11 @@ impl fmt::Display for ConversionError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use ConversionError::*;
         match self {
-            ParseKernel(ref s) => write!(f, "Invalid input for kernel: {}", s),
-            ParseMemory(ref s) => write!(f, "Invalid input for memory: {}", s),
-            ParseVcpus(ref s) => write!(f, "Invalid input for vCPUs: {}", s),
-            ParseNet(ref s) => write!(f, "Invalid input for network: {}", s),
-            ParseBlock(ref s) => write!(f, "Invalid input for block: {}", s),
+            ParseKernel(ref s) => write!(f, "Invalid input for kernel: {s}"),
+            ParseMemory(ref s) => write!(f, "Invalid input for memory: {s}"),
+            ParseVcpus(ref s) => write!(f, "Invalid input for vCPUs: {s}"),
+            ParseNet(ref s) => write!(f, "Invalid input for network: {s}"),
+            ParseBlock(ref s) => write!(f, "Invalid input for block: {s}"),
         }
     }
 }

--- a/crates/dbs-miniball/src/vmm/src/device_manager/resource_manager.rs
+++ b/crates/dbs-miniball/src/vmm/src/device_manager/resource_manager.rs
@@ -435,10 +435,7 @@ impl ResourceManager {
                         constraint.max = r.1 as u64;
                     }
                     match self.allocate_pio_address(&constraint) {
-                        Some(base) => Resource::PioAddressRange {
-                            base: base as u16,
-                            size: *size,
-                        },
+                        Some(base) => Resource::PioAddressRange { base, size: *size },
                         None => {
                             self.free_device_resources(&resources)?;
                             return Err(ResourceError::NoAvailResource);

--- a/crates/dbs-miniball/src/vmm/src/vmm.rs
+++ b/crates/dbs-miniball/src/vmm/src/vmm.rs
@@ -338,7 +338,7 @@ impl Vmm {
         loop {
             match self.event_mgr.handle_events(-1) {
                 Ok(_) => (),
-                Err(e) => eprintln!("Failed to handle events: {:?}", e),
+                Err(e) => eprintln!("Failed to handle events: {e:?}"),
             }
             if !self.exit_handler.keep_running() {
                 break;

--- a/crates/dbs-miniball/src/vmm/src/vmm.rs
+++ b/crates/dbs-miniball/src/vmm/src/vmm.rs
@@ -26,7 +26,7 @@ use linux_loader::loader::{
     bzimage::BzImage,
     elf::{self, Elf},
 };
-use virtio_queue::QueueStateSync;
+use virtio_queue::QueueSync;
 use vm_allocator::AllocPolicy;
 use vm_memory::atomic::GuestMemoryAtomic;
 use vm_memory::{GuestAddress, GuestMemory, GuestMemoryMmap, GuestRegionMmap};
@@ -179,11 +179,11 @@ type BlockDevice = Block<GuestMemoryAtomic<GuestMemoryMmap>>;
 
 /// Type of the miniball virtio devices.
 pub type DbsVirtioDevice =
-    Box<dyn VirtioDevice<GuestMemoryAtomic<GuestMemoryMmap>, QueueStateSync, GuestRegionMmap>>;
+    Box<dyn VirtioDevice<GuestMemoryAtomic<GuestMemoryMmap>, QueueSync, GuestRegionMmap>>;
 
 /// Type of the dragonball virtio mmio devices.
 pub type DbsMmioV2Device =
-    MmioV2Device<GuestMemoryAtomic<GuestMemoryMmap>, QueueStateSync, GuestRegionMmap>;
+    MmioV2Device<GuestMemoryAtomic<GuestMemoryMmap>, QueueSync, GuestRegionMmap>;
 
 /// A live VMM.
 pub struct Vmm {

--- a/crates/dbs-upcall/src/dev_mgr_service.rs
+++ b/crates/dbs-upcall/src/dev_mgr_service.rs
@@ -89,7 +89,7 @@ impl fmt::Debug for CpuDevRequest {
             if apic_id == &0 {
                 break;
             }
-            let _ = write!(apic_ids, "{}", apic_id);
+            let _ = write!(apic_ids, "{apic_id}");
             apic_ids.push(' ');
         }
         apic_ids.push_str(" ]");

--- a/crates/dbs-upcall/src/lib.rs
+++ b/crates/dbs-upcall/src/lib.rs
@@ -125,7 +125,7 @@ impl<S: UpcallClientService + Send> UpcallClientInfo<S> {
             .set_nonblocking(true)
             .map_err(UpcallClientError::ServerConnect)?;
 
-        let cmd = format!("CONNECT {}\n", SERVER_PORT);
+        let cmd = format!("CONNECT {SERVER_PORT}\n");
         stream
             .write_all(&cmd.into_bytes())
             .map_err(UpcallClientError::ServerConnect)?;
@@ -554,7 +554,7 @@ mod tests {
         assert!(inner_stream.read_exact(&mut read_buffer).is_ok());
         assert_eq!(
             read_buffer,
-            format!("CONNECT {}\n", SERVER_PORT).into_bytes()
+            format!("CONNECT {SERVER_PORT}\n",).into_bytes()
         );
 
         let writer_buffer = String::from("ERR").into_bytes();
@@ -660,10 +660,7 @@ mod tests {
         let mut inner_stream = vsock_backend.accept().unwrap();
         let mut read_buffer = vec![0; 12];
         assert!(inner_stream.read_exact(&mut read_buffer).is_ok());
-        assert_eq!(
-            read_buffer,
-            format!("CONNECT {}\n", SERVER_PORT).into_bytes()
-        );
+        assert_eq!(read_buffer, format!("CONNECT {SERVER_PORT}\n").into_bytes());
     }
 
     #[allow(clippy::mutex_atomic)]

--- a/crates/dbs-utils/src/net/mac.rs
+++ b/crates/dbs-utils/src/net/mac.rs
@@ -126,7 +126,7 @@ mod tests {
 
         let mac = MacAddr::parse_str("12:34:56:78:9a:BC").unwrap();
 
-        println!("parsed MAC address: {}", mac);
+        println!("parsed MAC address: {mac}");
 
         let bytes = mac.get_bytes();
         assert_eq!(bytes, [0x12u8, 0x34, 0x56, 0x78, 0x9a, 0xbc]);

--- a/crates/dbs-utils/src/net/tap.rs
+++ b/crates/dbs-utils/src/net/tap.rs
@@ -1,4 +1,5 @@
 // Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 //
 // Portions Copyright 2017 The Chromium OS Authors. All rights reserved.
@@ -320,7 +321,7 @@ mod tests {
             // The name of the tap should be {module_name}{index} so that
             // we make sure it stays different when tests are run concurrently.
             let next_ip = NEXT_IP.fetch_add(1, Ordering::SeqCst);
-            Self::open_named(&format!("dbs_tap{}", next_ip), false)
+            Self::open_named(&format!("dbs_tap{next_ip}"), false)
         }
 
         /// Set the host-side IP address for the tap interface.

--- a/crates/dbs-utils/src/net/tap.rs
+++ b/crates/dbs-utils/src/net/tap.rs
@@ -421,7 +421,7 @@ mod tests {
         let next_ip = NEXT_IP.fetch_add(1, Ordering::SeqCst);
 
         let tap = Tap::new().unwrap();
-        let ip_addr: Ipv4Addr = format!("{}{}", TAP_IP_PREFIX, next_ip).parse().unwrap();
+        let ip_addr: Ipv4Addr = format!("{TAP_IP_PREFIX}{next_ip}").parse().unwrap();
         let netmask: Ipv4Addr = SUBNET_MASK.parse().unwrap();
 
         let ret = tap.set_ip_addr(ip_addr);

--- a/crates/dbs-utils/src/rate_limiter.rs
+++ b/crates/dbs-utils/src/rate_limiter.rs
@@ -897,7 +897,7 @@ mod tests {
     fn test_rate_limiter_debug() {
         let l = RateLimiter::new(1, 2, 3, 4, 5, 6).unwrap();
         assert_eq!(
-            format!("{:?}", l),
+            format!("{l:?}"),
             format!(
                 "RateLimiter {{ bandwidth: {:?}, ops: {:?} }}",
                 l.bandwidth(),

--- a/crates/dbs-utils/src/time.rs
+++ b/crates/dbs-utils/src/time.rs
@@ -134,7 +134,7 @@ pub fn timestamp_cycles() -> u64 {
     #[cfg(target_arch = "x86_64")]
     // Safe because there's nothing that can go wrong with this call.
     unsafe {
-        std::arch::x86_64::_rdtsc() as u64
+        std::arch::x86_64::_rdtsc()
     }
     #[cfg(not(target_arch = "x86_64"))]
     {

--- a/crates/dbs-virtio-devices/Cargo.toml
+++ b/crates/dbs-virtio-devices/Cargo.toml
@@ -24,9 +24,9 @@ kvm-ioctls = "0.11.0"
 libc = "0.2.119"
 log = "0.4.14"
 nix = "0.23.1"
-nydus-api = { git = "https://github.com/dragonflyoss/image-service.git", rev = "99ba5000a734315ac8549c8ec21cebfc61d26e7f", optional = true }
-nydus-blobfs = { git = "https://github.com/dragonflyoss/image-service.git", rev = "99ba5000a734315ac8549c8ec21cebfc61d26e7f", optional = true }
-nydus-rafs = { git = "https://github.com/dragonflyoss/image-service.git", rev = "99ba5000a734315ac8549c8ec21cebfc61d26e7f", optional = true }
+nydus-api = "0.2.0"
+nydus-blobfs = "0.2.0"
+nydus-rafs = "0.2.0"
 rlimit = "0.7.0"
 serde = "1.0.27"
 serde_json = "1.0.9"

--- a/crates/dbs-virtio-devices/Cargo.toml
+++ b/crates/dbs-virtio-devices/Cargo.toml
@@ -24,8 +24,9 @@ kvm-ioctls = "0.11.0"
 libc = "0.2.119"
 log = "0.4.14"
 nix = "0.23.1"
-nydus-blobfs = { git = "https://github.com/dragonflyoss/image-service.git", rev = "0fafe1409f4d6b0ab015a65410fe2866654e44c0", optional = true }
-nydus-rafs = { git = "https://github.com/dragonflyoss/image-service.git", rev = "0fafe1409f4d6b0ab015a65410fe2866654e44c0", optional = true }
+nydus-api = { git = "https://github.com/dragonflyoss/image-service.git", rev = "99ba5000a734315ac8549c8ec21cebfc61d26e7f", optional = true }
+nydus-blobfs = { git = "https://github.com/dragonflyoss/image-service.git", rev = "99ba5000a734315ac8549c8ec21cebfc61d26e7f", optional = true }
+nydus-rafs = { git = "https://github.com/dragonflyoss/image-service.git", rev = "99ba5000a734315ac8549c8ec21cebfc61d26e7f", optional = true }
 rlimit = "0.7.0"
 serde = "1.0.27"
 serde_json = "1.0.9"

--- a/crates/dbs-virtio-devices/Cargo.toml
+++ b/crates/dbs-virtio-devices/Cargo.toml
@@ -18,21 +18,21 @@ dbs-interrupt = { version = "0.2.0", path = "../dbs-interrupt", features = ["kvm
 dbs-utils = { version = "0.2.0", path = "../dbs-utils" }
 epoll = "4.0.1"
 io-uring = "0.5.2"
-fuse-backend-rs = { version = "0.9.6", optional = true }
+fuse-backend-rs = { version = "0.10.0", optional = true }
 kvm-bindings = "0.6.0"
 kvm-ioctls = "0.11.0"
 libc = "0.2.119"
 log = "0.4.14"
 nix = "0.23.1"
-nydus-blobfs = { version = "0.1.1", optional = true }
-nydus-rafs = { version = "0.1.1", optional = true }
+nydus-blobfs = { git = "https://github.com/dragonflyoss/image-service.git", rev = "0fafe1409f4d6b0ab015a65410fe2866654e44c0", optional = true }
+nydus-rafs = { git = "https://github.com/dragonflyoss/image-service.git", rev = "0fafe1409f4d6b0ab015a65410fe2866654e44c0", optional = true }
 rlimit = "0.7.0"
 serde = "1.0.27"
 serde_json = "1.0.9"
 thiserror = "1"
 threadpool = "1"
 virtio-bindings = "0.1.0"
-virtio-queue = "0.4.0"
+virtio-queue = "0.6.0"
 vmm-sys-util = "0.11.0"
 vm-memory = { version = "0.9.0", features = [ "backend-mmap" ] }
 

--- a/crates/dbs-virtio-devices/src/block/device.rs
+++ b/crates/dbs-virtio-devices/src/block/device.rs
@@ -1044,7 +1044,7 @@ mod tests {
         file: DummyFile,
     ) -> InnerBlockEpollHandler<Arc<GuestMemoryMmap>, QueueSync> {
         let mem = Arc::new(GuestMemoryMmap::from_ranges(&[(GuestAddress(0x0), 0x10000)]).unwrap());
-        let queue = VirtioQueueConfig::create(255, 0).unwrap();
+        let queue = VirtioQueueConfig::create(256, 0).unwrap();
         let rate_limiter = RateLimiter::default();
         let disk_image: Box<dyn Ufile> = Box::new(file);
         let disk_image_id = build_device_id(disk_image.as_ref());

--- a/crates/dbs-virtio-devices/src/block/device.rs
+++ b/crates/dbs-virtio-devices/src/block/device.rs
@@ -91,7 +91,7 @@ impl<AS: DbsGuestAddressSpace> Block<AS> {
 
         let disk_image = &mut disk_images[0];
 
-        let disk_size = disk_image.seek(SeekFrom::End(0)).map_err(Error::IOError)? as u64;
+        let disk_size = disk_image.seek(SeekFrom::End(0)).map_err(Error::IOError)?;
         if disk_size % SECTOR_SIZE != 0 {
             warn!(
                 "Disk size {} is not a multiple of sector size {}; \

--- a/crates/dbs-virtio-devices/src/block/device.rs
+++ b/crates/dbs-virtio-devices/src/block/device.rs
@@ -20,7 +20,7 @@ use dbs_utils::{
 };
 use log::{debug, error, info, warn};
 use virtio_bindings::bindings::virtio_blk::*;
-use virtio_queue::QueueStateT;
+use virtio_queue::QueueT;
 use vm_memory::GuestMemoryRegion;
 use vmm_sys_util::eventfd::{EventFd, EFD_NONBLOCK};
 
@@ -201,7 +201,7 @@ impl<AS: DbsGuestAddressSpace> Block<AS> {
 impl<AS, Q, R> VirtioDevice<AS, Q, R> for Block<AS>
 where
     AS: DbsGuestAddressSpace,
-    Q: QueueStateT + Send + 'static,
+    Q: QueueT + Send + 'static,
     R: GuestMemoryRegion + Sync + Send + 'static,
 {
     fn device_type(&self) -> u32 {
@@ -376,7 +376,7 @@ mod tests {
     use dbs_interrupt::NoopNotifier;
     use dbs_utils::rate_limiter::{TokenBucket, TokenType};
     use kvm_ioctls::Kvm;
-    use virtio_queue::QueueStateSync;
+    use virtio_queue::QueueSync;
     use vm_memory::{Bytes, GuestAddress, GuestMemoryMmap, GuestRegionMmap};
     use vmm_sys_util::eventfd::EventFd;
 
@@ -871,38 +871,36 @@ mod tests {
         .unwrap();
 
         assert_eq!(
-            VirtioDevice::<Arc<GuestMemoryMmap<()>>, QueueStateSync, GuestRegionMmap>::device_type(
-                &dev
-            ),
+            VirtioDevice::<Arc<GuestMemoryMmap<()>>, QueueSync, GuestRegionMmap>::device_type(&dev),
             TYPE_BLOCK
         );
         let queue_size = vec![128];
         assert_eq!(
-            VirtioDevice::<Arc<GuestMemoryMmap<()>>, QueueStateSync, GuestRegionMmap>::queue_max_sizes(
+            VirtioDevice::<Arc<GuestMemoryMmap<()>>, QueueSync, GuestRegionMmap>::queue_max_sizes(
                 &dev
             ),
             &queue_size[..]
         );
         assert_eq!(
-            VirtioDevice::<Arc<GuestMemoryMmap<()>>, QueueStateSync, GuestRegionMmap>::get_avail_features(&dev, 0),
+            VirtioDevice::<Arc<GuestMemoryMmap<()>>, QueueSync, GuestRegionMmap>::get_avail_features(&dev, 0),
             dev.device_info.get_avail_features(0)
         );
         assert_eq!(
-            VirtioDevice::<Arc<GuestMemoryMmap<()>>, QueueStateSync, GuestRegionMmap>::get_avail_features(&dev, 1),
+            VirtioDevice::<Arc<GuestMemoryMmap<()>>, QueueSync, GuestRegionMmap>::get_avail_features(&dev, 1),
             dev.device_info.get_avail_features(1)
         );
         assert_eq!(
-            VirtioDevice::<Arc<GuestMemoryMmap<()>>, QueueStateSync, GuestRegionMmap>::get_avail_features(&dev, 2),
+            VirtioDevice::<Arc<GuestMemoryMmap<()>>, QueueSync, GuestRegionMmap>::get_avail_features(&dev, 2),
             dev.device_info.get_avail_features(2)
         );
         let mut config: [u8; 1] = [0];
-        VirtioDevice::<Arc<GuestMemoryMmap<()>>, QueueStateSync, GuestRegionMmap>::read_config(
+        VirtioDevice::<Arc<GuestMemoryMmap<()>>, QueueSync, GuestRegionMmap>::read_config(
             &mut dev,
             0,
             &mut config,
         );
         let config: [u8; 16] = [0; 16];
-        VirtioDevice::<Arc<GuestMemoryMmap<()>>, QueueStateSync, GuestRegionMmap>::write_config(
+        VirtioDevice::<Arc<GuestMemoryMmap<()>>, QueueSync, GuestRegionMmap>::write_config(
             &mut dev, 0, &config,
         );
     }
@@ -963,7 +961,7 @@ mod tests {
             dev.disk_images = vec![];
 
             let mem = GuestMemoryMmap::<()>::from_ranges(&[(GuestAddress(0), 0x10000)]).unwrap();
-            let queues = vec![VirtioQueueConfig::<QueueStateSync>::create(256, 0).unwrap()];
+            let queues = vec![VirtioQueueConfig::<QueueSync>::create(256, 0).unwrap()];
 
             let kvm = Kvm::new().unwrap();
             let vm_fd = Arc::new(kvm.create_vm().unwrap());
@@ -998,7 +996,7 @@ mod tests {
             .unwrap();
 
             let mem = GuestMemoryMmap::<()>::from_ranges(&[(GuestAddress(0), 0x10000)]).unwrap();
-            let queues = vec![VirtioQueueConfig::<QueueStateSync>::create(256, 0).unwrap()];
+            let queues = vec![VirtioQueueConfig::<QueueSync>::create(256, 0).unwrap()];
 
             let kvm = Kvm::new().unwrap();
             let vm_fd = Arc::new(kvm.create_vm().unwrap());
@@ -1044,7 +1042,7 @@ mod tests {
 
     fn get_block_epoll_handler_with_file(
         file: DummyFile,
-    ) -> InnerBlockEpollHandler<Arc<GuestMemoryMmap>, QueueStateSync> {
+    ) -> InnerBlockEpollHandler<Arc<GuestMemoryMmap>, QueueSync> {
         let mem = Arc::new(GuestMemoryMmap::from_ranges(&[(GuestAddress(0x0), 0x10000)]).unwrap());
         let queue = VirtioQueueConfig::create(255, 0).unwrap();
         let rate_limiter = RateLimiter::default();
@@ -1072,7 +1070,7 @@ mod tests {
         }
     }
 
-    fn get_block_epoll_handler() -> InnerBlockEpollHandler<Arc<GuestMemoryMmap>, QueueStateSync> {
+    fn get_block_epoll_handler() -> InnerBlockEpollHandler<Arc<GuestMemoryMmap>, QueueSync> {
         let mut file = DummyFile::new();
         file.capacity = 0x100000;
         get_block_epoll_handler_with_file(file)

--- a/crates/dbs-virtio-devices/src/block/ufile/aio.rs
+++ b/crates/dbs-virtio-devices/src/block/ufile/aio.rs
@@ -73,7 +73,7 @@ impl IoEngine for Aio {
             aio_resfd: self.aio_evtfd.as_raw_fd() as u32,
             aio_flags: IOCB_FLAG_RESFD,
             aio_buf: iovecs.as_mut_ptr() as u64,
-            aio_offset: offset as i64,
+            aio_offset: offset,
             aio_nbytes: iovecs.len() as u64,
             aio_data: user_data,
             ..Default::default()
@@ -97,9 +97,9 @@ impl IoEngine for Aio {
                 ];
             while v.len() < count as usize {
                 let r = self.aio_context.get_events(1, &mut events[0..], None)?;
-                for idx in 0..r {
-                    let index = events[idx as usize].data;
-                    let res2 = events[idx as usize].res;
+                for event in events.iter().take(r) {
+                    let index = event.data;
+                    let res2 = event.res;
                     v.push((index, res2));
                 }
             }

--- a/crates/dbs-virtio-devices/src/block/ufile/localfile.rs
+++ b/crates/dbs-virtio-devices/src/block/ufile/localfile.rs
@@ -253,7 +253,7 @@ mod tests {
         let bytes_write = file_with_aio.write(original_content).unwrap();
         assert_eq!(bytes_write, size_of_content);
         file_with_aio.flush().unwrap();
-        file_with_aio.seek(SeekFrom::Start(0)).unwrap();
+        file_with_aio.rewind().unwrap();
         let mut content = vec![0; 11];
         let bytes_read = file_with_aio.read(&mut content).unwrap();
         assert_eq!(bytes_read, size_of_content);

--- a/crates/dbs-virtio-devices/src/device.rs
+++ b/crates/dbs-virtio-devices/src/device.rs
@@ -842,8 +842,8 @@ pub(crate) mod tests {
         let gm = GuestMemoryAtomic::<GuestMemoryMmap>::new(gmm);
 
         let queues = vec![
-            VirtioQueueConfig::create(0, 0).unwrap(),
-            VirtioQueueConfig::create(0, 0).unwrap(),
+            VirtioQueueConfig::create(2, 0).unwrap(),
+            VirtioQueueConfig::create(2, 0).unwrap(),
         ];
         let kvm = Kvm::new().unwrap();
         let vm_fd = Arc::new(kvm.create_vm().unwrap());

--- a/crates/dbs-virtio-devices/src/device.rs
+++ b/crates/dbs-virtio-devices/src/device.rs
@@ -581,7 +581,7 @@ pub(crate) mod tests {
         let mut queues = Vec::new();
         for idx in 0..8 {
             queues.push(VirtioQueueConfig::new(
-                QueueSync::new(512),
+                QueueSync::new(512).unwrap(),
                 Arc::new(EventFd::new(0).unwrap()),
                 Arc::new(LegacyNotifier::new(
                     group.clone(),

--- a/crates/dbs-virtio-devices/src/device.rs
+++ b/crates/dbs-virtio-devices/src/device.rs
@@ -70,7 +70,7 @@ impl<Q: QueueT> VirtioQueueConfig<Q> {
 
         let queue = Q::new(queue_size)?;
         Ok(VirtioQueueConfig {
-            queue: queue,
+            queue,
             eventfd: Arc::new(eventfd),
             notifier: Arc::new(NoopNotifier::new()),
             index,

--- a/crates/dbs-virtio-devices/src/device.rs
+++ b/crates/dbs-virtio-devices/src/device.rs
@@ -545,7 +545,7 @@ impl VirtioDeviceInfo {
         self.epoll_manager.remove_subscriber(id).map_err(|e| {
             Error::IOError(std::io::Error::new(
                 std::io::ErrorKind::Other,
-                format!("remove_event_handler failed: {:?}", e),
+                format!("remove_event_handler failed: {e:?}"),
             ))
         })
     }

--- a/crates/dbs-virtio-devices/src/device.rs
+++ b/crates/dbs-virtio-devices/src/device.rs
@@ -24,7 +24,7 @@ use dbs_interrupt::{InterruptNotifier, NoopNotifier};
 use dbs_utils::epoll_manager::{EpollManager, EpollSubscriber, SubscriberId};
 use kvm_ioctls::VmFd;
 use log::{error, warn};
-use virtio_queue::{DescriptorChain, QueueStateOwnedT, QueueStateSync, QueueStateT};
+use virtio_queue::{DescriptorChain, QueueOwnedT, QueueSync, QueueT};
 use vm_memory::{
     Address, GuestAddress, GuestAddressSpace, GuestMemory, GuestMemoryRegion, GuestRegionMmap,
     GuestUsize,
@@ -37,7 +37,7 @@ use crate::{ActivateError, ActivateResult, Error, Result};
 ///
 /// The `VirtioQueueConfig` maintains configuration information for a Virtio queue.
 /// It also provides methods to access the queue and associated interrupt/event notifiers.
-pub struct VirtioQueueConfig<Q: QueueStateT = QueueStateSync> {
+pub struct VirtioQueueConfig<Q: QueueT = QueueSync> {
     /// Virtio queue object to access the associated queue.
     pub queue: Q,
     /// EventFd to receive queue notification from guest.
@@ -48,7 +48,7 @@ pub struct VirtioQueueConfig<Q: QueueStateT = QueueStateSync> {
     index: u16,
 }
 
-impl<Q: QueueStateT> VirtioQueueConfig<Q> {
+impl<Q: QueueT> VirtioQueueConfig<Q> {
     /// Create a `VirtioQueueConfig` object.
     pub fn new(
         queue: Q,
@@ -68,8 +68,9 @@ impl<Q: QueueStateT> VirtioQueueConfig<Q> {
     pub fn create(queue_size: u16, index: u16) -> Result<Self> {
         let eventfd = EventFd::new(EFD_NONBLOCK).map_err(Error::IOError)?;
 
+        let queue = Q::new(queue_size)?;
         Ok(VirtioQueueConfig {
-            queue: Q::new(queue_size),
+            queue: queue,
             eventfd: Arc::new(eventfd),
             notifier: Arc::new(NoopNotifier::new()),
             index,
@@ -151,7 +152,7 @@ impl<Q: QueueStateT> VirtioQueueConfig<Q> {
     }
 }
 
-impl<Q: QueueStateT + Clone> Clone for VirtioQueueConfig<Q> {
+impl<Q: QueueT + Clone> Clone for VirtioQueueConfig<Q> {
     fn clone(&self) -> Self {
         VirtioQueueConfig {
             queue: self.queue.clone(),
@@ -169,7 +170,7 @@ impl<Q: QueueStateT + Clone> Clone for VirtioQueueConfig<Q> {
 /// object. On VirtioDevice::reset(), the configuration object should be returned to the caller.
 pub struct VirtioDeviceConfig<
     AS: GuestAddressSpace,
-    Q: QueueStateT = QueueStateSync,
+    Q: QueueT = QueueSync,
     R: GuestMemoryRegion = GuestRegionMmap,
 > {
     /// `GustMemoryAddress` object to access the guest memory.
@@ -191,7 +192,7 @@ pub struct VirtioDeviceConfig<
 impl<AS, Q, R> VirtioDeviceConfig<AS, Q, R>
 where
     AS: GuestAddressSpace,
-    Q: QueueStateT,
+    Q: QueueT,
     R: GuestMemoryRegion,
 {
     /// Creates a new `VirtioDeviceConfig` object.
@@ -339,7 +340,7 @@ pub trait VirtioRegionHandler: Send {
 /// and all the events, memory, and queues for device operation will be moved into the device.
 /// Optionally, a virtio device can implement device reset in which it returns said resources and
 /// resets its internal.
-pub trait VirtioDevice<AS: GuestAddressSpace, Q: QueueStateT, R: GuestMemoryRegion>: Send {
+pub trait VirtioDevice<AS: GuestAddressSpace, Q: QueueT, R: GuestMemoryRegion>: Send {
     /// The virtio device type.
     fn device_type(&self) -> u32;
 
@@ -521,10 +522,7 @@ impl VirtioDeviceInfo {
     }
 
     /// Validate size of queues and queue eventfds.
-    pub fn check_queue_sizes<Q: QueueStateT>(
-        &self,
-        queues: &[VirtioQueueConfig<Q>],
-    ) -> ActivateResult {
+    pub fn check_queue_sizes<Q: QueueT>(&self, queues: &[VirtioQueueConfig<Q>]) -> ActivateResult {
         if queues.is_empty() || queues.len() != self.queue_sizes.len() {
             error!(
                 "{}: invalid configuration: maximum {} queue(s), got {} queues",
@@ -563,7 +561,7 @@ pub(crate) mod tests {
     };
     use dbs_utils::epoll_manager::{EventOps, Events, MutEventSubscriber};
     use kvm_ioctls::Kvm;
-    use virtio_queue::QueueStateSync;
+    use virtio_queue::QueueSync;
     use vm_memory::{GuestMemoryAtomic, GuestMemoryMmap, GuestMemoryRegion, MmapRegion};
 
     pub fn create_virtio_device_config() -> VirtioDeviceConfig<Arc<GuestMemoryMmap>> {
@@ -583,7 +581,7 @@ pub(crate) mod tests {
         let mut queues = Vec::new();
         for idx in 0..8 {
             queues.push(VirtioQueueConfig::new(
-                QueueStateSync::new(512),
+                QueueSync::new(512),
                 Arc::new(EventFd::new(0).unwrap()),
                 Arc::new(LegacyNotifier::new(
                     group.clone(),
@@ -613,7 +611,7 @@ pub(crate) mod tests {
         let status = Arc::new(InterruptStatusRegister32::new());
         let notifier = Arc::new(LegacyNotifier::new(group, status, VIRTIO_INTR_VRING));
 
-        let mut cfg = VirtioQueueConfig::<QueueStateSync>::create(1024, 1).unwrap();
+        let mut cfg = VirtioQueueConfig::<QueueSync>::create(1024, 1).unwrap();
         cfg.set_interrupt_notifier(notifier);
 
         let mem =
@@ -638,7 +636,7 @@ pub(crate) mod tests {
         let status = Arc::new(InterruptStatusRegister32::new());
         let notifier = Arc::new(LegacyNotifier::new(group, status, VIRTIO_INTR_VRING));
 
-        let mut cfg = VirtioQueueConfig::<QueueStateSync>::create(1024, 1).unwrap();
+        let mut cfg = VirtioQueueConfig::<QueueSync>::create(1024, 1).unwrap();
         cfg.set_interrupt_notifier(notifier);
         let mut cfg = cfg.clone();
 
@@ -700,9 +698,7 @@ pub(crate) mod tests {
         device_info: VirtioDeviceInfo,
     }
 
-    impl VirtioDevice<GuestMemoryAtomic<GuestMemoryMmap>, QueueStateSync, GuestRegionMmap>
-        for DummyDevice
-    {
+    impl VirtioDevice<GuestMemoryAtomic<GuestMemoryMmap>, QueueSync, GuestRegionMmap> for DummyDevice {
         fn device_type(&self) -> u32 {
             0xffff
         }
@@ -821,7 +817,7 @@ pub(crate) mod tests {
         assert!(matches!(
             device
                 .device_info
-                .check_queue_sizes::<QueueStateSync>(&queue_size),
+                .check_queue_sizes::<QueueSync>(&queue_size),
             Err(ActivateError::InvalidParam)
         ));
 

--- a/crates/dbs-virtio-devices/src/fs/device.rs
+++ b/crates/dbs-virtio-devices/src/fs/device.rs
@@ -480,7 +480,7 @@ impl<AS: GuestAddressSpace> VirtioFs<AS> {
 
                 (
                     Rafs::new(&rafs_conf, mountpoint, file)
-                        .map_err(|e| FsError::BackendFs(format!("Rafs::new() failed: {:?}", e)))?,
+                        .map_err(|e| FsError::BackendFs(format!("Rafs::new() failed: {e:?}")))?,
                     cfg.clone(),
                 )
             }
@@ -493,7 +493,7 @@ impl<AS: GuestAddressSpace> VirtioFs<AS> {
         );
         rafs.0
             .import(rafs.1, prefetch_files)
-            .map_err(|e| FsError::BackendFs(format!("Import rafs failed: {:?}", e)))?;
+            .map_err(|e| FsError::BackendFs(format!("Import rafs failed: {e:?}")))?;
         info!(
             "{}: Rafs imported with prefetch_list_path {:?}",
             VIRTIO_FS_NAME, prefetch_list_path
@@ -529,8 +529,7 @@ impl<AS: GuestAddressSpace> VirtioFs<AS> {
         }
         if source.is_none() {
             return Err(FsError::BackendFs(format!(
-                "rafs mounted at {} doesn't have source configured",
-                mountpoint
+                "rafs mounted at {mountpoint} doesn't have source configured"
             )));
         }
         // safe because config is not None.
@@ -547,8 +546,7 @@ impl<AS: GuestAddressSpace> VirtioFs<AS> {
             },
             None => {
                 return Err(FsError::BackendFs(format!(
-                    "rafs mount point {} is not mounted",
-                    mountpoint
+                    "rafs mount point {mountpoint} is not mounted"
                 )));
             }
         };
@@ -557,26 +555,24 @@ impl<AS: GuestAddressSpace> VirtioFs<AS> {
                 Some(f) => f,
                 None => {
                     return Err(FsError::BackendFs(format!(
-                        "rafs get_rootfs() failed: mountpoint {} not mounted",
-                        mountpoint
+                        "rafs get_rootfs() failed: mountpoint {mountpoint} not mounted"
                     )));
                 }
             },
             Err(e) => {
                 return Err(FsError::BackendFs(format!(
-                    "rafs get_rootfs() failed: {:?}",
-                    e
+                    "rafs get_rootfs() failed: {e:?}"
                 )));
             }
         };
         let any_fs = rootfs.deref().as_any();
         if let Some(fs_swap) = any_fs.downcast_ref::<Rafs>() {
             let mut file = <dyn RafsIoRead>::from_file(&source)
-                .map_err(|e| FsError::BackendFs(format!("RafsIoRead failed: {:?}", e)))?;
+                .map_err(|e| FsError::BackendFs(format!("RafsIoRead failed: {e:?}")))?;
 
             fs_swap
                 .update(&mut file, &rafs_conf)
-                .map_err(|e| FsError::BackendFs(format!("Update rafs failed: {:?}", e)))?;
+                .map_err(|e| FsError::BackendFs(format!("Update rafs failed: {e:?}")))?;
             self.backend_fs.insert(mountpoint.to_string(), new_info);
             Ok(())
         } else {

--- a/crates/dbs-virtio-devices/src/fs/device.rs
+++ b/crates/dbs-virtio-devices/src/fs/device.rs
@@ -29,7 +29,6 @@ use nydus_api::ConfigV2;
 use nydus_blobfs::{BlobFs, Config as BlobfsConfig};
 use nydus_rafs::{fs::Rafs, RafsIoRead};
 use rlimit::Resource;
-use serde::Deserialize;
 use virtio_bindings::bindings::virtio_blk::VIRTIO_F_VERSION_1;
 use virtio_queue::QueueT;
 use vm_memory::{
@@ -61,12 +60,6 @@ const CACHE_NONE_TIMEOUT: u64 = 0;
 pub(crate) const PASSTHROUGHFS: &str = "passthroughfs";
 pub(crate) const BLOBFS: &str = "blobfs";
 pub(crate) const RAFS: &str = "rafs";
-
-#[derive(Clone, Deserialize)]
-struct BlobCacheConfig {
-    #[serde(default)]
-    work_dir: String,
-}
 
 /// Info of backend filesystems of VirtioFs
 #[allow(dead_code)]
@@ -475,7 +468,7 @@ impl<AS: GuestAddressSpace> VirtioFs<AS> {
         prefetch_list_path: Option<String>,
     ) -> FsResult<()> {
         debug!("http_server rafs");
-        let mut file = Path::new(&source);
+        let file = Path::new(&source);
         let (mut rafs, rafs_cfg) = match config.as_ref() {
             Some(cfg) => {
                 let rafs_conf: Arc<ConfigV2> = Arc::new(
@@ -483,7 +476,7 @@ impl<AS: GuestAddressSpace> VirtioFs<AS> {
                 );
 
                 (
-                    Rafs::new(&rafs_conf, mountpoint, &mut file)
+                    Rafs::new(&rafs_conf, mountpoint, file)
                         .map_err(|e| FsError::BackendFs(format!("Rafs::new() failed: {:?}", e)))?,
                     cfg.clone(),
                 )

--- a/crates/dbs-virtio-devices/src/fs/handler.rs
+++ b/crates/dbs-virtio-devices/src/fs/handler.rs
@@ -95,7 +95,7 @@ impl FsCacheReqHandler for CacheHandler {
             libc::mmap(
                 addr as *mut libc::c_void,
                 len as usize,
-                libc::PROT_READ as i32,
+                libc::PROT_READ,
                 libc::MAP_SHARED | libc::MAP_FIXED,
                 fd,
                 foffset as libc::off_t,

--- a/crates/dbs-virtio-devices/src/fs/handler.rs
+++ b/crates/dbs-virtio-devices/src/fs/handler.rs
@@ -15,7 +15,7 @@ use fuse_backend_rs::api::Vfs;
 use fuse_backend_rs::transport::{FsCacheReqHandler, Reader, VirtioFsWriter, Writer};
 use log::{debug, error, info, trace};
 use threadpool::ThreadPool;
-use virtio_queue::{QueueStateOwnedT, QueueStateT};
+use virtio_queue::{QueueOwnedT, QueueT};
 use vm_memory::{GuestAddressSpace, GuestMemoryRegion};
 use vmm_sys_util::eventfd::EventFd;
 
@@ -169,7 +169,7 @@ impl FsCacheReqHandler for CacheHandler {
 
 pub(crate) struct VirtioFsEpollHandler<
     AS: 'static + GuestAddressSpace,
-    Q: QueueStateT,
+    Q: QueueT,
     R: GuestMemoryRegion,
 > {
     pub(crate) config: Arc<Mutex<VirtioDeviceConfig<AS, Q, R>>>,
@@ -187,7 +187,7 @@ where
     AS: GuestAddressSpace + Clone + Send,
     AS::T: Send,
     AS::M: Sync + Send,
-    Q: QueueStateT + Send + 'static,
+    Q: QueueT + Send + 'static,
     R: GuestMemoryRegion + Send + Sync + 'static,
 {
     #[allow(clippy::too_many_arguments)]
@@ -299,7 +299,7 @@ where
         }
 
         let notify = !self.is_multi_thread() && used_count > 0;
-        // unlock QueueStateT
+        // unlock QueueT
         drop(queue_guard);
         while !self.is_multi_thread() && used_count > 0 {
             used_count -= 1;
@@ -368,7 +368,7 @@ where
     AS: GuestAddressSpace + Send + Sync + 'static + Clone,
     AS::T: Send,
     AS::M: Sync + Send,
-    Q: QueueStateT + Send + 'static,
+    Q: QueueT + Send + 'static,
     R: GuestMemoryRegion + Send + Sync + 'static,
 {
     fn process(&mut self, events: Events, _ops: &mut EventOps) {

--- a/crates/dbs-virtio-devices/src/lib.rs
+++ b/crates/dbs-virtio-devices/src/lib.rs
@@ -211,7 +211,7 @@ pub mod tests {
 
     use dbs_interrupt::KvmIrqManager;
     use kvm_ioctls::{Kvm, VmFd};
-    use virtio_queue::{QueueStateSync, QueueStateT};
+    use virtio_queue::{QueueSync, QueueT};
     use vm_memory::{
         Address, GuestAddress, GuestMemory, GuestMemoryMmap, GuestUsize, VolatileMemory,
         VolatileRef, VolatileSlice,
@@ -442,9 +442,9 @@ pub mod tests {
             self.used.start()
         }
 
-        // Creates a new QueueStateSync, using the underlying memory regions represented by the VirtQueue.
-        pub fn create_queue(&self) -> QueueStateSync {
-            let mut q = QueueStateSync::new(self.size());
+        // Creates a new QueueSync, using the underlying memory regions represented by the VirtQueue.
+        pub fn create_queue(&self) -> QueueSync {
+            let mut q = QueueSync::new(self.size());
 
             q.set_size(self.size());
             q.set_ready(true);

--- a/crates/dbs-virtio-devices/src/lib.rs
+++ b/crates/dbs-virtio-devices/src/lib.rs
@@ -444,13 +444,13 @@ pub mod tests {
 
         // Creates a new QueueSync, using the underlying memory regions represented by the VirtQueue.
         pub fn create_queue(&self) -> QueueSync {
-            let mut q = QueueSync::new(self.size());
+            let mut q = QueueSync::new(self.size()).unwrap();
 
             q.set_size(self.size());
             q.set_ready(true);
-            q.lock().desc_table = self.dtable_start();
-            q.lock().avail_ring = self.avail_start();
-            q.lock().used_ring = self.used_start();
+            let _ = q.lock().try_set_desc_table_address(self.dtable_start());
+            let _ = q.lock().try_set_avail_ring_address(self.avail_start());
+            let _ = q.lock().try_set_used_ring_address(self.used_start());
 
             q
         }

--- a/crates/dbs-virtio-devices/src/mmio/dragonball.rs
+++ b/crates/dbs-virtio-devices/src/mmio/dragonball.rs
@@ -178,7 +178,7 @@ mod tests {
         );
         assert_eq!(door.offset(), DRAGONBALL_MMIO_DOORBELL_OFFSET as u32);
         assert_eq!(door.scale(), DRAGONBALL_MMIO_DOORBELL_SCALE as u32);
-        assert_eq!(door.queue_offset(0), DRAGONBALL_MMIO_DOORBELL_OFFSET as u64);
+        assert_eq!(door.queue_offset(0), DRAGONBALL_MMIO_DOORBELL_OFFSET);
         assert_eq!(door.queue_offset(4), 0x1010);
         assert_eq!(door.register_data(), 0x1000 | 0x40000);
     }

--- a/crates/dbs-virtio-devices/src/mmio/mmio_v2.rs
+++ b/crates/dbs-virtio-devices/src/mmio/mmio_v2.rs
@@ -397,7 +397,7 @@ where
                     return;
                 }
             };
-            LittleEndian::write_u16(data, v as u16);
+            LittleEndian::write_u16(data, v);
         } else {
             info!(
                 "unknown virtio mmio register read: 0x{:x}/0x{:x}",
@@ -854,10 +854,7 @@ pub(crate) mod tests {
         d.device_vendor |= DRAGONBALL_FEATURE_MSI_INTR;
         let mut buf = vec![0; 2];
         d.read(IoAddress(0), IoAddress(REG_MMIO_MSI_CSR), &mut buf[..]);
-        assert_eq!(
-            LittleEndian::read_u16(&buf[..]),
-            MMIO_MSI_CSR_SUPPORTED as u16
-        );
+        assert_eq!(LittleEndian::read_u16(&buf[..]), MMIO_MSI_CSR_SUPPORTED);
 
         let mut dev_cfg = vec![0; 4];
         assert_eq!(

--- a/crates/dbs-virtio-devices/src/mmio/mmio_v2.rs
+++ b/crates/dbs-virtio-devices/src/mmio/mmio_v2.rs
@@ -955,7 +955,7 @@ pub(crate) mod tests {
         LittleEndian::write_u32(&mut buf[..], 0b111);
         d.write(IoAddress(0), IoAddress(REG_MMIO_INTERRUPT_AC), &buf[..]);
 
-        assert_eq!(d.state().queues_mut()[0].queue.lock().desc_table.0, 0);
+        assert_eq!(d.state().queues_mut()[0].queue.lock().desc_table(), 0);
 
         // When write descriptor, descriptor table will judge like this:
         // if desc_table.mask(0xf) != 0 {
@@ -964,30 +964,30 @@ pub(crate) mod tests {
         // desc_table is the data that will be written.
         LittleEndian::write_u32(&mut buf[..], 0x120);
         d.write(IoAddress(0), IoAddress(REG_MMIO_QUEUE_DESC_LOW), &buf[..]);
-        assert_eq!(d.state().queues_mut()[0].queue.lock().desc_table.0, 0x120);
+        assert_eq!(d.state().queues_mut()[0].queue.lock().desc_table(), 0x120);
         d.write(IoAddress(0), IoAddress(REG_MMIO_QUEUE_DESC_HIGH), &buf[..]);
         assert_eq!(
-            d.state().queues_mut()[0].queue.lock().desc_table.0,
+            d.state().queues_mut()[0].queue.lock().desc_table(),
             0x120 + (0x120 << 32)
         );
 
-        assert_eq!(d.state().queues_mut()[0].queue.lock().avail_ring.0, 0);
+        assert_eq!(d.state().queues_mut()[0].queue.lock().avail_ring(), 0);
         LittleEndian::write_u32(&mut buf[..], 124);
         d.write(IoAddress(0), IoAddress(REG_MMIO_QUEUE_AVAIL_LOW), &buf[..]);
-        assert_eq!(d.state().queues_mut()[0].queue.lock().avail_ring.0, 124);
+        assert_eq!(d.state().queues_mut()[0].queue.lock().avail_ring(), 124);
         d.write(IoAddress(0), IoAddress(REG_MMIO_QUEUE_AVAIL_HIGH), &buf[..]);
         assert_eq!(
-            d.state().queues_mut()[0].queue.lock().avail_ring.0,
+            d.state().queues_mut()[0].queue.lock().avail_ring(),
             124 + (124 << 32)
         );
 
-        assert_eq!(d.state().queues_mut()[0].queue.lock().used_ring.0, 0);
+        assert_eq!(d.state().queues_mut()[0].queue.lock().used_ring(), 0);
         LittleEndian::write_u32(&mut buf[..], 128);
         d.write(IoAddress(0), IoAddress(REG_MMIO_QUEUE_USED_LOW), &buf[..]);
-        assert_eq!(d.state().queues_mut()[0].queue.lock().used_ring.0, 128);
+        assert_eq!(d.state().queues_mut()[0].queue.lock().used_ring(), 128);
         d.write(IoAddress(0), IoAddress(REG_MMIO_QUEUE_USED_HIGH), &buf[..]);
         assert_eq!(
-            d.state().queues_mut()[0].queue.lock().used_ring.0,
+            d.state().queues_mut()[0].queue.lock().used_ring(),
             128 + (128 << 32)
         );
 

--- a/crates/dbs-virtio-devices/src/net.rs
+++ b/crates/dbs-virtio-devices/src/net.rs
@@ -886,7 +886,7 @@ mod tests {
 
     fn create_net_epoll_handler(id: String) -> NetEpollHandler<Arc<GuestMemoryMmap>> {
         let next_ip = NEXT_IP.fetch_add(1, Ordering::SeqCst);
-        let tap = Tap::open_named(&format!("tap{}", next_ip), false).unwrap();
+        let tap = Tap::open_named(&format!("tap{next_ip}"), false).unwrap();
         let rx = RxVirtio::new(
             VirtioQueueConfig::create(256, 0).unwrap(),
             RateLimiter::default(),
@@ -924,7 +924,7 @@ mod tests {
     #[test]
     fn test_net_virtio_device_normal() {
         let next_ip = NEXT_IP.fetch_add(1, Ordering::SeqCst);
-        let tap = Tap::open_named(&format!("tap{}", next_ip), false).unwrap();
+        let tap = Tap::open_named(&format!("tap{next_ip}"), false).unwrap();
         let epoll_mgr = EpollManager::default();
 
         let mut dev = Net::<Arc<GuestMemoryMmap>>::new_with_tap(
@@ -985,7 +985,7 @@ mod tests {
         {
             // config queue size is not 2
             let next_ip = NEXT_IP.fetch_add(1, Ordering::SeqCst);
-            let tap = Tap::open_named(&format!("tap{}", next_ip), false).unwrap();
+            let tap = Tap::open_named(&format!("tap{next_ip}"), false).unwrap();
             let mut dev = Net::<Arc<GuestMemoryMmap>>::new_with_tap(
                 tap,
                 None,
@@ -1017,7 +1017,7 @@ mod tests {
         {
             // check queue sizes error
             let next_ip = NEXT_IP.fetch_add(1, Ordering::SeqCst);
-            let tap = Tap::open_named(&format!("tap{}", next_ip), false).unwrap();
+            let tap = Tap::open_named(&format!("tap{next_ip}"), false).unwrap();
             let mut dev = Net::<Arc<GuestMemoryMmap>>::new_with_tap(
                 tap,
                 None,
@@ -1052,7 +1052,7 @@ mod tests {
         {
             // test no tap
             let next_ip = NEXT_IP.fetch_add(1, Ordering::SeqCst);
-            let tap = Tap::open_named(&format!("tap{}", next_ip), false).unwrap();
+            let tap = Tap::open_named(&format!("tap{next_ip}"), false).unwrap();
             let mut dev = Net::<Arc<GuestMemoryMmap>>::new_with_tap(
                 tap,
                 None,
@@ -1086,7 +1086,7 @@ mod tests {
         {
             // Ok
             let next_ip = NEXT_IP.fetch_add(1, Ordering::SeqCst);
-            let tap = Tap::open_named(&format!("tap{}", next_ip), false).unwrap();
+            let tap = Tap::open_named(&format!("tap{next_ip}"), false).unwrap();
             let mut dev = Net::<Arc<GuestMemoryMmap>>::new_with_tap(
                 tap,
                 None,
@@ -1123,7 +1123,7 @@ mod tests {
     #[test]
     fn test_net_set_patch_rate_limiters() {
         let next_ip = NEXT_IP.fetch_add(1, Ordering::SeqCst);
-        let tap = Tap::open_named(&format!("tap{}", next_ip), false).unwrap();
+        let tap = Tap::open_named(&format!("tap{next_ip}"), false).unwrap();
         let epoll_mgr = EpollManager::default();
 
         let mut dev = Net::<Arc<GuestMemoryMmap>>::new_with_tap(

--- a/crates/dbs-virtio-devices/src/net.rs
+++ b/crates/dbs-virtio-devices/src/net.rs
@@ -1030,8 +1030,8 @@ mod tests {
 
             let mem = GuestMemoryMmap::from_ranges(&[(GuestAddress(0), 0x10000)]).unwrap();
             let queues = vec![
-                VirtioQueueConfig::create(0, 0).unwrap(),
-                VirtioQueueConfig::create(0, 0).unwrap(),
+                VirtioQueueConfig::create(2, 0).unwrap(),
+                VirtioQueueConfig::create(2, 0).unwrap(),
             ];
 
             let kvm = Kvm::new().unwrap();

--- a/crates/dbs-virtio-devices/src/net.rs
+++ b/crates/dbs-virtio-devices/src/net.rs
@@ -406,12 +406,10 @@ impl<AS: DbsGuestAddressSpace, Q: QueueT + Send, R: GuestMemoryRegion> NetEpollH
                 // TODO(performance - Issue #420): change this to use `writev()` instead of `write()`
                 // and get rid of the intermediate buffer.
                 for (desc_addr, desc_len) in self.tx.iovec.drain(..) {
-                    let limit = cmp::min((read_count + desc_len) as usize, self.tx.frame_buf.len());
+                    let limit = cmp::min(read_count + desc_len, self.tx.frame_buf.len());
 
-                    let read_result = mem.read(
-                        &mut self.tx.frame_buf[read_count..limit as usize],
-                        desc_addr,
-                    );
+                    let read_result =
+                        mem.read(&mut self.tx.frame_buf[read_count..limit], desc_addr);
                     match read_result {
                         Ok(sz) => read_count += sz,
                         Err(e) => {

--- a/crates/dbs-virtio-devices/src/vsock/backend/inner.rs
+++ b/crates/dbs-virtio-devices/src/vsock/backend/inner.rs
@@ -354,7 +354,7 @@ impl VsockInnerConnector {
         self.conn_sender.send(internal_stream).map_err(|e| {
             Error::new(
                 ErrorKind::ConnectionRefused,
-                format!("vsock inner stream sender err: {}", e),
+                format!("vsock inner stream sender err: {e}"),
             )
         })?;
         self.backend_event.write(1)?;

--- a/crates/dbs-virtio-devices/src/vsock/backend/unix_stream.rs
+++ b/crates/dbs-virtio-devices/src/vsock/backend/unix_stream.rs
@@ -154,7 +154,7 @@ mod tests {
     fn test_unix_backend_connect() {
         let host_sock_path = String::from("/tmp/host_sock_path_4");
         let local_server_port = 1;
-        let local_server_path = format!("{}_{}", host_sock_path, local_server_port);
+        let local_server_path = format!("{host_sock_path}_{local_server_port}");
         fs::remove_file(Path::new(&host_sock_path)).unwrap_or_default();
         fs::remove_file(Path::new(&local_server_path)).unwrap_or_default();
 

--- a/crates/dbs-virtio-devices/src/vsock/csm/connection.rs
+++ b/crates/dbs-virtio-devices/src/vsock/csm/connection.rs
@@ -650,7 +650,7 @@ impl VsockConnection {
     /// Get the maximum number of bytes that we can send to our peer, without
     /// overflowing its buffer.
     fn peer_avail_credit(&self) -> usize {
-        (Wrapping(self.peer_buf_alloc as u32) - (self.rx_cnt - self.peer_fwd_cnt)).0 as usize
+        (Wrapping(self.peer_buf_alloc) - (self.rx_cnt - self.peer_fwd_cnt)).0 as usize
     }
 
     /// Prepare a packet header for transmission to our peer.
@@ -1142,7 +1142,7 @@ pub(crate) mod tests {
         // CONN_TX_BUF_SIZE - CONN_CREDIT_UPDATE_THRESHOLD, we initialize
         // fwd_cnt at 6 bytes below the threshold.
         let initial_fwd_cnt =
-            csm_defs::CONN_TX_BUF_SIZE as u32 - csm_defs::CONN_CREDIT_UPDATE_THRESHOLD as u32 - 6;
+            csm_defs::CONN_TX_BUF_SIZE - csm_defs::CONN_CREDIT_UPDATE_THRESHOLD - 6;
         ctx.conn.fwd_cnt = Wrapping(initial_fwd_cnt);
 
         // Use a 4-byte packet for triggering the credit update threshold.

--- a/crates/dbs-virtio-devices/src/vsock/csm/connection.rs
+++ b/crates/dbs-virtio-devices/src/vsock/csm/connection.rs
@@ -679,7 +679,7 @@ pub(crate) mod tests {
     use std::os::unix::io::RawFd;
     use std::time::{Duration, Instant};
 
-    use virtio_queue::QueueStateT;
+    use virtio_queue::QueueT;
     use vmm_sys_util::eventfd::{EventFd, EFD_NONBLOCK};
 
     use super::super::super::backend::VsockBackendType;

--- a/crates/dbs-virtio-devices/src/vsock/device.rs
+++ b/crates/dbs-virtio-devices/src/vsock/device.rs
@@ -13,7 +13,7 @@ use std::sync::Arc;
 use dbs_device::resources::ResourceConstraint;
 use dbs_utils::epoll_manager::{EpollManager, SubscriberId};
 use log::trace;
-use virtio_queue::QueueStateT;
+use virtio_queue::QueueT;
 use vm_memory::GuestAddressSpace;
 use vm_memory::GuestMemoryRegion;
 
@@ -113,7 +113,7 @@ impl<AS: GuestAddressSpace, M: VsockGenericMuxer> Vsock<AS, M> {
 impl<AS, Q, R, M> VirtioDevice<AS, Q, R> for Vsock<AS, M>
 where
     AS: DbsGuestAddressSpace,
-    Q: QueueStateT + Send + 'static,
+    Q: QueueT + Send + 'static,
     R: GuestMemoryRegion + Sync + Send + 'static,
     M: VsockGenericMuxer + 'static,
 {
@@ -194,7 +194,7 @@ mod tests {
     use dbs_device::resources::DeviceResources;
     use dbs_interrupt::NoopNotifier;
     use kvm_ioctls::Kvm;
-    use virtio_queue::QueueStateSync;
+    use virtio_queue::QueueSync;
     use vm_memory::{GuestAddress, GuestMemoryMmap, GuestRegionMmap};
 
     use super::super::defs::uapi;
@@ -206,14 +206,14 @@ mod tests {
     impl<AS: DbsGuestAddressSpace, M: VsockGenericMuxer + 'static> Vsock<AS, M> {
         pub fn mock_activate(
             &mut self,
-            config: VirtioDeviceConfig<AS, QueueStateSync, GuestRegionMmap>,
-        ) -> Result<VsockEpollHandler<AS, QueueStateSync, GuestRegionMmap, M>> {
+            config: VirtioDeviceConfig<AS, QueueSync, GuestRegionMmap>,
+        ) -> Result<VsockEpollHandler<AS, QueueSync, GuestRegionMmap, M>> {
             trace!(target: "virtio-vsock", "{}: VirtioDevice::activate_re()", self.id());
 
             self.device_info
                 .check_queue_sizes(&config.queues[..])
                 .unwrap();
-            let handler: VsockEpollHandler<AS, QueueStateSync, GuestRegionMmap, M> =
+            let handler: VsockEpollHandler<AS, QueueSync, GuestRegionMmap, M> =
                 VsockEpollHandler::new(
                     config,
                     self.id().to_owned(),
@@ -240,25 +240,25 @@ mod tests {
             (driver_features >> 32) as u32,
         ];
         assert_eq!(
-            VirtioDevice::<Arc<GuestMemoryMmap<()>>, QueueStateSync, GuestRegionMmap>::device_type(
+            VirtioDevice::<Arc<GuestMemoryMmap<()>>, QueueSync, GuestRegionMmap>::device_type(
                 &ctx.device
             ),
             uapi::VIRTIO_ID_VSOCK
         );
         assert_eq!(
-            VirtioDevice::<Arc<GuestMemoryMmap<()>>, QueueStateSync, GuestRegionMmap>::get_avail_features(
+            VirtioDevice::<Arc<GuestMemoryMmap<()>>, QueueSync, GuestRegionMmap>::get_avail_features(
                 &ctx.device, 0
             ),
             device_pages[0]
         );
         assert_eq!(
-            VirtioDevice::<Arc<GuestMemoryMmap<()>>, QueueStateSync, GuestRegionMmap>::get_avail_features(
+            VirtioDevice::<Arc<GuestMemoryMmap<()>>, QueueSync, GuestRegionMmap>::get_avail_features(
                 &ctx.device, 1
             ),
             device_pages[1]
         );
         assert_eq!(
-            VirtioDevice::<Arc<GuestMemoryMmap<()>>, QueueStateSync, GuestRegionMmap>::get_avail_features(
+            VirtioDevice::<Arc<GuestMemoryMmap<()>>, QueueSync, GuestRegionMmap>::get_avail_features(
                 &ctx.device, 2
             ),
             0
@@ -287,13 +287,13 @@ mod tests {
 
         // Test reading 32-bit chunks.
         let mut data = [0u8; 8];
-        VirtioDevice::<Arc<GuestMemoryMmap<()>>, QueueStateSync, GuestRegionMmap>::read_config(
+        VirtioDevice::<Arc<GuestMemoryMmap<()>>, QueueSync, GuestRegionMmap>::read_config(
             &mut ctx.device,
             0,
             &mut data[..4],
         );
         test_bytes(&data[..], &(ctx.cid & 0xffff_ffff).to_le_bytes());
-        VirtioDevice::<Arc<GuestMemoryMmap<()>>, QueueStateSync, GuestRegionMmap>::read_config(
+        VirtioDevice::<Arc<GuestMemoryMmap<()>>, QueueSync, GuestRegionMmap>::read_config(
             &mut ctx.device,
             4,
             &mut data[4..],
@@ -302,7 +302,7 @@ mod tests {
 
         // Test reading 64-bit.
         let mut data = [0u8; 8];
-        VirtioDevice::<Arc<GuestMemoryMmap<()>>, QueueStateSync, GuestRegionMmap>::read_config(
+        VirtioDevice::<Arc<GuestMemoryMmap<()>>, QueueSync, GuestRegionMmap>::read_config(
             &mut ctx.device,
             0,
             &mut data,
@@ -311,7 +311,7 @@ mod tests {
 
         // Check out-of-bounds reading.
         let mut data = [0u8, 1, 2, 3, 4, 5, 6, 7];
-        VirtioDevice::<Arc<GuestMemoryMmap<()>>, QueueStateSync, GuestRegionMmap>::read_config(
+        VirtioDevice::<Arc<GuestMemoryMmap<()>>, QueueSync, GuestRegionMmap>::read_config(
             &mut ctx.device,
             2,
             &mut data,
@@ -320,7 +320,7 @@ mod tests {
 
         // Just covering lines here, since the vsock device has no writable config.
         // A warning is, however, logged, if the guest driver attempts to write any config data.
-        VirtioDevice::<Arc<GuestMemoryMmap<()>>, QueueStateSync, GuestRegionMmap>::write_config(
+        VirtioDevice::<Arc<GuestMemoryMmap<()>>, QueueSync, GuestRegionMmap>::write_config(
             &mut ctx.device,
             0,
             &data[..4],
@@ -328,9 +328,9 @@ mod tests {
 
         let mem = GuestMemoryMmap::<()>::from_ranges(&[(GuestAddress(0), 0x10000)]).unwrap();
         let queues = vec![
-            VirtioQueueConfig::<QueueStateSync>::create(0, 0).unwrap(),
-            VirtioQueueConfig::<QueueStateSync>::create(0, 0).unwrap(),
-            VirtioQueueConfig::<QueueStateSync>::create(0, 0).unwrap(),
+            VirtioQueueConfig::<QueueSync>::create(0, 0).unwrap(),
+            VirtioQueueConfig::<QueueSync>::create(0, 0).unwrap(),
+            VirtioQueueConfig::<QueueSync>::create(0, 0).unwrap(),
         ];
         let kvm = Kvm::new().unwrap();
         let vm_fd = Arc::new(kvm.create_vm().unwrap());

--- a/crates/dbs-virtio-devices/src/vsock/device.rs
+++ b/crates/dbs-virtio-devices/src/vsock/device.rs
@@ -328,9 +328,9 @@ mod tests {
 
         let mem = GuestMemoryMmap::<()>::from_ranges(&[(GuestAddress(0), 0x10000)]).unwrap();
         let queues = vec![
-            VirtioQueueConfig::<QueueSync>::create(0, 0).unwrap(),
-            VirtioQueueConfig::<QueueSync>::create(0, 0).unwrap(),
-            VirtioQueueConfig::<QueueSync>::create(0, 0).unwrap(),
+            VirtioQueueConfig::<QueueSync>::create(2, 0).unwrap(),
+            VirtioQueueConfig::<QueueSync>::create(2, 0).unwrap(),
+            VirtioQueueConfig::<QueueSync>::create(2, 0).unwrap(),
         ];
         let kvm = Kvm::new().unwrap();
         let vm_fd = Arc::new(kvm.create_vm().unwrap());

--- a/crates/dbs-virtio-devices/src/vsock/epoll_handler.rs
+++ b/crates/dbs-virtio-devices/src/vsock/epoll_handler.rs
@@ -11,7 +11,7 @@ use std::ops::Deref;
 
 use dbs_utils::epoll_manager::{EventOps, EventSet, Events, MutEventSubscriber};
 use log::{error, trace, warn};
-use virtio_queue::{QueueStateOwnedT, QueueStateSync, QueueStateT};
+use virtio_queue::{QueueOwnedT, QueueSync, QueueT};
 use vm_memory::{GuestMemoryRegion, GuestRegionMmap};
 
 use super::defs;
@@ -55,7 +55,7 @@ const QUEUE_CFG: usize = 2;
 ///     virtio RX buffers.
 pub struct VsockEpollHandler<
     AS: DbsGuestAddressSpace,
-    Q: QueueStateT + Send = QueueStateSync,
+    Q: QueueT + Send = QueueSync,
     R: GuestMemoryRegion = GuestRegionMmap,
     M: VsockGenericMuxer = VsockMuxer,
 > {
@@ -68,7 +68,7 @@ pub struct VsockEpollHandler<
 impl<AS, Q, R, M> VsockEpollHandler<AS, Q, R, M>
 where
     AS: DbsGuestAddressSpace,
-    Q: QueueStateT + Send,
+    Q: QueueT + Send,
     R: GuestMemoryRegion,
     M: VsockGenericMuxer,
 {
@@ -240,7 +240,7 @@ where
 impl<AS, Q, R, M> MutEventSubscriber for VsockEpollHandler<AS, Q, R, M>
 where
     AS: DbsGuestAddressSpace,
-    Q: QueueStateT + Send,
+    Q: QueueT + Send,
     R: GuestMemoryRegion,
     M: VsockGenericMuxer + 'static,
 {

--- a/crates/dbs-virtio-devices/src/vsock/mod.rs
+++ b/crates/dbs-virtio-devices/src/vsock/mod.rs
@@ -337,9 +337,9 @@ mod tests {
         pub fn create_event_handler_context(&self) -> EventHandlerContext {
             const QSIZE: u16 = 256;
 
-            let guest_rxvq = GuestQ::new(GuestAddress(0x0010_0000), &self.mem, QSIZE as u16);
-            let guest_txvq = GuestQ::new(GuestAddress(0x0020_0000), &self.mem, QSIZE as u16);
-            let guest_evvq = GuestQ::new(GuestAddress(0x0030_0000), &self.mem, QSIZE as u16);
+            let guest_rxvq = GuestQ::new(GuestAddress(0x0010_0000), &self.mem, QSIZE);
+            let guest_txvq = GuestQ::new(GuestAddress(0x0020_0000), &self.mem, QSIZE);
+            let guest_evvq = GuestQ::new(GuestAddress(0x0030_0000), &self.mem, QSIZE);
             let rxvq = guest_rxvq.create_queue();
             let txvq = guest_txvq.create_queue();
             let evvq = guest_evvq.create_queue();

--- a/crates/dbs-virtio-devices/src/vsock/mod.rs
+++ b/crates/dbs-virtio-devices/src/vsock/mod.rs
@@ -186,7 +186,7 @@ mod tests {
     use dbs_interrupt::NoopNotifier;
     use dbs_utils::epoll_manager::EpollManager;
     use kvm_ioctls::Kvm;
-    use virtio_queue::QueueStateSync;
+    use virtio_queue::QueueSync;
     use vm_memory::{GuestAddress, GuestAddressSpace, GuestMemoryMmap, GuestRegionMmap};
     use vmm_sys_util::eventfd::{EventFd, EFD_NONBLOCK};
 
@@ -412,10 +412,9 @@ mod tests {
 
     pub struct EventHandlerContext<'a> {
         pub device: Vsock<Arc<GuestMemoryMmap>, TestMuxer>,
-        pub epoll_handler: Option<
-            VsockEpollHandler<Arc<GuestMemoryMmap>, QueueStateSync, GuestRegionMmap, TestMuxer>,
-        >,
-        pub queues: Vec<VirtioQueueConfig<QueueStateSync>>,
+        pub epoll_handler:
+            Option<VsockEpollHandler<Arc<GuestMemoryMmap>, QueueSync, GuestRegionMmap, TestMuxer>>,
+        pub queues: Vec<VirtioQueueConfig<QueueSync>>,
         pub guest_rxvq: GuestQ<'a>,
         pub guest_txvq: GuestQ<'a>,
         pub guest_evvq: GuestQ<'a>,
@@ -428,7 +427,7 @@ mod tests {
             let kvm = Kvm::new().unwrap();
             let vm_fd = Arc::new(kvm.create_vm().unwrap());
             let resources = DeviceResources::new();
-            let config = VirtioDeviceConfig::<Arc<GuestMemoryMmap<()>>, QueueStateSync>::new(
+            let config = VirtioDeviceConfig::<Arc<GuestMemoryMmap<()>>, QueueSync>::new(
                 Arc::new(mem.clone()),
                 vm_fd,
                 resources,

--- a/crates/dbs-virtio-devices/src/vsock/muxer/muxer_impl.rs
+++ b/crates/dbs-virtio-devices/src/vsock/muxer/muxer_impl.rs
@@ -928,7 +928,7 @@ mod tests {
             peer_port: u32,
             data: &[u8],
         ) -> &mut VsockPacket {
-            assert!(data.len() <= self.pkt.buf().unwrap().len() as usize);
+            assert!(data.len() <= self.pkt.buf().unwrap().len());
             self.init_pkt(local_port, peer_port, uapi::VSOCK_OP_RW)
                 .set_len(data.len() as u32);
             self.pkt.buf_mut().unwrap()[..data.len()].copy_from_slice(data);

--- a/crates/dbs-virtio-devices/src/vsock/muxer/muxer_impl.rs
+++ b/crates/dbs-virtio-devices/src/vsock/muxer/muxer_impl.rs
@@ -978,7 +978,7 @@ mod tests {
             let (local_lsn_count, _) = self.count_epoll_listeners();
             assert_eq!(local_lsn_count, init_local_lsn_count + 1);
 
-            let buf = format!("CONNECT {}\n", peer_port);
+            let buf = format!("CONNECT {peer_port}\n");
             stream.write_all(buf.as_bytes()).unwrap();
             // The muxer would now get notified that data is available for reading from the locally
             // initiated connection.
@@ -1012,7 +1012,7 @@ mod tests {
 
             let mut buf = vec![0u8; 32];
             let len = stream.read(&mut buf[..]).unwrap();
-            assert_eq!(&buf[..len], format!("OK {}\n", local_port).as_bytes());
+            assert_eq!(&buf[..len], format!("OK {local_port}\n").as_bytes());
 
             (stream, local_port)
         }

--- a/crates/dbs-virtio-devices/src/vsock/muxer/muxer_impl.rs
+++ b/crates/dbs-virtio-devices/src/vsock/muxer/muxer_impl.rs
@@ -847,7 +847,7 @@ mod tests {
     use std::os::unix::net::{UnixListener, UnixStream};
     use std::path::{Path, PathBuf};
 
-    use virtio_queue::QueueStateT;
+    use virtio_queue::QueueT;
     use vmm_sys_util::tempfile::TempFile;
 
     use super::super::super::backend::VsockUnixStreamBackend;

--- a/crates/dbs-virtio-devices/src/vsock/packet.rs
+++ b/crates/dbs-virtio-devices/src/vsock/packet.rs
@@ -448,7 +448,7 @@ impl VsockPacket {
 
 #[cfg(test)]
 mod tests {
-    use virtio_queue::QueueStateT;
+    use virtio_queue::QueueT;
     use vm_memory::{GuestAddress, GuestMemoryMmap};
 
     use super::super::defs::MAX_PKT_BUF_SIZE;

--- a/crates/dbs-virtio-devices/src/vsock/packet.rs
+++ b/crates/dbs-virtio-devices/src/vsock/packet.rs
@@ -117,9 +117,7 @@ impl HdrWrapper {
         // TODO: check buffer alignment
 
         mem.checked_offset(desc.addr(), VSOCK_PKT_HDR_SIZE)
-            .ok_or_else(|| {
-                VsockError::GuestMemoryBounds(desc.addr().0, VSOCK_PKT_HDR_SIZE as usize)
-            })?;
+            .ok_or_else(|| VsockError::GuestMemoryBounds(desc.addr().0, VSOCK_PKT_HDR_SIZE))?;
 
         // It's safe to create the wrapper from this pointer, as:
         // - the guest driver aligned the data; and


### PR DESCRIPTION
Since the vm-memory conflict brought by virtio-queue 0.4.0, we need to upgrade virtio-queue to the newest version. Meanwhile, virtio-queue change a lot of APIs from 0.4.0 to 0.5.0, so this PR mainly for fixing all the API changes.

Signed-off-by: Chao Wu <chaowu@linux.alibaba.com>