### PR TITLE
virtio: release version 0.2.0

### DIFF
--- a/crates/dbs-upcall/Cargo.toml
+++ b/crates/dbs-upcall/Cargo.toml
@@ -17,4 +17,4 @@ thiserror = "1"
 timerfd = "1.2.0"
 
 dbs-utils = { path = "../dbs-utils", version = "0.2" }
-dbs-virtio-devices = { path = "../dbs-virtio-devices", version = "0.1", features = ["virtio-vsock"] }
+dbs-virtio-devices = { path = "../dbs-virtio-devices", version = "0.2", features = ["virtio-vsock"] }

--- a/crates/dbs-virtio-devices/CHANGELOG.md
+++ b/crates/dbs-virtio-devices/CHANGELOG.md
@@ -1,13 +1,22 @@
 # CHANGELOG
 
+## v0.1.0
+
+### Added 
+
+- This is the initial release for dbs-virtio-devices
+
 ## v0.1.1
 
 ### Updated
 
 - Update vmm-sys-util to 0.11.0
 
-## v0.1.0
+## v0.2.0
 
-### Added 
+### Updated 
 
-- This is the initial release for dbs-virtio-devices
+- Update kvm-ioctls to v0.12.0
+- Update kvm-bindings to v0.6.0
+- Update virtio-queue to v0.6.0
+- Update Nydus API to adjust to the latest Nydus version

--- a/crates/dbs-virtio-devices/Cargo.toml
+++ b/crates/dbs-virtio-devices/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dbs-virtio-devices"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["Alibaba Dragonball Team"]
 license = "Apache-2.0 AND BSD-3-Clause"
 edition = "2018"


### PR DESCRIPTION
- Update kvm-ioctls to v0.12.0
- Update kvm-bindings to v0.6.0
- Update virtio-queue to v0.6.0
- Update Nydus API to adjust to the latest Nydus version

Signed-off-by: Chao Wu <chaowu@linux.alibaba.com>