### PR TITLE
dbs-virtio-devices: fix Balloon::write_config() bugs

### DIFF
--- a/crates/dbs-interrupt/src/kvm/mod.rs
+++ b/crates/dbs-interrupt/src/kvm/mod.rs
@@ -204,7 +204,7 @@ impl KvmIrqRouting {
         irq_routings.resize_with(elem_cnt, Default::default);
 
         // Prepare the irq_routing header.
-        let mut irq_routing = &mut irq_routings[0];
+        let irq_routing = &mut irq_routings[0];
         irq_routing.nr = routes.len() as u32;
         irq_routing.flags = 0;
 

--- a/crates/dbs-legacy-devices/src/lib.rs
+++ b/crates/dbs-legacy-devices/src/lib.rs
@@ -13,6 +13,8 @@ pub use self::serial::*;
 #[cfg(target_arch = "x86_64")]
 mod cmos;
 #[cfg(target_arch = "x86_64")]
+pub use self::cmos::*;
+#[cfg(target_arch = "x86_64")]
 mod i8042;
 #[cfg(target_arch = "x86_64")]
 pub use self::i8042::*;

--- a/crates/dbs-virtio-devices/src/lib.rs
+++ b/crates/dbs-virtio-devices/src/lib.rs
@@ -209,6 +209,7 @@ pub enum Error {
 /// Specialized std::result::Result for Virtio device operations.
 pub type Result<T> = std::result::Result<T, Error>;
 
+#[allow(unused_macros)]
 macro_rules! warn_or_panic {
     ($($arg:tt)*) => {
         if cfg!(test) {
@@ -218,6 +219,7 @@ macro_rules! warn_or_panic {
         }
     }
 }
+#[allow(unused_imports)]
 pub(crate) use warn_or_panic;
 
 #[cfg(test)]


### PR DESCRIPTION
Fix two bugs in `Balloon::write_config()`:
1. `offset + data_len` might overflow. This causes a panic in debug builds, and wraps around in release builds.
https://github.com/openanolis/dragonball-sandbox/blob/8ed5e3fea96bf16747945d65c2b386542b28e1b7/crates/dbs-virtio-devices/src/balloon.rs#L634
2. Source (`data`) and destination (`right`) slices' sizes might be mismatched in `right.copy_from_slice(data)`, which causes a panic ([this is documented](https://doc.rust-lang.org/std/primitive.slice.html#panics-29)). This can happen if `data` is shorter than the right side of `config_slice.split_at_mut(offset)`:
https://github.com/openanolis/dragonball-sandbox/blob/8ed5e3fea96bf16747945d65c2b386542b28e1b7/crates/dbs-virtio-devices/src/balloon.rs#L638-L640