### PR TITLE
dbs-arch : release v0.2.3

### DIFF
--- a/crates/dbs-arch/CHANGELOG.md
+++ b/crates/dbs-arch/CHANGELOG.md
@@ -36,3 +36,9 @@
 ### Added
 
 - vPMU support in aarch64
+
+## v0.2.3
+
+### Fixed
+
+- read_mpidr return u64 instead of u128

--- a/crates/dbs-arch/Cargo.toml
+++ b/crates/dbs-arch/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dbs-arch"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["Alibaba Dragonball Team"]
 license = "Apache-2.0 AND BSD-3-Clause"
 edition = "2018"


### PR DESCRIPTION
Fixed:
- read_mpidr return u64 instead of u128