### PR TITLE
dbs-virtio-devices: Clear resources when removing virtio-net and vsock devices

### DIFF
--- a/crates/dbs-utils/src/net/net_gen/if_tun.rs
+++ b/crates/dbs-utils/src/net/net_gen/if_tun.rs
@@ -347,8 +347,10 @@ fn bindgen_test_layout_ethhdr() {
         1usize,
         concat!("Alignment of ", stringify!(ethhdr))
     );
+    let ethhdr_test = ethhdr::default();
+    let p_ethhdr_test = &ethhdr_test as *const ethhdr as usize;
     assert_eq!(
-        unsafe { &(*(0 as *const ethhdr)).h_dest as *const _ as usize },
+        std::ptr::addr_of!(ethhdr_test.h_dest) as usize - p_ethhdr_test,
         0usize,
         concat!(
             "Alignment of field: ",
@@ -358,7 +360,7 @@ fn bindgen_test_layout_ethhdr() {
         )
     );
     assert_eq!(
-        unsafe { &(*(0 as *const ethhdr)).h_source as *const _ as usize },
+        std::ptr::addr_of!(ethhdr_test.h_source) as usize - p_ethhdr_test,
         6usize,
         concat!(
             "Alignment of field: ",
@@ -368,7 +370,7 @@ fn bindgen_test_layout_ethhdr() {
         )
     );
     assert_eq!(
-        unsafe { &(*(0 as *const ethhdr)).h_proto as *const _ as usize },
+        std::ptr::addr_of!(ethhdr_test.h_proto) as usize - p_ethhdr_test,
         12usize,
         concat!(
             "Alignment of field: ",

--- a/crates/dbs-utils/src/net/net_gen/mod.rs
+++ b/crates/dbs-utils/src/net/net_gen/mod.rs
@@ -6,7 +6,6 @@
 #![allow(non_upper_case_globals)]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
-#![allow(unaligned_references)]
 #![allow(missing_docs)]
 #![allow(deref_nullptr)]
 

--- a/crates/dbs-virtio-devices/src/vsock/backend/unix_stream.rs
+++ b/crates/dbs-virtio-devices/src/vsock/backend/unix_stream.rs
@@ -91,6 +91,12 @@ impl VsockBackend for VsockUnixStreamBackend {
     }
 }
 
+impl Drop for VsockUnixStreamBackend {
+    fn drop(&mut self) {
+        std::fs::remove_file(&self.host_sock_path).ok();
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::fs;

--- a/crates/dbs-virtio-devices/src/vsock/device.rs
+++ b/crates/dbs-virtio-devices/src/vsock/device.rs
@@ -12,7 +12,9 @@ use std::sync::Arc;
 
 use dbs_device::resources::ResourceConstraint;
 use dbs_utils::epoll_manager::{EpollManager, SubscriberId};
+use log::debug;
 use log::trace;
+use log::warn;
 use virtio_queue::QueueT;
 use vm_memory::GuestAddressSpace;
 use vm_memory::GuestMemoryRegion;
@@ -186,6 +188,18 @@ where
 
     fn as_any_mut(&mut self) -> &mut dyn Any {
         self
+    }
+
+    fn remove(&mut self) {
+        let subscriber_id = self.subscriber_id.take();
+        if let Some(subscriber_id) = subscriber_id {
+            match self.device_info.remove_event_handler(subscriber_id) {
+                Ok(_) => debug!("virtio-vsock: removed subscriber_id {:?}", subscriber_id),
+                Err(err) => warn!("virtio-vsock: failed to remove event handler: {:?}", err),
+            };
+        } else {
+            self.muxer.take();
+        }
     }
 }
 


### PR DESCRIPTION
This PR implements functionaility of clearing resources for virtio-net
and virtio-vsock devices.
    
For virtio-net devices, the removed resource is its event hanlder.
    
For virtio-vsock devices, the removed resources are its event handler
and a socket on the host.
    
Fixes: #273