### PR TITLE
upcall: update virtio devices to 0.2.0

### DIFF
--- a/crates/dbs-upcall/CHANGELOG.md
+++ b/crates/dbs-upcall/CHANGELOG.md
@@ -5,3 +5,9 @@
 ### Added 
 
 - This is the initial release for dbs-upcall
+
+## v0.2.0
+
+### Updated
+
+- update dbs-virtio-devices to v0.2.0

--- a/crates/dbs-upcall/Cargo.toml
+++ b/crates/dbs-upcall/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dbs-upcall"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Alibaba Dragonball Team"]
 license = "Apache-2.0"
 edition = "2018"


### PR DESCRIPTION
- update dbs-virtio-devices to v0.2.0

Signed-off-by: Chao Wu <chaowu@linux.alibaba.com>