### PR TITLE
virtio-device: update to v0.3.1

### DIFF
--- a/crates/dbs-virtio-devices/CHANGELOG.md
+++ b/crates/dbs-virtio-devices/CHANGELOG.md
@@ -27,3 +27,10 @@
 
 - Add virtio-mem device
 - Add virtio-balloon device
+
+## v0.3.1
+
+### Fixed
+
+- Fixed #284, fix balloon pfn using u32
+- Fixed #285, add Madvise error type

--- a/crates/dbs-virtio-devices/Cargo.toml
+++ b/crates/dbs-virtio-devices/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dbs-virtio-devices"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Alibaba Dragonball Team"]
 license = "Apache-2.0 AND BSD-3-Clause"
 edition = "2018"


### PR DESCRIPTION
Fixed:
- Fixed #284, fix balloon pfn using u32
- Fixed #285, add Madvise error type