### PR TITLE
dbs-upcall: support vcpu resize on aarch64

### DIFF
--- a/crates/dbs-interrupt/Cargo.toml
+++ b/crates/dbs-interrupt/Cargo.toml
@@ -12,6 +12,7 @@ readme = "README.md"
 
 [dependencies]
 dbs-device = { path = "../dbs-device", version = "0.2.0" }
+dbs-arch = { path = "../dbs-arch", version = "0.2.1" }
 kvm-bindings = { version = "0.6.0", optional = true }
 kvm-ioctls = { version = "0.11.0", optional = true }
 libc = "0.2"

--- a/crates/dbs-interrupt/src/manager.rs
+++ b/crates/dbs-interrupt/src/manager.rs
@@ -489,7 +489,10 @@ pub(crate) mod tests {
 
     fn create_interrupt_manager() -> DeviceInterruptManager<Arc<KvmIrqManager>> {
         let vmfd = Arc::new(create_vm_fd());
+        #[cfg(target_arch = "x86_64")]
         vmfd.create_irq_chip().unwrap();
+        #[cfg(target_arch = "aarch64")]
+        let _ = dbs_arch::gic::create_gic(&vmfd, 1);
         let intr_mgr = Arc::new(KvmIrqManager::new(vmfd));
 
         let resource = create_init_resources();

--- a/crates/dbs-upcall/src/dev_mgr_service.rs
+++ b/crates/dbs-upcall/src/dev_mgr_service.rs
@@ -63,13 +63,16 @@ pub struct MmioDevRequest {
 pub struct CpuDevRequest {
     /// hotplug or hot unplug cpu count
     pub count: u8,
+    #[cfg(target_arch = "x86_64")]
     /// apic version
     pub apic_ver: u8,
+    #[cfg(target_arch = "x86_64")]
     /// apic id array
     pub apic_ids: [u8; 256],
 }
 
 impl PartialEq for CpuDevRequest {
+    #[cfg(target_arch = "x86_64")]
     fn eq(&self, other: &CpuDevRequest) -> bool {
         self.count == other.count
             && self.apic_ver == other.apic_ver
@@ -79,9 +82,15 @@ impl PartialEq for CpuDevRequest {
                 .zip(other.apic_ids.iter())
                 .all(|(s, o)| s == o)
     }
+
+    #[cfg(target_arch = "aarch64")]
+    fn eq(&self, other: &CpuDevRequest) -> bool {
+        self.count == other.count
+    }
 }
 
 impl fmt::Debug for CpuDevRequest {
+    #[cfg(target_arch = "x86_64")]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use std::fmt::Write as _;
         let mut apic_ids = String::from("[ ");
@@ -97,6 +106,13 @@ impl fmt::Debug for CpuDevRequest {
             .field("count", &self.count)
             .field("apic_ver", &self.apic_ver)
             .field("apic_ids", &apic_ids)
+            .finish()
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CpuDevRequest")
+            .field("count", &self.count)
             .finish()
     }
 }
@@ -161,8 +177,12 @@ impl DevMgrRequest {
 #[repr(C)]
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct CpuDevResponse {
+    #[cfg(target_arch = "x86_64")]
     /// apic id index of last act cpu
     pub apic_id_index: u32,
+    #[cfg(target_arch = "aarch64")]
+    /// cpu id of last act cpu
+    pub cpu_id: u32,
 }
 
 /// Device manager's response inner message.
@@ -318,7 +338,9 @@ mod tests {
         {
             let cpu_dev_request = CpuDevRequest {
                 count: 1,
+                #[cfg(target_arch = "x86_64")]
                 apic_ver: 2,
+                #[cfg(target_arch = "x86_64")]
                 apic_ids: [3; 256],
             };
             let dev_mgr_request = DevMgrRequest::AddVcpu(cpu_dev_request.clone());
@@ -343,7 +365,9 @@ mod tests {
         {
             let cpu_dev_request = CpuDevRequest {
                 count: 1,
+                #[cfg(target_arch = "x86_64")]
                 apic_ver: 2,
+                #[cfg(target_arch = "x86_64")]
                 apic_ids: [3; 256],
             };
             let dev_mgr_request = DevMgrRequest::DelVcpu(cpu_dev_request.clone());
@@ -386,12 +410,23 @@ mod tests {
             let mut vcpu_result = unsafe {
                 &mut *(buffer[(size_hdr + mem::size_of::<u32>())..].as_ptr() as *mut CpuDevResponse)
             };
-            vcpu_result.apic_id_index = 1;
+
+            #[cfg(target_arch = "x86_64")]
+            {
+                vcpu_result.apic_id_index = 1;
+            }
+            #[cfg(target_arch = "aarch64")]
+            {
+                vcpu_result.cpu_id = 1;
+            }
 
             match DevMgrResponse::make(&buffer).unwrap() {
                 DevMgrResponse::CpuDev(resp) => {
                     assert_eq!(resp.result, 0);
+                    #[cfg(target_arch = "x86_64")]
                     assert_eq!(resp.info.apic_id_index, 1);
+                    #[cfg(target_arch = "aarch64")]
+                    assert_eq!(resp.info.cpu_id, 1);
                 }
                 _ => unreachable!(),
             }


### PR DESCRIPTION
This PR add supports for vcpu resize feature with upcall.
By the way, fix a cargo test error on aarch64.