### PR TITLE
dbs-virtio-devices:  add metrics for net device

### DIFF
--- a/crates/dbs-virtio-devices/src/block/device.rs
+++ b/crates/dbs-virtio-devices/src/block/device.rs
@@ -25,7 +25,7 @@ use vm_memory::GuestMemoryRegion;
 use vmm_sys_util::eventfd::{EventFd, EFD_NONBLOCK};
 
 use crate::{
-    ActivateError, ActivateResult, DbsGuestAddressSpace, Error, Result, VirtioDevice,
+    ActivateError, ActivateResult, ConfigResult, DbsGuestAddressSpace, Error, Result, VirtioDevice,
     VirtioDeviceConfig, VirtioDeviceInfo, TYPE_BLOCK,
 };
 
@@ -220,11 +220,11 @@ where
         self.device_info.set_acked_features(page, value)
     }
 
-    fn read_config(&mut self, offset: u64, data: &mut [u8]) {
+    fn read_config(&mut self, offset: u64, data: &mut [u8]) -> ConfigResult {
         self.device_info.read_config(offset, data)
     }
 
-    fn write_config(&mut self, offset: u64, data: &[u8]) {
+    fn write_config(&mut self, offset: u64, data: &[u8]) -> ConfigResult {
         self.device_info.write_config(offset, data)
     }
 
@@ -898,11 +898,13 @@ mod tests {
             &mut dev,
             0,
             &mut config,
-        );
+        )
+        .unwrap();
         let config: [u8; 16] = [0; 16];
         VirtioDevice::<Arc<GuestMemoryMmap<()>>, QueueSync, GuestRegionMmap>::write_config(
             &mut dev, 0, &config,
-        );
+        )
+        .unwrap();
     }
 
     #[test]

--- a/crates/dbs-virtio-devices/src/fs/device.rs
+++ b/crates/dbs-virtio-devices/src/fs/device.rs
@@ -37,7 +37,7 @@ use vm_memory::{
 use vmm_sys_util::eventfd::EventFd;
 
 use crate::{
-    ActivateError, ActivateResult, Error, Result, VirtioDevice, VirtioDeviceConfig,
+    ActivateError, ActivateResult, ConfigResult, Error, Result, VirtioDevice, VirtioDeviceConfig,
     VirtioDeviceInfo, VirtioRegionHandler, VirtioSharedMemory, VirtioSharedMemoryList,
     TYPE_VIRTIO_FS,
 };
@@ -785,7 +785,7 @@ where
         self.device_info.set_acked_features(page, value)
     }
 
-    fn read_config(&mut self, offset: u64, data: &mut [u8]) {
+    fn read_config(&mut self, offset: u64, data: &mut [u8]) -> ConfigResult {
         trace!(
             target: VIRTIO_FS_NAME,
             "{}: VirtioDevice::read_config(0x{:x}, {:?})",
@@ -796,7 +796,7 @@ where
         self.device_info.read_config(offset, data)
     }
 
-    fn write_config(&mut self, offset: u64, data: &[u8]) {
+    fn write_config(&mut self, offset: u64, data: &[u8]) -> ConfigResult {
         trace!(
             target: VIRTIO_FS_NAME,
             "{}: VirtioDevice::write_config(0x{:x}, {:?})",
@@ -1173,11 +1173,13 @@ pub mod tests {
             &mut fs,
             0,
             &mut config,
-        );
+        )
+        .unwrap();
         let config: [u8; 16] = [0; 16];
         VirtioDevice::<Arc<GuestMemoryMmap<()>>, QueueSync, GuestRegionMmap>::write_config(
             &mut fs, 0, &config,
-        );
+        )
+        .unwrap();
     }
 
     #[test]

--- a/crates/dbs-virtio-devices/src/lib.rs
+++ b/crates/dbs-virtio-devices/src/lib.rs
@@ -120,8 +120,21 @@ pub enum ActivateError {
     IOError(#[from] IOError),
 }
 
+/// Error code for VirtioDevice::read_config()/write_config().
+#[derive(Debug, thiserror::Error, Eq, PartialEq)]
+pub enum ConfigError {
+    #[error("Invalid offset: {0}.")]
+    InvalidOffset(u64),
+    #[error("Offset({0}) plus data length ({0}) overflow.")]
+    PlusOverflow(u64, u64),
+    #[error("Invalid offset plus data length: {0}.")]
+    InvalidOffsetPlusDataLen(u64),
+}
+
 /// Specialized std::result::Result for VirtioDevice::activate().
 pub type ActivateResult = std::result::Result<(), ActivateError>;
+/// Specialized std::result::Result for VirtioDevice::read_config()/write_config().
+pub type ConfigResult = std::result::Result<(), ConfigError>;
 
 /// Error for virtio devices to handle requests from guests.
 #[derive(Debug, thiserror::Error)]

--- a/crates/dbs-virtio-devices/src/vsock/backend/tcp.rs
+++ b/crates/dbs-virtio-devices/src/vsock/backend/tcp.rs
@@ -154,7 +154,7 @@ mod tests {
 
     #[test]
     fn test_tcp_backend_vsock_stream() {
-        let tcp_sock_addr = String::from("127.0.0.2:9003");
+        let tcp_sock_addr = String::from("127.0.0.2:9005");
         let _vsock_backend = VsockTcpBackend::new(tcp_sock_addr.clone()).unwrap();
         let vsock_stream = TcpStream::connect(&tcp_sock_addr).unwrap();
 


### PR DESCRIPTION
add metrics for net device and add `read_config/write_config` return type for the `cfg_fails` metric.

Fixes: https://github.com/kata-containers/kata-containers/issues/7248