### PR TITLE
dbs-boot: release v0.4.0

### DIFF
--- a/crates/dbs-boot/CHANGELOG.md
+++ b/crates/dbs-boot/CHANGELOG.md
@@ -34,3 +34,11 @@
 - Use caret dependencies for kvm-ioctls
 - Update kvm-ioctls to v0.12.0
 - Update fdt in aarch64 to support vPMU
+
+## v0.4.0
+
+### Updated
+
+- Update create_fdt interface
+- Simplify create_fdt parameters
+- Refector fdt UT

--- a/crates/dbs-boot/Cargo.toml
+++ b/crates/dbs-boot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dbs-boot"
-version = "0.3.1"
+version = "0.4.0"
 authors = ["Alibaba Dragonball Team"]
 description = "Traits and structs for booting sandbox"
 license = "Apache-2.0 AND BSD-3-Clause"


### PR DESCRIPTION
Updated:
- update create_fdt interface
- simplify create_fdt parameters
- refector fdt UT