### PR TITLE
vsock: passthrough fd support for hybrid mode

### DIFF
--- a/crates/dbs-virtio-devices/Cargo.toml
+++ b/crates/dbs-virtio-devices/Cargo.toml
@@ -36,6 +36,7 @@ virtio-bindings = "0.1.0"
 virtio-queue = "0.6.0"
 vmm-sys-util = "0.11.0"
 vm-memory = { version = "0.9.0", features = [ "backend-mmap" ] }
+sendfd = "0.4.3"
 
 [dev-dependencies]
 vm-memory = { version = "0.9.0", features = [ "backend-mmap", "backend-atomic" ] }

--- a/crates/dbs-virtio-devices/src/vsock/backend/mod.rs
+++ b/crates/dbs-virtio-devices/src/vsock/backend/mod.rs
@@ -6,7 +6,7 @@
 /// or even the protocol created by us.
 use std::any::Any;
 use std::io::{Read, Write};
-use std::os::unix::io::AsRawFd;
+use std::os::unix::io::{AsRawFd, RawFd};
 use std::time::Duration;
 
 mod inner;
@@ -15,6 +15,7 @@ mod unix_stream;
 
 pub use self::inner::{VsockInnerBackend, VsockInnerConnector, VsockInnerStream};
 pub use self::tcp::VsockTcpBackend;
+pub use self::unix_stream::HybridUnixStreamBackend;
 pub use self::unix_stream::VsockUnixStreamBackend;
 
 /// The type of vsock backend.
@@ -57,6 +58,14 @@ pub trait VsockStream: Read + Write + AsRawFd + Send {
     }
     /// Set the write timeout to the time duration specified.
     fn set_write_timeout(&mut self, _dur: Option<Duration>) -> std::io::Result<()> {
+        Err(std::io::Error::from(std::io::ErrorKind::InvalidInput))
+    }
+    /// Receive the port and fd from the peer.
+    fn recv_data_fd(
+        &self,
+        _bytes: &mut [u8],
+        _fds: &mut [RawFd],
+    ) -> std::io::Result<(usize, usize)> {
         Err(std::io::Error::from(std::io::ErrorKind::InvalidInput))
     }
     /// Used to downcast to the specific type.

--- a/crates/dbs-virtio-devices/src/vsock/backend/unix_stream.rs
+++ b/crates/dbs-virtio-devices/src/vsock/backend/unix_stream.rs
@@ -2,14 +2,76 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::any::Any;
+use std::io::{Read, Write};
 use std::os::unix::io::{AsRawFd, RawFd};
 use std::os::unix::net::{UnixListener, UnixStream};
 use std::time::Duration;
 
 use log::info;
+use sendfd::RecvWithFd;
 
 use super::super::{Result, VsockError};
 use super::{VsockBackend, VsockBackendType, VsockStream};
+
+pub struct HybridUnixStreamBackend {
+    pub unix_stream: Box<dyn VsockStream>,
+    pub slave_stream: Option<Box<dyn VsockStream>>,
+}
+
+impl VsockStream for HybridUnixStreamBackend {
+    fn backend_type(&self) -> VsockBackendType {
+        self.unix_stream.backend_type()
+    }
+
+    fn set_nonblocking(&mut self, nonblocking: bool) -> std::io::Result<()> {
+        self.unix_stream.set_nonblocking(nonblocking)
+    }
+
+    fn set_read_timeout(&mut self, dur: Option<Duration>) -> std::io::Result<()> {
+        self.unix_stream.set_read_timeout(dur)
+    }
+
+    fn set_write_timeout(&mut self, dur: Option<Duration>) -> std::io::Result<()> {
+        self.unix_stream.set_write_timeout(dur)
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self.unix_stream.as_any()
+    }
+
+    fn recv_data_fd(&self, bytes: &mut [u8], fds: &mut [RawFd]) -> std::io::Result<(usize, usize)> {
+        self.unix_stream.recv_data_fd(bytes, fds)
+    }
+}
+
+impl AsRawFd for HybridUnixStreamBackend {
+    fn as_raw_fd(&self) -> RawFd {
+        self.unix_stream.as_raw_fd()
+    }
+}
+
+impl Read for HybridUnixStreamBackend {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        self.unix_stream.read(buf)
+    }
+}
+
+impl Write for HybridUnixStreamBackend {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        // The slave stream was only used to reply the connect result "ok <port>",
+        // thus it was only used once here, and the data would be replied by the
+        // main stream.
+        if let Some(mut stream) = self.slave_stream.take() {
+            stream.write(buf)
+        } else {
+            self.unix_stream.write(buf)
+        }
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.unix_stream.flush()
+    }
+}
 
 impl VsockStream for UnixStream {
     fn backend_type(&self) -> VsockBackendType {
@@ -30,6 +92,10 @@ impl VsockStream for UnixStream {
 
     fn as_any(&self) -> &dyn Any {
         self
+    }
+
+    fn recv_data_fd(&self, bytes: &mut [u8], fds: &mut [RawFd]) -> std::io::Result<(usize, usize)> {
+        self.recv_with_fd(bytes, fds)
     }
 }
 


### PR DESCRIPTION
After applying this commit, the hybrid vsock would support two types of connections:

1) pass "CONNECT <port>\n" to the hybrid unix socket; 2) pass "PASSFD\n" to the hybrid unix socket first,
   then, using sendmsg and msg_control to pass the <port>
   number and fd to the unix socket.

In both of the cases, you should read on the socket to get a response of "OK <assigned_hostside_port>\n".